### PR TITLE
feat(math): add SIMD-accelerated Goldilocks field arithmetic

### DIFF
--- a/crypto/math/Cargo.toml
+++ b/crypto/math/Cargo.toml
@@ -53,3 +53,7 @@ cuda = ["dep:cudarc", "dep:lambdaworks-gpu"]
 
 [target.wasm32-unknown-unknown.dependencies]
 getrandom = { version = "0.2.15", features = ["js"] }
+
+[[bench]]
+name = "packed_goldilocks"
+harness = false

--- a/crypto/math/benches/packed_goldilocks.rs
+++ b/crypto/math/benches/packed_goldilocks.rs
@@ -1,0 +1,568 @@
+//! Benchmarks for PackedGoldilocks2 and PackedFp2x2 SIMD operations.
+//!
+//! Run with: cargo bench --bench packed_goldilocks
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+
+use math::field::fields::u64_goldilocks_field::Goldilocks64Field;
+use math::field::simd::{Fp2Raw, Fp3Raw, PackedFp2x2, PackedFp3x2, PackedGoldilocks2};
+use math::field::traits::IsField;
+
+const P: u64 = 0xFFFF_FFFF_0000_0001;
+
+fn bench_add(c: &mut Criterion) {
+    let mut group = c.benchmark_group("goldilocks_add");
+
+    // Scalar operations (2 elements)
+    let a0 = P - 12345;
+    let a1 = P - 67890;
+    let b0 = 54321u64;
+    let b1 = 98765u64;
+
+    group.throughput(Throughput::Elements(2));
+
+    group.bench_function("scalar_2x", |bench| {
+        bench.iter(|| {
+            let r0 = Goldilocks64Field::add(black_box(&a0), black_box(&b0));
+            let r1 = Goldilocks64Field::add(black_box(&a1), black_box(&b1));
+            black_box((r0, r1))
+        });
+    });
+
+    // SIMD operations
+    let a_packed = PackedGoldilocks2::from_array([a0, a1]);
+    let b_packed = PackedGoldilocks2::from_array([b0, b1]);
+
+    group.bench_function("simd_2x", |bench| {
+        bench.iter(|| black_box(black_box(a_packed) + black_box(b_packed)));
+    });
+
+    group.finish();
+}
+
+fn bench_sub(c: &mut Criterion) {
+    let mut group = c.benchmark_group("goldilocks_sub");
+
+    let a0 = 12345u64;
+    let a1 = 67890u64;
+    let b0 = P - 54321;
+    let b1 = P - 98765;
+
+    group.throughput(Throughput::Elements(2));
+
+    group.bench_function("scalar_2x", |bench| {
+        bench.iter(|| {
+            let r0 = Goldilocks64Field::sub(black_box(&a0), black_box(&b0));
+            let r1 = Goldilocks64Field::sub(black_box(&a1), black_box(&b1));
+            black_box((r0, r1))
+        });
+    });
+
+    let a_packed = PackedGoldilocks2::from_array([a0, a1]);
+    let b_packed = PackedGoldilocks2::from_array([b0, b1]);
+
+    group.bench_function("simd_2x", |bench| {
+        bench.iter(|| black_box(black_box(a_packed) - black_box(b_packed)));
+    });
+
+    group.finish();
+}
+
+fn bench_mul(c: &mut Criterion) {
+    let mut group = c.benchmark_group("goldilocks_mul");
+
+    let a0 = P - 12345;
+    let a1 = P - 67890;
+    let b0 = P - 54321;
+    let b1 = P - 98765;
+
+    group.throughput(Throughput::Elements(2));
+
+    group.bench_function("scalar_2x", |bench| {
+        bench.iter(|| {
+            let r0 = Goldilocks64Field::mul(black_box(&a0), black_box(&b0));
+            let r1 = Goldilocks64Field::mul(black_box(&a1), black_box(&b1));
+            black_box((r0, r1))
+        });
+    });
+
+    let a_packed = PackedGoldilocks2::from_array([a0, a1]);
+    let b_packed = PackedGoldilocks2::from_array([b0, b1]);
+
+    group.bench_function("simd_2x", |bench| {
+        bench.iter(|| black_box(black_box(a_packed) * black_box(b_packed)));
+    });
+
+    group.finish();
+}
+
+fn bench_neg(c: &mut Criterion) {
+    let mut group = c.benchmark_group("goldilocks_neg");
+
+    let a0 = P - 12345;
+    let a1 = P - 67890;
+
+    group.throughput(Throughput::Elements(2));
+
+    group.bench_function("scalar_2x", |bench| {
+        bench.iter(|| {
+            let r0 = Goldilocks64Field::neg(black_box(&a0));
+            let r1 = Goldilocks64Field::neg(black_box(&a1));
+            black_box((r0, r1))
+        });
+    });
+
+    let a_packed = PackedGoldilocks2::from_array([a0, a1]);
+
+    group.bench_function("simd_2x", |bench| {
+        bench.iter(|| black_box(-black_box(a_packed)));
+    });
+
+    group.finish();
+}
+
+fn bench_combined_ops(c: &mut Criterion) {
+    let mut group = c.benchmark_group("goldilocks_combined");
+
+    // Simulate a typical FFT butterfly: (a + wb, a - wb)
+    let a0 = 12345u64;
+    let a1 = 67890u64;
+    let w0 = P - 111;
+    let w1 = P - 222;
+    let b0 = 54321u64;
+    let b1 = 98765u64;
+
+    group.throughput(Throughput::Elements(2));
+
+    group.bench_function("butterfly_scalar_2x", |bench| {
+        bench.iter(|| {
+            let wb0 = Goldilocks64Field::mul(black_box(&w0), black_box(&b0));
+            let wb1 = Goldilocks64Field::mul(black_box(&w1), black_box(&b1));
+            let y0_0 = Goldilocks64Field::add(black_box(&a0), &wb0);
+            let y0_1 = Goldilocks64Field::add(black_box(&a1), &wb1);
+            let y1_0 = Goldilocks64Field::sub(black_box(&a0), &wb0);
+            let y1_1 = Goldilocks64Field::sub(black_box(&a1), &wb1);
+            black_box((y0_0, y0_1, y1_0, y1_1))
+        });
+    });
+
+    let a_packed = PackedGoldilocks2::from_array([a0, a1]);
+    let w_packed = PackedGoldilocks2::from_array([w0, w1]);
+    let b_packed = PackedGoldilocks2::from_array([b0, b1]);
+
+    group.bench_function("butterfly_simd_2x", |bench| {
+        bench.iter(|| {
+            let wb = black_box(w_packed) * black_box(b_packed);
+            let y0 = black_box(a_packed) + wb;
+            let y1 = black_box(a_packed) - wb;
+            black_box((y0, y1))
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_batch_operations(c: &mut Criterion) {
+    let mut group = c.benchmark_group("goldilocks_batch");
+
+    const BATCH_SIZE: usize = 1024;
+
+    // Create test data
+    let scalar_a: Vec<u64> = (0..BATCH_SIZE).map(|i| (i as u64 * 12345) % P).collect();
+    let scalar_b: Vec<u64> = (0..BATCH_SIZE).map(|i| (i as u64 * 67890) % P).collect();
+
+    let packed_a: Vec<PackedGoldilocks2> = scalar_a
+        .chunks(2)
+        .map(|c| PackedGoldilocks2::from_array([c[0], c[1]]))
+        .collect();
+    let packed_b: Vec<PackedGoldilocks2> = scalar_b
+        .chunks(2)
+        .map(|c| PackedGoldilocks2::from_array([c[0], c[1]]))
+        .collect();
+
+    group.throughput(Throughput::Elements(BATCH_SIZE as u64));
+
+    group.bench_with_input(
+        BenchmarkId::new("add_scalar", BATCH_SIZE),
+        &(&scalar_a, &scalar_b),
+        |bench, (a, b)| {
+            bench.iter(|| {
+                let mut result = Vec::with_capacity(BATCH_SIZE);
+                for i in 0..BATCH_SIZE {
+                    result.push(Goldilocks64Field::add(&a[i], &b[i]));
+                }
+                black_box(result)
+            });
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("add_simd", BATCH_SIZE),
+        &(&packed_a, &packed_b),
+        |bench, (a, b)| {
+            bench.iter(|| {
+                let mut result = Vec::with_capacity(BATCH_SIZE / 2);
+                for i in 0..BATCH_SIZE / 2 {
+                    result.push(a[i] + b[i]);
+                }
+                black_box(result)
+            });
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("mul_scalar", BATCH_SIZE),
+        &(&scalar_a, &scalar_b),
+        |bench, (a, b)| {
+            bench.iter(|| {
+                let mut result = Vec::with_capacity(BATCH_SIZE);
+                for i in 0..BATCH_SIZE {
+                    result.push(Goldilocks64Field::mul(&a[i], &b[i]));
+                }
+                black_box(result)
+            });
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("mul_simd", BATCH_SIZE),
+        &(&packed_a, &packed_b),
+        |bench, (a, b)| {
+            bench.iter(|| {
+                let mut result = Vec::with_capacity(BATCH_SIZE / 2);
+                for i in 0..BATCH_SIZE / 2 {
+                    result.push(a[i] * b[i]);
+                }
+                black_box(result)
+            });
+        },
+    );
+
+    group.finish();
+}
+
+// ============================================================================
+// Fp2 Benchmarks
+// ============================================================================
+
+fn bench_fp2_mul(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fp2_mul");
+
+    let a0 = Fp2Raw::new(P - 12345, P - 67890);
+    let a1 = Fp2Raw::new(P - 11111, P - 22222);
+    let b0 = Fp2Raw::new(P - 54321, P - 98765);
+    let b1 = Fp2Raw::new(P - 33333, P - 44444);
+
+    group.throughput(Throughput::Elements(2));
+
+    group.bench_function("scalar_2x", |bench| {
+        bench.iter(|| {
+            let r0 = Fp2Raw::mul(black_box(a0), black_box(b0));
+            let r1 = Fp2Raw::mul(black_box(a1), black_box(b1));
+            black_box((r0, r1))
+        });
+    });
+
+    let packed_a = PackedFp2x2::from_array([a0, a1]);
+    let packed_b = PackedFp2x2::from_array([b0, b1]);
+
+    group.bench_function("simd_2x", |bench| {
+        bench.iter(|| black_box(black_box(packed_a) * black_box(packed_b)));
+    });
+
+    group.finish();
+}
+
+fn bench_fp2_add(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fp2_add");
+
+    let a0 = Fp2Raw::new(P - 12345, P - 67890);
+    let a1 = Fp2Raw::new(P - 11111, P - 22222);
+    let b0 = Fp2Raw::new(54321, 98765);
+    let b1 = Fp2Raw::new(33333, 44444);
+
+    group.throughput(Throughput::Elements(2));
+
+    group.bench_function("scalar_2x", |bench| {
+        bench.iter(|| {
+            let r0 = Fp2Raw::add(black_box(a0), black_box(b0));
+            let r1 = Fp2Raw::add(black_box(a1), black_box(b1));
+            black_box((r0, r1))
+        });
+    });
+
+    let packed_a = PackedFp2x2::from_array([a0, a1]);
+    let packed_b = PackedFp2x2::from_array([b0, b1]);
+
+    group.bench_function("simd_2x", |bench| {
+        bench.iter(|| black_box(black_box(packed_a) + black_box(packed_b)));
+    });
+
+    group.finish();
+}
+
+fn bench_fp_times_fp2(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fp_times_fp2");
+
+    // Scalar * Fp2 element
+    let scalar0 = P - 12345;
+    let scalar1 = P - 67890;
+    let fp2_0 = Fp2Raw::new(54321, 98765);
+    let fp2_1 = Fp2Raw::new(33333, 44444);
+
+    group.throughput(Throughput::Elements(2));
+
+    group.bench_function("scalar_2x", |bench| {
+        bench.iter(|| {
+            let r0 = Fp2Raw::new(
+                Goldilocks64Field::mul(&scalar0, &fp2_0.real),
+                Goldilocks64Field::mul(&scalar0, &fp2_0.imag),
+            );
+            let r1 = Fp2Raw::new(
+                Goldilocks64Field::mul(&scalar1, &fp2_1.real),
+                Goldilocks64Field::mul(&scalar1, &fp2_1.imag),
+            );
+            black_box((r0, r1))
+        });
+    });
+
+    let packed_scalar = PackedGoldilocks2::from_array([scalar0, scalar1]);
+    let packed_fp2 = PackedFp2x2::from_array([fp2_0, fp2_1]);
+
+    group.bench_function("simd_2x", |bench| {
+        bench.iter(|| black_box(black_box(packed_fp2).mul_by_fp(black_box(packed_scalar))));
+    });
+
+    group.finish();
+}
+
+fn bench_fp2_batch(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fp2_batch");
+
+    const BATCH_SIZE: usize = 512;
+
+    // Create test data
+    let scalar_a: Vec<Fp2Raw> = (0..BATCH_SIZE)
+        .map(|i| Fp2Raw::new((i as u64 * 12345) % P, (i as u64 * 67890) % P))
+        .collect();
+    let scalar_b: Vec<Fp2Raw> = (0..BATCH_SIZE)
+        .map(|i| Fp2Raw::new((i as u64 * 11111) % P, (i as u64 * 22222) % P))
+        .collect();
+
+    let packed_a: Vec<PackedFp2x2> = scalar_a
+        .chunks(2)
+        .map(|c| PackedFp2x2::from_array([c[0], c[1]]))
+        .collect();
+    let packed_b: Vec<PackedFp2x2> = scalar_b
+        .chunks(2)
+        .map(|c| PackedFp2x2::from_array([c[0], c[1]]))
+        .collect();
+
+    group.throughput(Throughput::Elements(BATCH_SIZE as u64));
+
+    group.bench_with_input(
+        BenchmarkId::new("mul_scalar", BATCH_SIZE),
+        &(&scalar_a, &scalar_b),
+        |bench, (a, b)| {
+            bench.iter(|| {
+                let mut result = Vec::with_capacity(BATCH_SIZE);
+                for i in 0..BATCH_SIZE {
+                    result.push(Fp2Raw::mul(a[i], b[i]));
+                }
+                black_box(result)
+            });
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("mul_simd", BATCH_SIZE),
+        &(&packed_a, &packed_b),
+        |bench, (a, b)| {
+            bench.iter(|| {
+                let mut result = Vec::with_capacity(BATCH_SIZE / 2);
+                for i in 0..BATCH_SIZE / 2 {
+                    result.push(a[i] * b[i]);
+                }
+                black_box(result)
+            });
+        },
+    );
+
+    group.finish();
+}
+
+// ============================================================================
+// Fp3 Benchmarks
+// ============================================================================
+
+fn bench_fp3_add(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fp3_add");
+
+    let a0 = Fp3Raw::new(P - 12345, P - 67890, P - 11111);
+    let a1 = Fp3Raw::new(P - 22222, P - 33333, P - 44444);
+    let b0 = Fp3Raw::new(54321, 98765, 55555);
+    let b1 = Fp3Raw::new(66666, 77777, 88888);
+
+    group.throughput(Throughput::Elements(2));
+
+    group.bench_function("scalar_2x", |bench| {
+        bench.iter(|| {
+            let r0 = Fp3Raw::add(black_box(a0), black_box(b0));
+            let r1 = Fp3Raw::add(black_box(a1), black_box(b1));
+            black_box((r0, r1))
+        });
+    });
+
+    let packed_a = PackedFp3x2::from_array([a0, a1]);
+    let packed_b = PackedFp3x2::from_array([b0, b1]);
+
+    group.bench_function("simd_2x", |bench| {
+        bench.iter(|| black_box(black_box(packed_a) + black_box(packed_b)));
+    });
+
+    group.finish();
+}
+
+fn bench_fp3_mul(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fp3_mul");
+
+    let a0 = Fp3Raw::new(P - 12345, P - 67890, P - 11111);
+    let a1 = Fp3Raw::new(P - 22222, P - 33333, P - 44444);
+    let b0 = Fp3Raw::new(P - 54321, P - 98765, P - 55555);
+    let b1 = Fp3Raw::new(P - 66666, P - 77777, P - 88888);
+
+    group.throughput(Throughput::Elements(2));
+
+    group.bench_function("scalar_2x", |bench| {
+        bench.iter(|| {
+            let r0 = Fp3Raw::mul(black_box(a0), black_box(b0));
+            let r1 = Fp3Raw::mul(black_box(a1), black_box(b1));
+            black_box((r0, r1))
+        });
+    });
+
+    let packed_a = PackedFp3x2::from_array([a0, a1]);
+    let packed_b = PackedFp3x2::from_array([b0, b1]);
+
+    group.bench_function("simd_2x", |bench| {
+        bench.iter(|| black_box(black_box(packed_a) * black_box(packed_b)));
+    });
+
+    group.finish();
+}
+
+fn bench_fp_times_fp3(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fp_times_fp3");
+
+    // Scalar * Fp3 element
+    let scalar0 = P - 12345;
+    let scalar1 = P - 67890;
+    let fp3_0 = Fp3Raw::new(54321, 98765, 11111);
+    let fp3_1 = Fp3Raw::new(33333, 44444, 55555);
+
+    group.throughput(Throughput::Elements(2));
+
+    group.bench_function("scalar_2x", |bench| {
+        bench.iter(|| {
+            let r0 = Fp3Raw::mul_by_fp(black_box(fp3_0), black_box(scalar0));
+            let r1 = Fp3Raw::mul_by_fp(black_box(fp3_1), black_box(scalar1));
+            black_box((r0, r1))
+        });
+    });
+
+    let packed_scalar = PackedGoldilocks2::from_array([scalar0, scalar1]);
+    let packed_fp3 = PackedFp3x2::from_array([fp3_0, fp3_1]);
+
+    group.bench_function("simd_2x", |bench| {
+        bench.iter(|| black_box(black_box(packed_fp3).mul_by_fp(black_box(packed_scalar))));
+    });
+
+    group.finish();
+}
+
+fn bench_fp3_batch(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fp3_batch");
+
+    const BATCH_SIZE: usize = 512;
+
+    // Create test data
+    let scalar_a: Vec<Fp3Raw> = (0..BATCH_SIZE)
+        .map(|i| {
+            Fp3Raw::new(
+                (i as u64 * 12345) % P,
+                (i as u64 * 67890) % P,
+                (i as u64 * 11111) % P,
+            )
+        })
+        .collect();
+    let scalar_b: Vec<Fp3Raw> = (0..BATCH_SIZE)
+        .map(|i| {
+            Fp3Raw::new(
+                (i as u64 * 11111) % P,
+                (i as u64 * 22222) % P,
+                (i as u64 * 33333) % P,
+            )
+        })
+        .collect();
+
+    let packed_a: Vec<PackedFp3x2> = scalar_a
+        .chunks(2)
+        .map(|c| PackedFp3x2::from_array([c[0], c[1]]))
+        .collect();
+    let packed_b: Vec<PackedFp3x2> = scalar_b
+        .chunks(2)
+        .map(|c| PackedFp3x2::from_array([c[0], c[1]]))
+        .collect();
+
+    group.throughput(Throughput::Elements(BATCH_SIZE as u64));
+
+    group.bench_with_input(
+        BenchmarkId::new("mul_scalar", BATCH_SIZE),
+        &(&scalar_a, &scalar_b),
+        |bench, (a, b)| {
+            bench.iter(|| {
+                let mut result = Vec::with_capacity(BATCH_SIZE);
+                for i in 0..BATCH_SIZE {
+                    result.push(Fp3Raw::mul(a[i], b[i]));
+                }
+                black_box(result)
+            });
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("mul_simd", BATCH_SIZE),
+        &(&packed_a, &packed_b),
+        |bench, (a, b)| {
+            bench.iter(|| {
+                let mut result = Vec::with_capacity(BATCH_SIZE / 2);
+                for i in 0..BATCH_SIZE / 2 {
+                    result.push(a[i] * b[i]);
+                }
+                black_box(result)
+            });
+        },
+    );
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_add,
+    bench_sub,
+    bench_mul,
+    bench_neg,
+    bench_combined_ops,
+    bench_batch_operations,
+    bench_fp2_add,
+    bench_fp2_mul,
+    bench_fp_times_fp2,
+    bench_fp2_batch,
+    bench_fp3_add,
+    bench_fp3_mul,
+    bench_fp_times_fp3,
+    bench_fp3_batch,
+);
+
+criterion_main!(benches);

--- a/crypto/math/src/field/mod.rs
+++ b/crypto/math/src/field/mod.rs
@@ -5,6 +5,8 @@ pub mod errors;
 pub mod extensions;
 /// Implementation of particular cases of fields.
 pub mod fields;
+/// SIMD-accelerated field arithmetic.
+pub mod simd;
 /// Field for test purposes.
 pub mod test_fields;
 /// Common behaviour for field elements.

--- a/crypto/math/src/field/simd/mod.rs
+++ b/crypto/math/src/field/simd/mod.rs
@@ -1,0 +1,40 @@
+//! SIMD-accelerated field arithmetic.
+//!
+//! This module provides vectorized implementations of field operations
+//! for improved performance on modern CPUs with SIMD support.
+//!
+//! Currently supported:
+//! - ARM NEON (aarch64): 2-wide Goldilocks operations via `uint64x2_t`
+//!
+//! # Usage
+//!
+//! The SIMD types process multiple field elements in parallel:
+//!
+//! ```ignore
+//! use math::field::simd::PackedGoldilocks2;
+//!
+//! let a = PackedGoldilocks2::from_array([1, 2]);
+//! let b = PackedGoldilocks2::from_array([3, 4]);
+//! let c = a + b;  // [4, 6]
+//! ```
+
+#[cfg(target_arch = "aarch64")]
+pub mod packed_goldilocks;
+
+#[cfg(target_arch = "aarch64")]
+pub use packed_goldilocks::PackedGoldilocks2;
+
+// Fallback for non-aarch64 architectures
+#[cfg(not(target_arch = "aarch64"))]
+pub mod packed_goldilocks_scalar;
+
+#[cfg(not(target_arch = "aarch64"))]
+pub use packed_goldilocks_scalar::PackedGoldilocks2;
+
+// Quadratic extension Fp2
+pub mod packed_fp2;
+pub use packed_fp2::{Fp2Raw, PackedFp2x2};
+
+// Cubic extension Fp3
+pub mod packed_fp3;
+pub use packed_fp3::{Fp3Raw, PackedFp3x2};

--- a/crypto/math/src/field/simd/packed_fp2.rs
+++ b/crypto/math/src/field/simd/packed_fp2.rs
@@ -1,0 +1,637 @@
+//! SIMD-accelerated Goldilocks quadratic extension (Fp2) arithmetic.
+//!
+//! This module provides `PackedFp2x2`, a type that holds 2 Fp2 elements
+//! and performs operations on them in parallel using SIMD operations.
+//!
+//! # Fp2 Field Structure
+//!
+//! Fp2 = Fp[x] / (x^2 - W) where W = 7 is the quadratic non-residue.
+//! Elements are represented as a0 + a1*w where w^2 = 7.
+//!
+//! Multiplication: (a0 + a1*w)(b0 + b1*w) = (a0*b0 + 7*a1*b1) + (a0*b1 + a1*b0)*w
+//!
+//! # Memory Layout
+//!
+//! Uses Struct-of-Arrays (SoA) layout for optimal SIMD utilization:
+//! - real: [r0, r1] - real components of two Fp2 elements
+//! - imag: [i0, i1] - imaginary components of two Fp2 elements
+
+use core::fmt;
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use super::PackedGoldilocks2;
+use crate::field::fields::u64_goldilocks_field::Goldilocks64Field;
+use crate::field::traits::IsField;
+
+/// The quadratic non-residue W = 7.
+/// Fp2 is constructed as Fp[x] / (x^2 - 7)
+pub const W: u64 = 7;
+
+/// An Fp2 element represented as (real, imag) where element = real + imag * w.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Fp2Raw {
+    pub real: u64,
+    pub imag: u64,
+}
+
+impl Fp2Raw {
+    pub const ZERO: Self = Self { real: 0, imag: 0 };
+    pub const ONE: Self = Self { real: 1, imag: 0 };
+
+    #[inline(always)]
+    pub fn new(real: u64, imag: u64) -> Self {
+        Self { real, imag }
+    }
+
+    #[inline(always)]
+    pub fn add(a: Self, b: Self) -> Self {
+        Self {
+            real: Goldilocks64Field::add(&a.real, &b.real),
+            imag: Goldilocks64Field::add(&a.imag, &b.imag),
+        }
+    }
+
+    #[inline(always)]
+    pub fn sub(a: Self, b: Self) -> Self {
+        Self {
+            real: Goldilocks64Field::sub(&a.real, &b.real),
+            imag: Goldilocks64Field::sub(&a.imag, &b.imag),
+        }
+    }
+
+    #[inline(always)]
+    pub fn neg(a: Self) -> Self {
+        Self {
+            real: Goldilocks64Field::neg(&a.real),
+            imag: Goldilocks64Field::neg(&a.imag),
+        }
+    }
+
+    /// Multiplies two Fp2 elements using Karatsuba multiplication.
+    /// (a0 + a1*w)(b0 + b1*w) = (a0*b0 + W*a1*b1) + (a0*b1 + a1*b0)*w
+    #[inline(always)]
+    pub fn mul(a: Self, b: Self) -> Self {
+        let a0b0 = Goldilocks64Field::mul(&a.real, &b.real);
+        let a1b1 = Goldilocks64Field::mul(&a.imag, &b.imag);
+        let sum_a = Goldilocks64Field::add(&a.real, &a.imag);
+        let sum_b = Goldilocks64Field::add(&b.real, &b.imag);
+        let z = Goldilocks64Field::mul(&sum_a, &sum_b);
+
+        // W*a1*b1 = 7*a1*b1
+        let w_a1b1 = mul_by_w_scalar(a1b1);
+
+        Self {
+            real: Goldilocks64Field::add(&a0b0, &w_a1b1),
+            imag: Goldilocks64Field::sub(&Goldilocks64Field::sub(&z, &a0b0), &a1b1),
+        }
+    }
+}
+
+/// Multiply a scalar by W = 7.
+#[inline(always)]
+fn mul_by_w_scalar(x: u64) -> u64 {
+    // 7x = 8x - x
+    let x2 = Goldilocks64Field::double(&x);
+    let x4 = Goldilocks64Field::double(&x2);
+    let x8 = Goldilocks64Field::double(&x4);
+    Goldilocks64Field::sub(&x8, &x)
+}
+
+/// A packed vector of 2 Fp2 (Goldilocks quadratic extension) elements.
+///
+/// Uses Struct-of-Arrays layout with two PackedGoldilocks2 vectors:
+/// - `real`: real components [a0_real, a1_real]
+/// - `imag`: imaginary components [a0_imag, a1_imag]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct PackedFp2x2 {
+    /// Real (coefficient of w^0) components
+    pub real: PackedGoldilocks2,
+    /// Imaginary (coefficient of w^1) components
+    pub imag: PackedGoldilocks2,
+}
+
+impl PackedFp2x2 {
+    /// Number of Fp2 elements packed in this type.
+    pub const WIDTH: usize = 2;
+
+    /// Zero element (additive identity).
+    pub const ZERO: Self = Self {
+        real: PackedGoldilocks2::ZERO,
+        imag: PackedGoldilocks2::ZERO,
+    };
+
+    /// One element (multiplicative identity).
+    pub const ONE: Self = Self {
+        real: PackedGoldilocks2::ONE,
+        imag: PackedGoldilocks2::ZERO,
+    };
+
+    /// Creates a new packed Fp2 element with all lanes set to the same value.
+    #[inline(always)]
+    pub fn broadcast(val: Fp2Raw) -> Self {
+        Self {
+            real: PackedGoldilocks2::broadcast(val.real),
+            imag: PackedGoldilocks2::broadcast(val.imag),
+        }
+    }
+
+    /// Creates a new packed element from an array of Fp2 elements.
+    #[inline(always)]
+    pub fn from_array(vals: [Fp2Raw; 2]) -> Self {
+        Self {
+            real: PackedGoldilocks2::from_array([vals[0].real, vals[1].real]),
+            imag: PackedGoldilocks2::from_array([vals[0].imag, vals[1].imag]),
+        }
+    }
+
+    /// Creates from raw u64 arrays.
+    #[inline(always)]
+    pub fn from_raw(reals: [u64; 2], imags: [u64; 2]) -> Self {
+        Self {
+            real: PackedGoldilocks2::from_array(reals),
+            imag: PackedGoldilocks2::from_array(imags),
+        }
+    }
+
+    /// Extracts the elements as an array of Fp2 elements.
+    #[inline(always)]
+    pub fn to_array(self) -> [Fp2Raw; 2] {
+        let reals = self.real.to_array();
+        let imags = self.imag.to_array();
+        [
+            Fp2Raw::new(reals[0], imags[0]),
+            Fp2Raw::new(reals[1], imags[1]),
+        ]
+    }
+
+    /// Extracts raw u64 arrays.
+    #[inline(always)]
+    pub fn to_raw(self) -> ([u64; 2], [u64; 2]) {
+        (self.real.to_array(), self.imag.to_array())
+    }
+
+    /// Gets the element at the specified index.
+    #[inline(always)]
+    pub fn get(&self, idx: usize) -> Fp2Raw {
+        debug_assert!(idx < 2);
+        let reals = self.real.to_array();
+        let imags = self.imag.to_array();
+        Fp2Raw::new(reals[idx], imags[idx])
+    }
+
+    /// Doubles the element.
+    #[inline(always)]
+    pub fn double(self) -> Self {
+        Self {
+            real: self.real.double(),
+            imag: self.imag.double(),
+        }
+    }
+
+    /// Squares the element.
+    /// (a0 + a1*w)^2 = (a0^2 + W*a1^2) + 2*a0*a1*w
+    #[inline(always)]
+    pub fn square(self) -> Self {
+        let a0_sq = self.real.square();
+        let a1_sq = self.imag.square();
+        let a0a1 = self.real * self.imag;
+
+        // W*a1^2 = 7*a1^2
+        let w_a1_sq = mul_by_w(a1_sq);
+
+        Self {
+            real: a0_sq + w_a1_sq,
+            imag: a0a1.double(),
+        }
+    }
+
+    /// Returns the conjugate: conjugate(a0 + a1*w) = a0 - a1*w
+    #[inline(always)]
+    pub fn conjugate(self) -> Self {
+        Self {
+            real: self.real,
+            imag: -self.imag,
+        }
+    }
+
+    /// Multiplies by a base field element (scalar from Fp).
+    #[inline(always)]
+    pub fn mul_by_fp(self, scalar: PackedGoldilocks2) -> Self {
+        Self {
+            real: self.real * scalar,
+            imag: self.imag * scalar,
+        }
+    }
+}
+
+/// Multiply a packed element by W = 7.
+/// Uses the identity: 7x = 8x - x = (x << 3) - x
+#[inline(always)]
+fn mul_by_w(x: PackedGoldilocks2) -> PackedGoldilocks2 {
+    let x2 = x.double();
+    let x4 = x2.double();
+    let x8 = x4.double();
+    x8 - x
+}
+
+// ============================================================================
+// Arithmetic Operations
+// ============================================================================
+
+impl Add for PackedFp2x2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn add(self, rhs: Self) -> Self::Output {
+        Self {
+            real: self.real + rhs.real,
+            imag: self.imag + rhs.imag,
+        }
+    }
+}
+
+impl AddAssign for PackedFp2x2 {
+    #[inline(always)]
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl Sub for PackedFp2x2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self {
+            real: self.real - rhs.real,
+            imag: self.imag - rhs.imag,
+        }
+    }
+}
+
+impl SubAssign for PackedFp2x2 {
+    #[inline(always)]
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl Neg for PackedFp2x2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn neg(self) -> Self::Output {
+        Self {
+            real: -self.real,
+            imag: -self.imag,
+        }
+    }
+}
+
+impl Mul for PackedFp2x2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn mul(self, rhs: Self) -> Self::Output {
+        // Karatsuba multiplication for Fp2:
+        // (a0 + a1*w)(b0 + b1*w) = (a0*b0 + W*a1*b1) + (a0*b1 + a1*b0)*w
+        //
+        // Using Karatsuba:
+        // z = (a0 + a1)(b0 + b1)
+        // c0 = a0*b0 + W*a1*b1
+        // c1 = z - a0*b0 - a1*b1 = a0*b1 + a1*b0
+
+        let a0b0 = self.real * rhs.real;
+        let a1b1 = self.imag * rhs.imag;
+        let sum_a = self.real + self.imag;
+        let sum_b = rhs.real + rhs.imag;
+        let z = sum_a * sum_b;
+
+        // W*a1*b1 = 7*a1*b1
+        let w_a1b1 = mul_by_w(a1b1);
+
+        Self {
+            real: a0b0 + w_a1b1,
+            imag: z - a0b0 - a1b1,
+        }
+    }
+}
+
+impl MulAssign for PackedFp2x2 {
+    #[inline(always)]
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs;
+    }
+}
+
+// ============================================================================
+// Trait Implementations
+// ============================================================================
+
+impl Default for PackedFp2x2 {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl fmt::Debug for PackedFp2x2 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let elems = self.to_array();
+        f.debug_struct("PackedFp2x2")
+            .field("0", &elems[0])
+            .field("1", &elems[1])
+            .finish()
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fp2(r: u64, i: u64) -> Fp2Raw {
+        Fp2Raw::new(r, i)
+    }
+
+    #[test]
+    fn test_from_to_array() {
+        let a = fp2(111, 222);
+        let b = fp2(333, 444);
+        let packed = PackedFp2x2::from_array([a, b]);
+        let unpacked = packed.to_array();
+        assert_eq!(unpacked[0], a);
+        assert_eq!(unpacked[1], b);
+    }
+
+    #[test]
+    fn test_add() {
+        let a0 = fp2(1, 2);
+        let a1 = fp2(3, 4);
+        let b0 = fp2(5, 6);
+        let b1 = fp2(7, 8);
+
+        let packed_a = PackedFp2x2::from_array([a0, a1]);
+        let packed_b = PackedFp2x2::from_array([b0, b1]);
+        let result = (packed_a + packed_b).to_array();
+
+        assert_eq!(result[0], Fp2Raw::add(a0, b0));
+        assert_eq!(result[1], Fp2Raw::add(a1, b1));
+    }
+
+    #[test]
+    fn test_sub() {
+        let a0 = fp2(10, 20);
+        let a1 = fp2(30, 40);
+        let b0 = fp2(1, 2);
+        let b1 = fp2(3, 4);
+
+        let packed_a = PackedFp2x2::from_array([a0, a1]);
+        let packed_b = PackedFp2x2::from_array([b0, b1]);
+        let result = (packed_a - packed_b).to_array();
+
+        assert_eq!(result[0], Fp2Raw::sub(a0, b0));
+        assert_eq!(result[1], Fp2Raw::sub(a1, b1));
+    }
+
+    #[test]
+    fn test_neg() {
+        let a0 = fp2(5, 10);
+        let a1 = fp2(15, 20);
+
+        let packed = PackedFp2x2::from_array([a0, a1]);
+        let result = (-packed).to_array();
+
+        assert_eq!(result[0], Fp2Raw::neg(a0));
+        assert_eq!(result[1], Fp2Raw::neg(a1));
+    }
+
+    #[test]
+    fn test_mul() {
+        let a0 = fp2(2, 3);
+        let a1 = fp2(4, 5);
+        let b0 = fp2(6, 7);
+        let b1 = fp2(8, 9);
+
+        let packed_a = PackedFp2x2::from_array([a0, a1]);
+        let packed_b = PackedFp2x2::from_array([b0, b1]);
+        let result = (packed_a * packed_b).to_array();
+
+        assert_eq!(result[0], Fp2Raw::mul(a0, b0));
+        assert_eq!(result[1], Fp2Raw::mul(a1, b1));
+    }
+
+    #[test]
+    fn test_mul_large() {
+        // Test with larger values
+        let p = super::super::packed_goldilocks::P;
+        let a0 = fp2(p - 1, p - 2);
+        let a1 = fp2(p - 3, p - 4);
+        let b0 = fp2(p - 5, p - 6);
+        let b1 = fp2(p - 7, p - 8);
+
+        let packed_a = PackedFp2x2::from_array([a0, a1]);
+        let packed_b = PackedFp2x2::from_array([b0, b1]);
+        let result = (packed_a * packed_b).to_array();
+
+        assert_eq!(result[0], Fp2Raw::mul(a0, b0));
+        assert_eq!(result[1], Fp2Raw::mul(a1, b1));
+    }
+
+    #[test]
+    fn test_square() {
+        let a0 = fp2(7, 11);
+        let a1 = fp2(13, 17);
+
+        let packed = PackedFp2x2::from_array([a0, a1]);
+        let squared = packed.square().to_array();
+        let mul_self = (packed * packed).to_array();
+
+        assert_eq!(squared[0], mul_self[0]);
+        assert_eq!(squared[1], mul_self[1]);
+    }
+
+    #[test]
+    fn test_double() {
+        let a0 = fp2(5, 10);
+        let a1 = fp2(15, 20);
+
+        let packed = PackedFp2x2::from_array([a0, a1]);
+        let doubled = packed.double().to_array();
+        let added = (packed + packed).to_array();
+
+        assert_eq!(doubled[0], added[0]);
+        assert_eq!(doubled[1], added[1]);
+    }
+
+    #[test]
+    fn test_conjugate() {
+        let a0 = fp2(5, 10);
+        let a1 = fp2(15, 20);
+
+        let packed = PackedFp2x2::from_array([a0, a1]);
+        let conj = packed.conjugate().to_array();
+
+        assert_eq!(conj[0].real, 5);
+        assert_eq!(conj[0].imag, Goldilocks64Field::neg(&10));
+        assert_eq!(conj[1].real, 15);
+        assert_eq!(conj[1].imag, Goldilocks64Field::neg(&20));
+    }
+
+    #[test]
+    fn test_identity_elements() {
+        let a = PackedFp2x2::from_array([fp2(123, 456), fp2(789, 101112)]);
+
+        // Additive identity
+        let sum = a + PackedFp2x2::ZERO;
+        assert_eq!(sum, a);
+
+        // Multiplicative identity
+        let prod = a * PackedFp2x2::ONE;
+        assert_eq!(prod.to_array()[0], a.to_array()[0]);
+        assert_eq!(prod.to_array()[1], a.to_array()[1]);
+    }
+
+    #[test]
+    fn test_algebraic_properties() {
+        let a = PackedFp2x2::from_array([fp2(123, 456), fp2(789, 101)]);
+        let b = PackedFp2x2::from_array([fp2(111, 222), fp2(333, 444)]);
+        let c = PackedFp2x2::from_array([fp2(555, 666), fp2(777, 888)]);
+
+        // Commutativity of addition
+        assert_eq!((a + b).to_array(), (b + a).to_array());
+
+        // Commutativity of multiplication
+        assert_eq!((a * b).to_array(), (b * a).to_array());
+
+        // Associativity of addition
+        assert_eq!(((a + b) + c).to_array(), (a + (b + c)).to_array());
+
+        // Associativity of multiplication
+        assert_eq!(((a * b) * c).to_array(), (a * (b * c)).to_array());
+
+        // Distributivity
+        assert_eq!((a * (b + c)).to_array(), (a * b + a * c).to_array());
+
+        // Additive inverse
+        let neg_a = -a;
+        let zero = (a + neg_a).to_array();
+        assert_eq!(zero[0], Fp2Raw::ZERO);
+        assert_eq!(zero[1], Fp2Raw::ZERO);
+    }
+}
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+
+    const P: u64 = super::super::packed_goldilocks::P;
+
+    fn arb_fp2() -> impl Strategy<Value = Fp2Raw> {
+        (0..P, 0..P).prop_map(|(r, i)| Fp2Raw::new(r, i))
+    }
+
+    fn arb_packed_fp2() -> impl Strategy<Value = PackedFp2x2> {
+        (arb_fp2(), arb_fp2()).prop_map(|(a, b)| PackedFp2x2::from_array([a, b]))
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1000))]
+
+        #[test]
+        fn prop_add_matches_scalar(
+            a0 in arb_fp2(),
+            a1 in arb_fp2(),
+            b0 in arb_fp2(),
+            b1 in arb_fp2()
+        ) {
+            let packed_a = PackedFp2x2::from_array([a0, a1]);
+            let packed_b = PackedFp2x2::from_array([b0, b1]);
+            let result = (packed_a + packed_b).to_array();
+
+            let expected0 = Fp2Raw::add(a0, b0);
+            let expected1 = Fp2Raw::add(a1, b1);
+
+            prop_assert_eq!(result[0], expected0);
+            prop_assert_eq!(result[1], expected1);
+        }
+
+        #[test]
+        fn prop_sub_matches_scalar(
+            a0 in arb_fp2(),
+            a1 in arb_fp2(),
+            b0 in arb_fp2(),
+            b1 in arb_fp2()
+        ) {
+            let packed_a = PackedFp2x2::from_array([a0, a1]);
+            let packed_b = PackedFp2x2::from_array([b0, b1]);
+            let result = (packed_a - packed_b).to_array();
+
+            let expected0 = Fp2Raw::sub(a0, b0);
+            let expected1 = Fp2Raw::sub(a1, b1);
+
+            prop_assert_eq!(result[0], expected0);
+            prop_assert_eq!(result[1], expected1);
+        }
+
+        #[test]
+        fn prop_mul_matches_scalar(
+            a0 in arb_fp2(),
+            a1 in arb_fp2(),
+            b0 in arb_fp2(),
+            b1 in arb_fp2()
+        ) {
+            let packed_a = PackedFp2x2::from_array([a0, a1]);
+            let packed_b = PackedFp2x2::from_array([b0, b1]);
+            let result = (packed_a * packed_b).to_array();
+
+            let expected0 = Fp2Raw::mul(a0, b0);
+            let expected1 = Fp2Raw::mul(a1, b1);
+
+            prop_assert_eq!(result[0], expected0, "mul lane 0 mismatch");
+            prop_assert_eq!(result[1], expected1, "mul lane 1 mismatch");
+        }
+
+        #[test]
+        fn prop_square_equals_mul_self(a in arb_packed_fp2()) {
+            let squared = a.square().to_array();
+            let mul_self = (a * a).to_array();
+            prop_assert_eq!(squared[0], mul_self[0]);
+            prop_assert_eq!(squared[1], mul_self[1]);
+        }
+
+        #[test]
+        fn prop_double_equals_add_self(a in arb_packed_fp2()) {
+            let doubled = a.double().to_array();
+            let added = (a + a).to_array();
+            prop_assert_eq!(doubled[0], added[0]);
+            prop_assert_eq!(doubled[1], added[1]);
+        }
+
+        #[test]
+        fn prop_add_commutative(a in arb_packed_fp2(), b in arb_packed_fp2()) {
+            prop_assert_eq!((a + b).to_array(), (b + a).to_array());
+        }
+
+        #[test]
+        fn prop_mul_commutative(a in arb_packed_fp2(), b in arb_packed_fp2()) {
+            prop_assert_eq!((a * b).to_array(), (b * a).to_array());
+        }
+
+        #[test]
+        fn prop_distributive(a in arb_packed_fp2(), b in arb_packed_fp2(), c in arb_packed_fp2()) {
+            prop_assert_eq!((a * (b + c)).to_array(), (a * b + a * c).to_array());
+        }
+
+        #[test]
+        fn prop_additive_inverse(a in arb_packed_fp2()) {
+            let neg_a = -a;
+            let result = (a + neg_a).to_array();
+            prop_assert_eq!(result[0], Fp2Raw::ZERO);
+            prop_assert_eq!(result[1], Fp2Raw::ZERO);
+        }
+    }
+}

--- a/crypto/math/src/field/simd/packed_fp3.rs
+++ b/crypto/math/src/field/simd/packed_fp3.rs
@@ -1,0 +1,635 @@
+//! SIMD-accelerated Goldilocks cubic extension (Fp3) arithmetic.
+//!
+//! This module provides `PackedFp3x2`, a type that holds 2 Fp3 elements
+//! and performs operations on them in parallel using SIMD operations.
+//!
+//! # Fp3 Field Structure
+//!
+//! Fp3 = Fp[x] / (x^3 - W) where W = 2 is the cubic non-residue.
+//! Elements are represented as a0 + a1*w + a2*w^2 where w^3 = 2.
+//!
+//! # Memory Layout
+//!
+//! Uses Struct-of-Arrays (SoA) layout for optimal SIMD utilization:
+//! - c0: [c0_0, c0_1] - coefficient of w^0 for two Fp3 elements
+//! - c1: [c1_0, c1_1] - coefficient of w^1 for two Fp3 elements
+//! - c2: [c2_0, c2_1] - coefficient of w^2 for two Fp3 elements
+
+use core::fmt;
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use super::PackedGoldilocks2;
+use crate::field::fields::u64_goldilocks_field::Goldilocks64Field;
+use crate::field::traits::IsField;
+
+/// The cubic non-residue W = 2.
+/// Fp3 is constructed as Fp[x] / (x^3 - 2)
+pub const W: u64 = 2;
+
+/// An Fp3 element represented as (c0, c1, c2) where element = c0 + c1*w + c2*w^2.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Fp3Raw {
+    pub c0: u64,
+    pub c1: u64,
+    pub c2: u64,
+}
+
+impl Fp3Raw {
+    pub const ZERO: Self = Self { c0: 0, c1: 0, c2: 0 };
+    pub const ONE: Self = Self { c0: 1, c1: 0, c2: 0 };
+
+    #[inline(always)]
+    pub fn new(c0: u64, c1: u64, c2: u64) -> Self {
+        Self { c0, c1, c2 }
+    }
+
+    #[inline(always)]
+    pub fn add(a: Self, b: Self) -> Self {
+        Self {
+            c0: Goldilocks64Field::add(&a.c0, &b.c0),
+            c1: Goldilocks64Field::add(&a.c1, &b.c1),
+            c2: Goldilocks64Field::add(&a.c2, &b.c2),
+        }
+    }
+
+    #[inline(always)]
+    pub fn sub(a: Self, b: Self) -> Self {
+        Self {
+            c0: Goldilocks64Field::sub(&a.c0, &b.c0),
+            c1: Goldilocks64Field::sub(&a.c1, &b.c1),
+            c2: Goldilocks64Field::sub(&a.c2, &b.c2),
+        }
+    }
+
+    #[inline(always)]
+    pub fn neg(a: Self) -> Self {
+        Self {
+            c0: Goldilocks64Field::neg(&a.c0),
+            c1: Goldilocks64Field::neg(&a.c1),
+            c2: Goldilocks64Field::neg(&a.c2),
+        }
+    }
+
+    /// Multiplies two Fp3 elements.
+    /// (a0 + a1*w + a2*w^2) * (b0 + b1*w + b2*w^2) mod (w^3 - 2)
+    ///
+    /// Using Karatsuba-like optimization with W=2:
+    /// c0 = v0 + 2 * ((a1 + a2)(b1 + b2) - v1 - v2)
+    /// c1 = (a0 + a1)(b0 + b1) - v0 - v1 + 2 * v2
+    /// c2 = (a0 + a2)(b0 + b2) - v0 + v1 - v2
+    #[inline(always)]
+    pub fn mul(a: Self, b: Self) -> Self {
+        let v0 = Goldilocks64Field::mul(&a.c0, &b.c0);
+        let v1 = Goldilocks64Field::mul(&a.c1, &b.c1);
+        let v2 = Goldilocks64Field::mul(&a.c2, &b.c2);
+
+        let a1_plus_a2 = Goldilocks64Field::add(&a.c1, &a.c2);
+        let b1_plus_b2 = Goldilocks64Field::add(&b.c1, &b.c2);
+        let a0_plus_a1 = Goldilocks64Field::add(&a.c0, &a.c1);
+        let b0_plus_b1 = Goldilocks64Field::add(&b.c0, &b.c1);
+        let a0_plus_a2 = Goldilocks64Field::add(&a.c0, &a.c2);
+        let b0_plus_b2 = Goldilocks64Field::add(&b.c0, &b.c2);
+
+        // c0 = v0 + 2 * ((a1 + a2)(b1 + b2) - v1 - v2)
+        let cross_12 = Goldilocks64Field::mul(&a1_plus_a2, &b1_plus_b2);
+        let cross_12_minus_v1_v2 = Goldilocks64Field::sub(
+            &Goldilocks64Field::sub(&cross_12, &v1),
+            &v2,
+        );
+        let c0 = Goldilocks64Field::add(&v0, &Goldilocks64Field::double(&cross_12_minus_v1_v2));
+
+        // c1 = (a0 + a1)(b0 + b1) - v0 - v1 + 2 * v2
+        let cross_01 = Goldilocks64Field::mul(&a0_plus_a1, &b0_plus_b1);
+        let c1 = Goldilocks64Field::add(
+            &Goldilocks64Field::sub(&Goldilocks64Field::sub(&cross_01, &v0), &v1),
+            &Goldilocks64Field::double(&v2),
+        );
+
+        // c2 = (a0 + a2)(b0 + b2) - v0 + v1 - v2
+        let cross_02 = Goldilocks64Field::mul(&a0_plus_a2, &b0_plus_b2);
+        let c2 = Goldilocks64Field::sub(
+            &Goldilocks64Field::add(&Goldilocks64Field::sub(&cross_02, &v0), &v1),
+            &v2,
+        );
+
+        Self { c0, c1, c2 }
+    }
+
+    /// Multiplies by a scalar from Fp.
+    #[inline(always)]
+    pub fn mul_by_fp(a: Self, scalar: u64) -> Self {
+        Self {
+            c0: Goldilocks64Field::mul(&a.c0, &scalar),
+            c1: Goldilocks64Field::mul(&a.c1, &scalar),
+            c2: Goldilocks64Field::mul(&a.c2, &scalar),
+        }
+    }
+}
+
+/// A packed vector of 2 Fp3 (Goldilocks cubic extension) elements.
+///
+/// Uses Struct-of-Arrays layout with three PackedGoldilocks2 vectors.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct PackedFp3x2 {
+    /// Coefficient of w^0
+    pub c0: PackedGoldilocks2,
+    /// Coefficient of w^1
+    pub c1: PackedGoldilocks2,
+    /// Coefficient of w^2
+    pub c2: PackedGoldilocks2,
+}
+
+impl PackedFp3x2 {
+    /// Number of Fp3 elements packed in this type.
+    pub const WIDTH: usize = 2;
+
+    /// Zero element (additive identity).
+    pub const ZERO: Self = Self {
+        c0: PackedGoldilocks2::ZERO,
+        c1: PackedGoldilocks2::ZERO,
+        c2: PackedGoldilocks2::ZERO,
+    };
+
+    /// One element (multiplicative identity).
+    pub const ONE: Self = Self {
+        c0: PackedGoldilocks2::ONE,
+        c1: PackedGoldilocks2::ZERO,
+        c2: PackedGoldilocks2::ZERO,
+    };
+
+    /// Creates a new packed Fp3 element with all lanes set to the same value.
+    #[inline(always)]
+    pub fn broadcast(val: Fp3Raw) -> Self {
+        Self {
+            c0: PackedGoldilocks2::broadcast(val.c0),
+            c1: PackedGoldilocks2::broadcast(val.c1),
+            c2: PackedGoldilocks2::broadcast(val.c2),
+        }
+    }
+
+    /// Creates a new packed element from an array of Fp3 elements.
+    #[inline(always)]
+    pub fn from_array(vals: [Fp3Raw; 2]) -> Self {
+        Self {
+            c0: PackedGoldilocks2::from_array([vals[0].c0, vals[1].c0]),
+            c1: PackedGoldilocks2::from_array([vals[0].c1, vals[1].c1]),
+            c2: PackedGoldilocks2::from_array([vals[0].c2, vals[1].c2]),
+        }
+    }
+
+    /// Extracts the elements as an array of Fp3 elements.
+    #[inline(always)]
+    pub fn to_array(self) -> [Fp3Raw; 2] {
+        let c0s = self.c0.to_array();
+        let c1s = self.c1.to_array();
+        let c2s = self.c2.to_array();
+        [
+            Fp3Raw::new(c0s[0], c1s[0], c2s[0]),
+            Fp3Raw::new(c0s[1], c1s[1], c2s[1]),
+        ]
+    }
+
+    /// Gets the element at the specified index.
+    #[inline(always)]
+    pub fn get(&self, idx: usize) -> Fp3Raw {
+        debug_assert!(idx < 2);
+        let c0s = self.c0.to_array();
+        let c1s = self.c1.to_array();
+        let c2s = self.c2.to_array();
+        Fp3Raw::new(c0s[idx], c1s[idx], c2s[idx])
+    }
+
+    /// Doubles the element.
+    #[inline(always)]
+    pub fn double(self) -> Self {
+        Self {
+            c0: self.c0.double(),
+            c1: self.c1.double(),
+            c2: self.c2.double(),
+        }
+    }
+
+    /// Multiplies by a base field element (scalar from Fp).
+    #[inline(always)]
+    pub fn mul_by_fp(self, scalar: PackedGoldilocks2) -> Self {
+        Self {
+            c0: self.c0 * scalar,
+            c1: self.c1 * scalar,
+            c2: self.c2 * scalar,
+        }
+    }
+}
+
+// ============================================================================
+// Arithmetic Operations
+// ============================================================================
+
+impl Add for PackedFp3x2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn add(self, rhs: Self) -> Self::Output {
+        Self {
+            c0: self.c0 + rhs.c0,
+            c1: self.c1 + rhs.c1,
+            c2: self.c2 + rhs.c2,
+        }
+    }
+}
+
+impl AddAssign for PackedFp3x2 {
+    #[inline(always)]
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl Sub for PackedFp3x2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self {
+            c0: self.c0 - rhs.c0,
+            c1: self.c1 - rhs.c1,
+            c2: self.c2 - rhs.c2,
+        }
+    }
+}
+
+impl SubAssign for PackedFp3x2 {
+    #[inline(always)]
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl Neg for PackedFp3x2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn neg(self) -> Self::Output {
+        Self {
+            c0: -self.c0,
+            c1: -self.c1,
+            c2: -self.c2,
+        }
+    }
+}
+
+impl Mul for PackedFp3x2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn mul(self, rhs: Self) -> Self::Output {
+        // Karatsuba multiplication for Fp3:
+        // (a0 + a1*w + a2*w^2) * (b0 + b1*w + b2*w^2) mod (w^3 - 2)
+        //
+        // v0 = a0*b0, v1 = a1*b1, v2 = a2*b2
+        // c0 = v0 + 2 * ((a1 + a2)(b1 + b2) - v1 - v2)
+        // c1 = (a0 + a1)(b0 + b1) - v0 - v1 + 2 * v2
+        // c2 = (a0 + a2)(b0 + b2) - v0 + v1 - v2
+
+        let v0 = self.c0 * rhs.c0;
+        let v1 = self.c1 * rhs.c1;
+        let v2 = self.c2 * rhs.c2;
+
+        let a1_plus_a2 = self.c1 + self.c2;
+        let b1_plus_b2 = rhs.c1 + rhs.c2;
+        let a0_plus_a1 = self.c0 + self.c1;
+        let b0_plus_b1 = rhs.c0 + rhs.c1;
+        let a0_plus_a2 = self.c0 + self.c2;
+        let b0_plus_b2 = rhs.c0 + rhs.c2;
+
+        // c0 = v0 + 2 * ((a1 + a2)(b1 + b2) - v1 - v2)
+        let cross_12 = a1_plus_a2 * b1_plus_b2;
+        let cross_12_minus_v1_v2 = cross_12 - v1 - v2;
+        let c0 = v0 + cross_12_minus_v1_v2.double();
+
+        // c1 = (a0 + a1)(b0 + b1) - v0 - v1 + 2 * v2
+        let cross_01 = a0_plus_a1 * b0_plus_b1;
+        let c1 = cross_01 - v0 - v1 + v2.double();
+
+        // c2 = (a0 + a2)(b0 + b2) - v0 + v1 - v2
+        let cross_02 = a0_plus_a2 * b0_plus_b2;
+        let c2 = cross_02 - v0 + v1 - v2;
+
+        Self { c0, c1, c2 }
+    }
+}
+
+impl MulAssign for PackedFp3x2 {
+    #[inline(always)]
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs;
+    }
+}
+
+// ============================================================================
+// Trait Implementations
+// ============================================================================
+
+impl Default for PackedFp3x2 {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl fmt::Debug for PackedFp3x2 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let elems = self.to_array();
+        f.debug_struct("PackedFp3x2")
+            .field("0", &elems[0])
+            .field("1", &elems[1])
+            .finish()
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fp3(c0: u64, c1: u64, c2: u64) -> Fp3Raw {
+        Fp3Raw::new(c0, c1, c2)
+    }
+
+    #[test]
+    fn test_from_to_array() {
+        let a = fp3(111, 222, 333);
+        let b = fp3(444, 555, 666);
+        let packed = PackedFp3x2::from_array([a, b]);
+        let unpacked = packed.to_array();
+        assert_eq!(unpacked[0], a);
+        assert_eq!(unpacked[1], b);
+    }
+
+    #[test]
+    fn test_add() {
+        let a0 = fp3(1, 2, 3);
+        let a1 = fp3(4, 5, 6);
+        let b0 = fp3(7, 8, 9);
+        let b1 = fp3(10, 11, 12);
+
+        let packed_a = PackedFp3x2::from_array([a0, a1]);
+        let packed_b = PackedFp3x2::from_array([b0, b1]);
+        let result = (packed_a + packed_b).to_array();
+
+        assert_eq!(result[0], Fp3Raw::add(a0, b0));
+        assert_eq!(result[1], Fp3Raw::add(a1, b1));
+    }
+
+    #[test]
+    fn test_sub() {
+        let a0 = fp3(10, 20, 30);
+        let a1 = fp3(40, 50, 60);
+        let b0 = fp3(1, 2, 3);
+        let b1 = fp3(4, 5, 6);
+
+        let packed_a = PackedFp3x2::from_array([a0, a1]);
+        let packed_b = PackedFp3x2::from_array([b0, b1]);
+        let result = (packed_a - packed_b).to_array();
+
+        assert_eq!(result[0], Fp3Raw::sub(a0, b0));
+        assert_eq!(result[1], Fp3Raw::sub(a1, b1));
+    }
+
+    #[test]
+    fn test_neg() {
+        let a0 = fp3(5, 10, 15);
+        let a1 = fp3(20, 25, 30);
+
+        let packed = PackedFp3x2::from_array([a0, a1]);
+        let result = (-packed).to_array();
+
+        assert_eq!(result[0], Fp3Raw::neg(a0));
+        assert_eq!(result[1], Fp3Raw::neg(a1));
+    }
+
+    #[test]
+    fn test_mul() {
+        let a0 = fp3(2, 3, 4);
+        let a1 = fp3(5, 6, 7);
+        let b0 = fp3(8, 9, 10);
+        let b1 = fp3(11, 12, 13);
+
+        let packed_a = PackedFp3x2::from_array([a0, a1]);
+        let packed_b = PackedFp3x2::from_array([b0, b1]);
+        let result = (packed_a * packed_b).to_array();
+
+        assert_eq!(result[0], Fp3Raw::mul(a0, b0));
+        assert_eq!(result[1], Fp3Raw::mul(a1, b1));
+    }
+
+    #[test]
+    fn test_mul_large() {
+        let p = super::super::packed_goldilocks::P;
+        let a0 = fp3(p - 1, p - 2, p - 3);
+        let a1 = fp3(p - 4, p - 5, p - 6);
+        let b0 = fp3(p - 7, p - 8, p - 9);
+        let b1 = fp3(p - 10, p - 11, p - 12);
+
+        let packed_a = PackedFp3x2::from_array([a0, a1]);
+        let packed_b = PackedFp3x2::from_array([b0, b1]);
+        let result = (packed_a * packed_b).to_array();
+
+        assert_eq!(result[0], Fp3Raw::mul(a0, b0));
+        assert_eq!(result[1], Fp3Raw::mul(a1, b1));
+    }
+
+    #[test]
+    fn test_double() {
+        let a0 = fp3(5, 10, 15);
+        let a1 = fp3(20, 25, 30);
+
+        let packed = PackedFp3x2::from_array([a0, a1]);
+        let doubled = packed.double().to_array();
+        let added = (packed + packed).to_array();
+
+        assert_eq!(doubled[0], added[0]);
+        assert_eq!(doubled[1], added[1]);
+    }
+
+    #[test]
+    fn test_mul_by_fp() {
+        let a0 = fp3(2, 3, 4);
+        let a1 = fp3(5, 6, 7);
+        let scalar0 = 10u64;
+        let scalar1 = 20u64;
+
+        let packed = PackedFp3x2::from_array([a0, a1]);
+        let packed_scalar = PackedGoldilocks2::from_array([scalar0, scalar1]);
+        let result = packed.mul_by_fp(packed_scalar).to_array();
+
+        assert_eq!(result[0], Fp3Raw::mul_by_fp(a0, scalar0));
+        assert_eq!(result[1], Fp3Raw::mul_by_fp(a1, scalar1));
+    }
+
+    #[test]
+    fn test_identity_elements() {
+        let a = PackedFp3x2::from_array([fp3(123, 456, 789), fp3(111, 222, 333)]);
+
+        // Additive identity
+        let sum = a + PackedFp3x2::ZERO;
+        assert_eq!(sum, a);
+
+        // Multiplicative identity
+        let prod = a * PackedFp3x2::ONE;
+        assert_eq!(prod.to_array()[0], a.to_array()[0]);
+        assert_eq!(prod.to_array()[1], a.to_array()[1]);
+    }
+
+    #[test]
+    fn test_algebraic_properties() {
+        let a = PackedFp3x2::from_array([fp3(123, 456, 789), fp3(101, 202, 303)]);
+        let b = PackedFp3x2::from_array([fp3(111, 222, 333), fp3(444, 555, 666)]);
+        let c = PackedFp3x2::from_array([fp3(777, 888, 999), fp3(100, 200, 300)]);
+
+        // Commutativity of addition
+        assert_eq!((a + b).to_array(), (b + a).to_array());
+
+        // Commutativity of multiplication
+        assert_eq!((a * b).to_array(), (b * a).to_array());
+
+        // Associativity of addition
+        assert_eq!(((a + b) + c).to_array(), (a + (b + c)).to_array());
+
+        // Associativity of multiplication
+        assert_eq!(((a * b) * c).to_array(), (a * (b * c)).to_array());
+
+        // Distributivity
+        assert_eq!((a * (b + c)).to_array(), (a * b + a * c).to_array());
+
+        // Additive inverse
+        let neg_a = -a;
+        let zero = (a + neg_a).to_array();
+        assert_eq!(zero[0], Fp3Raw::ZERO);
+        assert_eq!(zero[1], Fp3Raw::ZERO);
+    }
+}
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+
+    const P: u64 = super::super::packed_goldilocks::P;
+
+    fn arb_fp3() -> impl Strategy<Value = Fp3Raw> {
+        (0..P, 0..P, 0..P).prop_map(|(c0, c1, c2)| Fp3Raw::new(c0, c1, c2))
+    }
+
+    fn arb_packed_fp3() -> impl Strategy<Value = PackedFp3x2> {
+        (arb_fp3(), arb_fp3()).prop_map(|(a, b)| PackedFp3x2::from_array([a, b]))
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1000))]
+
+        #[test]
+        fn prop_add_matches_scalar(
+            a0 in arb_fp3(),
+            a1 in arb_fp3(),
+            b0 in arb_fp3(),
+            b1 in arb_fp3()
+        ) {
+            let packed_a = PackedFp3x2::from_array([a0, a1]);
+            let packed_b = PackedFp3x2::from_array([b0, b1]);
+            let result = (packed_a + packed_b).to_array();
+
+            let expected0 = Fp3Raw::add(a0, b0);
+            let expected1 = Fp3Raw::add(a1, b1);
+
+            prop_assert_eq!(result[0], expected0);
+            prop_assert_eq!(result[1], expected1);
+        }
+
+        #[test]
+        fn prop_sub_matches_scalar(
+            a0 in arb_fp3(),
+            a1 in arb_fp3(),
+            b0 in arb_fp3(),
+            b1 in arb_fp3()
+        ) {
+            let packed_a = PackedFp3x2::from_array([a0, a1]);
+            let packed_b = PackedFp3x2::from_array([b0, b1]);
+            let result = (packed_a - packed_b).to_array();
+
+            let expected0 = Fp3Raw::sub(a0, b0);
+            let expected1 = Fp3Raw::sub(a1, b1);
+
+            prop_assert_eq!(result[0], expected0);
+            prop_assert_eq!(result[1], expected1);
+        }
+
+        #[test]
+        fn prop_mul_matches_scalar(
+            a0 in arb_fp3(),
+            a1 in arb_fp3(),
+            b0 in arb_fp3(),
+            b1 in arb_fp3()
+        ) {
+            let packed_a = PackedFp3x2::from_array([a0, a1]);
+            let packed_b = PackedFp3x2::from_array([b0, b1]);
+            let result = (packed_a * packed_b).to_array();
+
+            let expected0 = Fp3Raw::mul(a0, b0);
+            let expected1 = Fp3Raw::mul(a1, b1);
+
+            prop_assert_eq!(result[0], expected0, "mul lane 0 mismatch");
+            prop_assert_eq!(result[1], expected1, "mul lane 1 mismatch");
+        }
+
+        #[test]
+        fn prop_mul_by_fp_matches_scalar(
+            a0 in arb_fp3(),
+            a1 in arb_fp3(),
+            s0 in 0..P,
+            s1 in 0..P
+        ) {
+            let packed_a = PackedFp3x2::from_array([a0, a1]);
+            let packed_s = PackedGoldilocks2::from_array([s0, s1]);
+            let result = packed_a.mul_by_fp(packed_s).to_array();
+
+            let expected0 = Fp3Raw::mul_by_fp(a0, s0);
+            let expected1 = Fp3Raw::mul_by_fp(a1, s1);
+
+            prop_assert_eq!(result[0], expected0);
+            prop_assert_eq!(result[1], expected1);
+        }
+
+        #[test]
+        fn prop_double_equals_add_self(a in arb_packed_fp3()) {
+            let doubled = a.double().to_array();
+            let added = (a + a).to_array();
+            prop_assert_eq!(doubled[0], added[0]);
+            prop_assert_eq!(doubled[1], added[1]);
+        }
+
+        #[test]
+        fn prop_add_commutative(a in arb_packed_fp3(), b in arb_packed_fp3()) {
+            prop_assert_eq!((a + b).to_array(), (b + a).to_array());
+        }
+
+        #[test]
+        fn prop_mul_commutative(a in arb_packed_fp3(), b in arb_packed_fp3()) {
+            prop_assert_eq!((a * b).to_array(), (b * a).to_array());
+        }
+
+        #[test]
+        fn prop_distributive(a in arb_packed_fp3(), b in arb_packed_fp3(), c in arb_packed_fp3()) {
+            prop_assert_eq!((a * (b + c)).to_array(), (a * b + a * c).to_array());
+        }
+
+        #[test]
+        fn prop_additive_inverse(a in arb_packed_fp3()) {
+            let neg_a = -a;
+            let result = (a + neg_a).to_array();
+            prop_assert_eq!(result[0], Fp3Raw::ZERO);
+            prop_assert_eq!(result[1], Fp3Raw::ZERO);
+        }
+    }
+}

--- a/crypto/math/src/field/simd/packed_goldilocks.rs
+++ b/crypto/math/src/field/simd/packed_goldilocks.rs
@@ -1,0 +1,728 @@
+//! SIMD-accelerated Goldilocks field arithmetic using ARM NEON.
+//!
+//! This module provides `PackedGoldilocks2`, a type that holds 2 Goldilocks
+//! field elements and performs operations on them in parallel using NEON
+//! intrinsics.
+//!
+//! # Goldilocks Field
+//!
+//! The Goldilocks prime is p = 2^64 - 2^32 + 1, which has a special structure
+//! enabling efficient reduction:
+//! - EPSILON = 2^32 - 1
+//! - For x < 2^128: reduce(x) ≡ x_lo + x_hi * EPSILON (mod p)
+//!
+//! # Performance
+//!
+//! On Apple M3, this provides approximately 1.3-1.5x speedup for field
+//! multiplication compared to scalar operations.
+
+use core::arch::aarch64::*;
+use core::fmt;
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use crate::field::element::FieldElement;
+use crate::field::fields::u64_goldilocks_field::Goldilocks64Field;
+
+/// The Goldilocks prime: p = 2^64 - 2^32 + 1
+pub const P: u64 = 0xFFFF_FFFF_0000_0001;
+
+/// EPSILON = 2^32 - 1 = p - 2^64 (used for fast reduction)
+/// When x overflows 2^64, we add EPSILON instead of subtracting 2^64.
+pub const EPSILON: u64 = 0xFFFF_FFFF;
+
+/// A packed vector of 2 Goldilocks field elements.
+///
+/// Uses ARM NEON `uint64x2_t` for parallel arithmetic operations.
+/// Elements are stored in canonical form [0, P).
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct PackedGoldilocks2(uint64x2_t);
+
+impl PackedGoldilocks2 {
+    /// Number of field elements packed in this type.
+    pub const WIDTH: usize = 2;
+
+    /// Zero element (additive identity).
+    pub const ZERO: Self = unsafe { Self(core::mem::transmute([0u64; 2])) };
+
+    /// One element (multiplicative identity).
+    pub const ONE: Self = unsafe { Self(core::mem::transmute([1u64; 2])) };
+
+    /// Creates a new packed element with all lanes set to the same value.
+    #[inline(always)]
+    pub fn broadcast(val: u64) -> Self {
+        debug_assert!(val < P, "value must be in canonical form");
+        unsafe { Self(vdupq_n_u64(val)) }
+    }
+
+    /// Creates a new packed element from an array of field elements.
+    #[inline(always)]
+    pub fn from_array(vals: [u64; 2]) -> Self {
+        debug_assert!(vals[0] < P && vals[1] < P, "values must be in canonical form");
+        unsafe { Self(vld1q_u64(vals.as_ptr())) }
+    }
+
+    /// Creates a new packed element from FieldElement array.
+    #[inline(always)]
+    pub fn from_field_elements(vals: [FieldElement<Goldilocks64Field>; 2]) -> Self {
+        Self::from_array([*vals[0].value(), *vals[1].value()])
+    }
+
+    /// Extracts the elements as an array.
+    #[inline(always)]
+    pub fn to_array(self) -> [u64; 2] {
+        let mut result = [0u64; 2];
+        unsafe { vst1q_u64(result.as_mut_ptr(), self.0) };
+        result
+    }
+
+    /// Extracts the elements as FieldElements.
+    #[inline(always)]
+    pub fn to_field_elements(self) -> [FieldElement<Goldilocks64Field>; 2] {
+        let arr = self.to_array();
+        [
+            FieldElement::<Goldilocks64Field>::from_raw(arr[0]),
+            FieldElement::<Goldilocks64Field>::from_raw(arr[1]),
+        ]
+    }
+
+    /// Gets the element at the specified index.
+    #[inline(always)]
+    pub fn get(&self, idx: usize) -> u64 {
+        debug_assert!(idx < 2);
+        self.to_array()[idx]
+    }
+
+    /// Returns the underlying NEON vector.
+    #[inline(always)]
+    pub fn into_inner(self) -> uint64x2_t {
+        self.0
+    }
+
+    /// Creates from a raw NEON vector (unsafe: caller must ensure values are canonical).
+    ///
+    /// # Safety
+    /// The values in the vector must be in the range [0, P).
+    #[inline(always)]
+    pub unsafe fn from_inner_unchecked(v: uint64x2_t) -> Self {
+        Self(v)
+    }
+
+    /// Reduces values that may be in [0, 2P) to canonical form [0, P).
+    #[inline(always)]
+    fn reduce(self) -> Self {
+        unsafe {
+            let p = vdupq_n_u64(P);
+            // If val >= P, subtract P
+            let reduced = vsubq_u64(self.0, p);
+            // mask = 0xFFFF... if self >= P, else 0
+            let mask = vcgeq_u64(self.0, p);
+            // Select reduced if mask is set, else keep original
+            Self(vbslq_u64(mask, reduced, self.0))
+        }
+    }
+
+    /// Doubles the element (equivalent to self + self but slightly faster).
+    #[inline(always)]
+    pub fn double(self) -> Self {
+        self + self
+    }
+
+    /// Squares the element.
+    #[inline(always)]
+    pub fn square(self) -> Self {
+        self * self
+    }
+}
+
+// ============================================================================
+// Arithmetic Operations
+// ============================================================================
+
+impl Add for PackedGoldilocks2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn add(self, rhs: Self) -> Self::Output {
+        unsafe {
+            let sum = vaddq_u64(self.0, rhs.0);
+            // Check for overflow: if sum < self, overflow occurred
+            let overflow_mask = vcltq_u64(sum, self.0);
+            // If overflow, add EPSILON (since 2^64 ≡ EPSILON mod P)
+            let epsilon = vdupq_n_u64(EPSILON);
+            // overflow_mask is all 1s or all 0s per lane, so AND gives epsilon or 0
+            let correction = vandq_u64(overflow_mask, epsilon);
+            let result = vaddq_u64(sum, correction);
+            // Final reduction
+            Self(result).reduce()
+        }
+    }
+}
+
+impl AddAssign for PackedGoldilocks2 {
+    #[inline(always)]
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl Sub for PackedGoldilocks2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn sub(self, rhs: Self) -> Self::Output {
+        unsafe {
+            // Check for underflow before subtraction
+            let underflow_mask = vcltq_u64(self.0, rhs.0);
+            let diff = vsubq_u64(self.0, rhs.0);
+            // If underflow, we wrapped by adding 2^64, so subtract EPSILON
+            // But subtraction can underflow again, so we add P instead
+            let p = vdupq_n_u64(P);
+            let correction = vandq_u64(underflow_mask, p);
+            Self(vaddq_u64(diff, correction))
+        }
+    }
+}
+
+impl SubAssign for PackedGoldilocks2 {
+    #[inline(always)]
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl Neg for PackedGoldilocks2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn neg(self) -> Self::Output {
+        // -x = P - x for non-zero x, 0 for zero
+        unsafe {
+            let p = vdupq_n_u64(P);
+            let zero = vdupq_n_u64(0);
+            let is_zero = vceqq_u64(self.0, zero);
+            let neg = vsubq_u64(p, self.0);
+            Self(vbslq_u64(is_zero, zero, neg))
+        }
+    }
+}
+
+impl Mul for PackedGoldilocks2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn mul(self, rhs: Self) -> Self::Output {
+        // NEON 64-bit multiplication via 32x32->64 products
+        // a * b where a = a_lo + a_hi * 2^32, b = b_lo + b_hi * 2^32
+        //
+        // Full 128-bit product:
+        //   lo64 = a_lo*b_lo + low32(a_lo*b_hi + a_hi*b_lo) << 32
+        //   hi64 = a_hi*b_hi + high33(a_lo*b_hi + a_hi*b_lo) + carry
+        //
+        // Note: a_lo*b_hi + a_hi*b_lo can be up to 65 bits!
+        //
+        // Then apply Goldilocks reduction: 2^64 ≡ EPSILON (mod P)
+        unsafe {
+            // Reinterpret as 32-bit values: [a0_lo, a0_hi, a1_lo, a1_hi]
+            let a_32: uint32x4_t = vreinterpretq_u32_u64(self.0);
+            let b_32: uint32x4_t = vreinterpretq_u32_u64(rhs.0);
+
+            // Deinterleave to get [a0_lo, a1_lo] and [a0_hi, a1_hi]
+            let a_lo_32 = vuzp1q_u32(a_32, a_32);
+            let a_hi_32 = vuzp2q_u32(a_32, a_32);
+            let b_lo_32 = vuzp1q_u32(b_32, b_32);
+            let b_hi_32 = vuzp2q_u32(b_32, b_32);
+
+            // Extract as uint32x2_t for vmull_u32
+            let a_lo = vget_low_u32(a_lo_32);
+            let a_hi = vget_low_u32(a_hi_32);
+            let b_lo = vget_low_u32(b_lo_32);
+            let b_hi = vget_low_u32(b_hi_32);
+
+            // Compute four 32x32->64 products
+            let p_ll: uint64x2_t = vmull_u32(a_lo, b_lo); // a_lo * b_lo
+            let p_lh: uint64x2_t = vmull_u32(a_lo, b_hi); // a_lo * b_hi
+            let p_hl: uint64x2_t = vmull_u32(a_hi, b_lo); // a_hi * b_lo
+            let p_hh: uint64x2_t = vmull_u32(a_hi, b_hi); // a_hi * b_hi
+
+            // Middle term: p_lh + p_hl (can overflow to 65 bits!)
+            let p_mid = vaddq_u64(p_lh, p_hl);
+            // Detect overflow: if p_mid < p_lh, we overflowed
+            let mid_overflow = vcltq_u64(p_mid, p_lh);
+            let mid_carry = vandq_u64(mid_overflow, vdupq_n_u64(1)); // 1 if overflow, else 0
+
+            // Low 64 bits of result:
+            // lo = p_ll + (low32(p_mid) << 32)
+            let mid_lo_shifted = vshlq_n_u64(p_mid, 32); // mid << 32 (takes low 32 bits and shifts)
+            let lo = vaddq_u64(p_ll, mid_lo_shifted);
+
+            // Detect overflow from adding mid_lo_shifted to p_ll
+            let lo_overflow = vcltq_u64(lo, p_ll);
+            let lo_carry = vandq_u64(lo_overflow, vdupq_n_u64(1));
+
+            // High 64 bits of result:
+            // hi = p_hh + high32(p_mid) + mid_carry*2^32 + lo_carry
+            let mid_hi = vshrq_n_u64(p_mid, 32); // mid >> 32
+            let mid_carry_shifted = vshlq_n_u64(mid_carry, 32); // mid overflow contributes to bit 64
+            let hi = vaddq_u64(vaddq_u64(vaddq_u64(p_hh, mid_hi), mid_carry_shifted), lo_carry);
+
+            // Apply Goldilocks reduction: x = lo + hi * EPSILON (mod P)
+            // Since 2^64 ≡ EPSILON (mod P)
+            reduce_128_neon(lo, hi)
+        }
+    }
+}
+
+/// NEON 128-bit Goldilocks reduction
+///
+/// Reduces a 128-bit value (lo, hi) modulo P = 2^64 - 2^32 + 1
+/// Using the identity: 2^64 ≡ 2^32 - 1 ≡ EPSILON (mod P)
+///
+/// For x = lo + hi * 2^64:
+///   x ≡ lo + hi * EPSILON (mod P)
+///   x ≡ lo - hi_hi + hi_lo * EPSILON (mod P)
+///   where hi = hi_lo + hi_hi * 2^32
+#[inline(always)]
+unsafe fn reduce_128_neon(lo: uint64x2_t, hi: uint64x2_t) -> PackedGoldilocks2 {
+    unsafe {
+        let epsilon = vdupq_n_u64(EPSILON);
+
+        // Split hi into hi_lo (low 32 bits) and hi_hi (high 32 bits)
+        let hi_lo = vandq_u64(hi, epsilon); // hi & 0xFFFFFFFF
+        let hi_hi = vshrq_n_u64(hi, 32); // hi >> 32
+
+        // Step 1: t0 = lo - hi_hi
+        // If borrow, subtract EPSILON (equivalent to adding P - EPSILON = 2^32)
+        let borrow_mask = vcltq_u64(lo, hi_hi);
+        let t0 = vsubq_u64(lo, hi_hi);
+        // On borrow: we wrapped by 2^64, so we subtracted too much
+        // Need to add 2^64 mod P = EPSILON, but since we wrapped, result is too high
+        // Actually: wrapping sub means result = lo - hi_hi + 2^64 = lo - hi_hi + EPSILON + P
+        // So we need to subtract EPSILON to get lo - hi_hi + P
+        let borrow_correction = vandq_u64(borrow_mask, epsilon);
+        let t0 = vsubq_u64(t0, borrow_correction);
+
+        // Step 2: t1 = hi_lo * EPSILON
+        // hi_lo is at most 32 bits, EPSILON is 32 bits, so product fits in 64 bits
+        // We can compute this as: hi_lo * (2^32 - 1) = (hi_lo << 32) - hi_lo
+        let hi_lo_shifted = vshlq_n_u64(hi_lo, 32);
+        let t1 = vsubq_u64(hi_lo_shifted, hi_lo);
+
+        // Step 3: result = t0 + t1
+        let sum = vaddq_u64(t0, t1);
+        let carry_mask = vcltq_u64(sum, t0);
+        let carry_correction = vandq_u64(carry_mask, epsilon);
+        let result = vaddq_u64(sum, carry_correction);
+
+        // Final reduction: if result >= P, subtract P
+        PackedGoldilocks2(result).reduce()
+    }
+}
+
+impl MulAssign for PackedGoldilocks2 {
+    #[inline(always)]
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs;
+    }
+}
+
+// ============================================================================
+// Trait Implementations
+// ============================================================================
+
+impl Default for PackedGoldilocks2 {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl fmt::Debug for PackedGoldilocks2 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let arr = self.to_array();
+        f.debug_tuple("PackedGoldilocks2")
+            .field(&arr[0])
+            .field(&arr[1])
+            .finish()
+    }
+}
+
+impl PartialEq for PackedGoldilocks2 {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_array() == other.to_array()
+    }
+}
+
+impl Eq for PackedGoldilocks2 {}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::field::fields::u64_goldilocks_field::Goldilocks64Field;
+    use crate::field::traits::IsField;
+
+    /// Reference scalar implementation for testing
+    fn scalar_add(a: u64, b: u64) -> u64 {
+        Goldilocks64Field::add(&a, &b)
+    }
+
+    fn scalar_sub(a: u64, b: u64) -> u64 {
+        Goldilocks64Field::sub(&a, &b)
+    }
+
+    fn scalar_mul(a: u64, b: u64) -> u64 {
+        Goldilocks64Field::mul(&a, &b)
+    }
+
+    fn scalar_neg(a: u64) -> u64 {
+        Goldilocks64Field::neg(&a)
+    }
+
+    #[test]
+    fn test_broadcast() {
+        let val = 12345u64;
+        let packed = PackedGoldilocks2::broadcast(val);
+        let arr = packed.to_array();
+        assert_eq!(arr[0], val);
+        assert_eq!(arr[1], val);
+    }
+
+    #[test]
+    fn test_from_to_array() {
+        let vals = [111u64, 222u64];
+        let packed = PackedGoldilocks2::from_array(vals);
+        assert_eq!(packed.to_array(), vals);
+    }
+
+    #[test]
+    fn test_add_simple() {
+        let a = PackedGoldilocks2::from_array([1, 2]);
+        let b = PackedGoldilocks2::from_array([3, 4]);
+        let c = a + b;
+        let result = c.to_array();
+        assert_eq!(result[0], scalar_add(1, 3));
+        assert_eq!(result[1], scalar_add(2, 4));
+    }
+
+    #[test]
+    fn test_add_overflow() {
+        // Test values near the field modulus
+        let a = PackedGoldilocks2::from_array([P - 1, P - 2]);
+        let b = PackedGoldilocks2::from_array([2, 3]);
+        let c = a + b;
+        let result = c.to_array();
+        assert_eq!(result[0], scalar_add(P - 1, 2));
+        assert_eq!(result[1], scalar_add(P - 2, 3));
+    }
+
+    #[test]
+    fn test_sub_simple() {
+        let a = PackedGoldilocks2::from_array([5, 10]);
+        let b = PackedGoldilocks2::from_array([3, 4]);
+        let c = a - b;
+        let result = c.to_array();
+        assert_eq!(result[0], scalar_sub(5, 3));
+        assert_eq!(result[1], scalar_sub(10, 4));
+    }
+
+    #[test]
+    fn test_sub_underflow() {
+        // Test underflow (result should wrap around in the field)
+        let a = PackedGoldilocks2::from_array([1, 2]);
+        let b = PackedGoldilocks2::from_array([3, 4]);
+        let c = a - b;
+        let result = c.to_array();
+        assert_eq!(result[0], scalar_sub(1, 3));
+        assert_eq!(result[1], scalar_sub(2, 4));
+    }
+
+    #[test]
+    fn test_neg() {
+        let a = PackedGoldilocks2::from_array([5, 0]);
+        let neg_a = -a;
+        let result = neg_a.to_array();
+        assert_eq!(result[0], scalar_neg(5));
+        assert_eq!(result[1], 0); // -0 = 0
+    }
+
+    #[test]
+    fn test_mul_simple() {
+        let a = PackedGoldilocks2::from_array([2, 3]);
+        let b = PackedGoldilocks2::from_array([4, 5]);
+        let c = a * b;
+        let result = c.to_array();
+        assert_eq!(result[0], scalar_mul(2, 4));
+        assert_eq!(result[1], scalar_mul(3, 5));
+    }
+
+    #[test]
+    fn test_mul_large() {
+        // Test with large values that will overflow 64 bits
+        let a = PackedGoldilocks2::from_array([P - 1, P - 2]);
+        let b = PackedGoldilocks2::from_array([P - 3, P - 4]);
+        let c = a * b;
+        let result = c.to_array();
+        assert_eq!(result[0], scalar_mul(P - 1, P - 3));
+        assert_eq!(result[1], scalar_mul(P - 2, P - 4));
+    }
+
+    #[test]
+    fn test_mul_identity() {
+        let a = PackedGoldilocks2::from_array([12345, 67890]);
+        let one = PackedGoldilocks2::ONE;
+        let c = a * one;
+        assert_eq!(a.to_array(), c.to_array());
+    }
+
+    #[test]
+    fn test_mul_zero() {
+        let a = PackedGoldilocks2::from_array([12345, 67890]);
+        let zero = PackedGoldilocks2::ZERO;
+        let c = a * zero;
+        assert_eq!(c.to_array(), [0, 0]);
+    }
+
+    #[test]
+    fn test_double() {
+        let a = PackedGoldilocks2::from_array([5, P - 1]);
+        let doubled = a.double();
+        let added = a + a;
+        assert_eq!(doubled.to_array(), added.to_array());
+    }
+
+    #[test]
+    fn test_square() {
+        let a = PackedGoldilocks2::from_array([7, 11]);
+        let squared = a.square();
+        let multiplied = a * a;
+        assert_eq!(squared.to_array(), multiplied.to_array());
+    }
+
+    #[test]
+    fn test_algebraic_properties() {
+        let a = PackedGoldilocks2::from_array([123456789, 987654321]);
+        let b = PackedGoldilocks2::from_array([111111111, 222222222]);
+        let c = PackedGoldilocks2::from_array([333333333, 444444444]);
+
+        // Commutativity of addition
+        assert_eq!((a + b).to_array(), (b + a).to_array());
+
+        // Commutativity of multiplication
+        assert_eq!((a * b).to_array(), (b * a).to_array());
+
+        // Associativity of addition
+        assert_eq!(((a + b) + c).to_array(), (a + (b + c)).to_array());
+
+        // Associativity of multiplication
+        assert_eq!(((a * b) * c).to_array(), (a * (b * c)).to_array());
+
+        // Distributivity
+        assert_eq!((a * (b + c)).to_array(), (a * b + a * c).to_array());
+
+        // Additive inverse
+        let neg_a = -a;
+        assert_eq!((a + neg_a).to_array(), [0, 0]);
+    }
+
+    #[test]
+    fn test_edge_cases() {
+        // Test with 0
+        let zero = PackedGoldilocks2::ZERO;
+        let a = PackedGoldilocks2::from_array([12345, 67890]);
+        assert_eq!((a + zero).to_array(), a.to_array());
+        assert_eq!((a - zero).to_array(), a.to_array());
+        assert_eq!((a * zero).to_array(), [0, 0]);
+
+        // Test with 1
+        let one = PackedGoldilocks2::ONE;
+        assert_eq!((a * one).to_array(), a.to_array());
+
+        // Test with P-1
+        let p_minus_1 = PackedGoldilocks2::from_array([P - 1, P - 1]);
+        let result = p_minus_1 + PackedGoldilocks2::from_array([1, 1]);
+        assert_eq!(result.to_array(), [0, 0]);
+    }
+
+    #[test]
+    fn test_mul_specific_values() {
+        // Test some specific multiplication cases
+        let cases = [
+            (0u64, 0u64),
+            (1, 1),
+            (2, 3),
+            (EPSILON, EPSILON),
+            (P - 1, 2),
+            (P - 1, P - 1),
+            (1 << 32, 1 << 32),
+            ((1 << 32) - 1, (1 << 32) + 1),
+        ];
+
+        for (a_val, b_val) in cases {
+            let a = PackedGoldilocks2::from_array([a_val, a_val]);
+            let b = PackedGoldilocks2::from_array([b_val, b_val]);
+            let c = a * b;
+            let result = c.to_array();
+            let expected = scalar_mul(a_val, b_val);
+            assert_eq!(
+                result[0], expected,
+                "mul({}, {}) = {} (expected {})",
+                a_val, b_val, result[0], expected
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use crate::field::fields::u64_goldilocks_field::Goldilocks64Field;
+    use crate::field::traits::IsField;
+    use proptest::prelude::*;
+
+    fn arb_field_element() -> impl Strategy<Value = u64> {
+        0..P
+    }
+
+    fn arb_packed() -> impl Strategy<Value = PackedGoldilocks2> {
+        (arb_field_element(), arb_field_element())
+            .prop_map(|(a, b)| PackedGoldilocks2::from_array([a, b]))
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(10000))]
+
+        #[test]
+        fn prop_add_matches_scalar(
+            a0 in arb_field_element(),
+            a1 in arb_field_element(),
+            b0 in arb_field_element(),
+            b1 in arb_field_element()
+        ) {
+            let a = PackedGoldilocks2::from_array([a0, a1]);
+            let b = PackedGoldilocks2::from_array([b0, b1]);
+            let c = a + b;
+            let result = c.to_array();
+
+            let expected0 = Goldilocks64Field::add(&a0, &b0);
+            let expected1 = Goldilocks64Field::add(&a1, &b1);
+
+            prop_assert_eq!(result[0], expected0, "add lane 0 mismatch");
+            prop_assert_eq!(result[1], expected1, "add lane 1 mismatch");
+        }
+
+        #[test]
+        fn prop_sub_matches_scalar(
+            a0 in arb_field_element(),
+            a1 in arb_field_element(),
+            b0 in arb_field_element(),
+            b1 in arb_field_element()
+        ) {
+            let a = PackedGoldilocks2::from_array([a0, a1]);
+            let b = PackedGoldilocks2::from_array([b0, b1]);
+            let c = a - b;
+            let result = c.to_array();
+
+            let expected0 = Goldilocks64Field::sub(&a0, &b0);
+            let expected1 = Goldilocks64Field::sub(&a1, &b1);
+
+            prop_assert_eq!(result[0], expected0, "sub lane 0 mismatch");
+            prop_assert_eq!(result[1], expected1, "sub lane 1 mismatch");
+        }
+
+        #[test]
+        fn prop_neg_matches_scalar(
+            a0 in arb_field_element(),
+            a1 in arb_field_element()
+        ) {
+            let a = PackedGoldilocks2::from_array([a0, a1]);
+            let neg_a = -a;
+            let result = neg_a.to_array();
+
+            let expected0 = Goldilocks64Field::neg(&a0);
+            let expected1 = Goldilocks64Field::neg(&a1);
+
+            prop_assert_eq!(result[0], expected0, "neg lane 0 mismatch");
+            prop_assert_eq!(result[1], expected1, "neg lane 1 mismatch");
+        }
+
+        #[test]
+        fn prop_mul_matches_scalar(
+            a0 in arb_field_element(),
+            a1 in arb_field_element(),
+            b0 in arb_field_element(),
+            b1 in arb_field_element()
+        ) {
+            let a = PackedGoldilocks2::from_array([a0, a1]);
+            let b = PackedGoldilocks2::from_array([b0, b1]);
+            let c = a * b;
+            let result = c.to_array();
+
+            let expected0 = Goldilocks64Field::mul(&a0, &b0);
+            let expected1 = Goldilocks64Field::mul(&a1, &b1);
+
+            prop_assert_eq!(result[0], expected0, "mul lane 0 mismatch: {} * {} = {} (expected {})", a0, b0, result[0], expected0);
+            prop_assert_eq!(result[1], expected1, "mul lane 1 mismatch: {} * {} = {} (expected {})", a1, b1, result[1], expected1);
+        }
+
+        #[test]
+        fn prop_double_equals_add_self(a in arb_packed()) {
+            let doubled = a.double();
+            let added = a + a;
+            prop_assert_eq!(doubled.to_array(), added.to_array());
+        }
+
+        #[test]
+        fn prop_square_equals_mul_self(a in arb_packed()) {
+            let squared = a.square();
+            let multiplied = a * a;
+            prop_assert_eq!(squared.to_array(), multiplied.to_array());
+        }
+
+        #[test]
+        fn prop_add_commutative(a in arb_packed(), b in arb_packed()) {
+            prop_assert_eq!((a + b).to_array(), (b + a).to_array());
+        }
+
+        #[test]
+        fn prop_mul_commutative(a in arb_packed(), b in arb_packed()) {
+            prop_assert_eq!((a * b).to_array(), (b * a).to_array());
+        }
+
+        #[test]
+        fn prop_add_associative(a in arb_packed(), b in arb_packed(), c in arb_packed()) {
+            prop_assert_eq!(((a + b) + c).to_array(), (a + (b + c)).to_array());
+        }
+
+        #[test]
+        fn prop_mul_associative(a in arb_packed(), b in arb_packed(), c in arb_packed()) {
+            prop_assert_eq!(((a * b) * c).to_array(), (a * (b * c)).to_array());
+        }
+
+        #[test]
+        fn prop_distributive(a in arb_packed(), b in arb_packed(), c in arb_packed()) {
+            prop_assert_eq!((a * (b + c)).to_array(), (a * b + a * c).to_array());
+        }
+
+        #[test]
+        fn prop_additive_identity(a in arb_packed()) {
+            let zero = PackedGoldilocks2::ZERO;
+            prop_assert_eq!((a + zero).to_array(), a.to_array());
+        }
+
+        #[test]
+        fn prop_multiplicative_identity(a in arb_packed()) {
+            let one = PackedGoldilocks2::ONE;
+            prop_assert_eq!((a * one).to_array(), a.to_array());
+        }
+
+        #[test]
+        fn prop_additive_inverse(a in arb_packed()) {
+            let neg_a = -a;
+            let result = a + neg_a;
+            prop_assert_eq!(result.to_array(), [0, 0]);
+        }
+    }
+}

--- a/crypto/math/src/field/simd/packed_goldilocks_scalar.rs
+++ b/crypto/math/src/field/simd/packed_goldilocks_scalar.rs
@@ -1,0 +1,193 @@
+//! Scalar fallback implementation of PackedGoldilocks2.
+//!
+//! This module provides a non-SIMD implementation that mimics the SIMD API
+//! for use on architectures without ARM NEON support.
+
+use core::fmt;
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use crate::field::element::FieldElement;
+use crate::field::fields::u64_goldilocks_field::Goldilocks64Field;
+use crate::field::traits::IsField;
+
+/// The Goldilocks prime: p = 2^64 - 2^32 + 1
+pub const P: u64 = 0xFFFF_FFFF_0000_0001;
+
+/// EPSILON = 2^32 - 1
+pub const EPSILON: u64 = 0xFFFF_FFFF;
+
+/// A "packed" vector of 2 Goldilocks field elements (scalar fallback).
+///
+/// This implementation processes elements sequentially rather than in parallel,
+/// but maintains API compatibility with the SIMD version.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct PackedGoldilocks2([u64; 2]);
+
+impl PackedGoldilocks2 {
+    /// Number of field elements packed in this type.
+    pub const WIDTH: usize = 2;
+
+    /// Zero element (additive identity).
+    pub const ZERO: Self = Self([0, 0]);
+
+    /// One element (multiplicative identity).
+    pub const ONE: Self = Self([1, 1]);
+
+    /// Creates a new packed element with all lanes set to the same value.
+    #[inline(always)]
+    pub fn broadcast(val: u64) -> Self {
+        debug_assert!(val < P, "value must be in canonical form");
+        Self([val, val])
+    }
+
+    /// Creates a new packed element from an array of field elements.
+    #[inline(always)]
+    pub fn from_array(vals: [u64; 2]) -> Self {
+        debug_assert!(vals[0] < P && vals[1] < P, "values must be in canonical form");
+        Self(vals)
+    }
+
+    /// Creates a new packed element from FieldElement array.
+    #[inline(always)]
+    pub fn from_field_elements(vals: [FieldElement<Goldilocks64Field>; 2]) -> Self {
+        Self::from_array([*vals[0].value(), *vals[1].value()])
+    }
+
+    /// Extracts the elements as an array.
+    #[inline(always)]
+    pub fn to_array(self) -> [u64; 2] {
+        self.0
+    }
+
+    /// Extracts the elements as FieldElements.
+    #[inline(always)]
+    pub fn to_field_elements(self) -> [FieldElement<Goldilocks64Field>; 2] {
+        [
+            FieldElement::<Goldilocks64Field>::from_raw(self.0[0]),
+            FieldElement::<Goldilocks64Field>::from_raw(self.0[1]),
+        ]
+    }
+
+    /// Gets the element at the specified index.
+    #[inline(always)]
+    pub fn get(&self, idx: usize) -> u64 {
+        debug_assert!(idx < 2);
+        self.0[idx]
+    }
+
+    /// Doubles the element.
+    #[inline(always)]
+    pub fn double(self) -> Self {
+        self + self
+    }
+
+    /// Squares the element.
+    #[inline(always)]
+    pub fn square(self) -> Self {
+        self * self
+    }
+}
+
+impl Add for PackedGoldilocks2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn add(self, rhs: Self) -> Self::Output {
+        Self([
+            Goldilocks64Field::add(&self.0[0], &rhs.0[0]),
+            Goldilocks64Field::add(&self.0[1], &rhs.0[1]),
+        ])
+    }
+}
+
+impl AddAssign for PackedGoldilocks2 {
+    #[inline(always)]
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl Sub for PackedGoldilocks2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self([
+            Goldilocks64Field::sub(&self.0[0], &rhs.0[0]),
+            Goldilocks64Field::sub(&self.0[1], &rhs.0[1]),
+        ])
+    }
+}
+
+impl SubAssign for PackedGoldilocks2 {
+    #[inline(always)]
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl Neg for PackedGoldilocks2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn neg(self) -> Self::Output {
+        Self([
+            Goldilocks64Field::neg(&self.0[0]),
+            Goldilocks64Field::neg(&self.0[1]),
+        ])
+    }
+}
+
+impl Mul for PackedGoldilocks2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self([
+            Goldilocks64Field::mul(&self.0[0], &rhs.0[0]),
+            Goldilocks64Field::mul(&self.0[1], &rhs.0[1]),
+        ])
+    }
+}
+
+impl MulAssign for PackedGoldilocks2 {
+    #[inline(always)]
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs;
+    }
+}
+
+impl Default for PackedGoldilocks2 {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl fmt::Debug for PackedGoldilocks2 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("PackedGoldilocks2")
+            .field(&self.0[0])
+            .field(&self.0[1])
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_ops() {
+        let a = PackedGoldilocks2::from_array([1, 2]);
+        let b = PackedGoldilocks2::from_array([3, 4]);
+
+        let sum = a + b;
+        assert_eq!(sum.to_array(), [4, 6]);
+
+        let diff = b - a;
+        assert_eq!(diff.to_array(), [2, 2]);
+
+        let prod = a * b;
+        assert_eq!(prod.to_array(), [3, 8]);
+    }
+}


### PR DESCRIPTION
Add ARM NEON optimized field operations for Goldilocks prime field and its quadratic (Fp2) and cubic (Fp3) extensions.

Key features:
- PackedGoldilocks2: 2-wide SIMD for base field operations
- PackedFp2x2: 2-wide SIMD for quadratic extension (x^2 - 7)
- PackedFp3x2: 2-wide SIMD for cubic extension (x^3 - 2)
- Karatsuba multiplication for extension fields
- Scalar fallback for non-aarch64 architectures
- Comprehensive benchmarks comparing scalar vs SIMD performance

Performance improvements (Apple M3):
- Base field add/sub: 1.4-1.5x faster
- Fp2 multiplication: 1.35x faster
- Fp3 multiplication: 1.21x faster
- Batch operations: up to 1.76x faster