### PR TITLE
Add tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,8 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2173,6 +2175,7 @@ dependencies = [
  "once_cell",
  "regex-automata",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2024"
 
 [dependencies]
 thiserror = "1.0.68"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/executor/src/main.rs
+++ b/executor/src/main.rs
@@ -2,14 +2,17 @@ use executor::{
     elf::Elf,
     vm::execution::{ExecutorError, run_program},
 };
+use tracing::{info, trace};
 
 fn main() -> Result<(), ExecutorError> {
-    println!("Reading elf");
+    tracing_subscriber::fmt::init();
+
+    info!("Reading elf");
     let elf_data = std::fs::read("./program_artifacts/asm/basic_program.elf").unwrap();
     let program = Elf::load(&elf_data).unwrap();
-    println!("Program entry: 0x{:08x}", program.entry_point);
+    info!("Program entry: {:#010x}", program.entry_point);
     program.image.iter().for_each(|(addr, word)| {
-        println!("0x{addr:08x}: 0x{word:08x}");
+        trace!("{:#010x}: {:#010x}", addr, word);
     });
     run_program(program.image, program.entry_point, vec![])?;
     Ok(())

--- a/executor/src/vm/execution.rs
+++ b/executor/src/vm/execution.rs
@@ -1,5 +1,7 @@
 use std::{collections::BTreeMap, fmt::Debug};
 
+use tracing::debug;
+
 use crate::vm::{
     instruction::{
         decoding::{Instruction, InstructionError},
@@ -49,10 +51,10 @@ fn run_from_entrypoint(
         let log = instruction.run(&mut pc, &mut registers, memory)?;
         logs.push(log);
     }
-    println!("Final Register Values:\n {}", &registers);
+    debug!("Final register values:\n{}", &registers);
     let memory_return_value = memory.read_return_value()?;
     let registers_return_values = registers.read_return_values();
-    println!("Registers Return Values: {registers_return_values:?}");
+    debug!("Register return values: {:?}", registers_return_values);
     Ok((
         ReturnValues {
             memory_values: memory_return_value,

--- a/executor/tests/asm.rs
+++ b/executor/tests/asm.rs
@@ -1,12 +1,21 @@
 use executor::{elf::Elf, vm::execution::run_program};
+use tracing::{debug, trace};
+use tracing_subscriber::EnvFilter;
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .try_init();
+}
 
 fn run_program_and_check_output(elf_path: &str, expected_output: i32) {
-    println!("Testing {}", elf_path);
+    init_tracing();
+    debug!("Testing {}", elf_path);
     let elf_data = std::fs::read(elf_path).unwrap();
     let program = Elf::load(&elf_data).unwrap();
-    println!("Program entry: 0x{:08x}", program.entry_point);
+    debug!("Program entry: {:#010x}", program.entry_point);
     program.image.iter().for_each(|(addr, word)| {
-        println!("0x{:08x}: 0x{:08x}", addr, word);
+        trace!("{:#010x}: {:#010x}", addr, word);
     });
     let (results, _logs) =
         run_program(program.image, program.entry_point, vec![]).expect("Failed to run program");

--- a/executor/tests/rust.rs
+++ b/executor/tests/rust.rs
@@ -2,17 +2,26 @@ use executor::{
     elf::Elf,
     vm::execution::{ReturnValues, run_program},
 };
+use tracing::{debug, trace};
+use tracing_subscriber::EnvFilter;
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .try_init();
+}
 
 fn run_program_without_expect(
     elf_path: &str,
     private_inputs: Vec<u8>,
 ) -> Result<(ReturnValues, Vec<executor::vm::logs::Log>), executor::vm::execution::ExecutorError> {
-    println!("Testing {}", elf_path);
+    init_tracing();
+    debug!("Testing {}", elf_path);
     let elf_data = std::fs::read(elf_path).unwrap();
     let program = Elf::load(&elf_data).unwrap();
-    println!("Program entry: 0x{:08x}", program.entry_point);
+    debug!("Program entry: {:#010x}", program.entry_point);
     program.image.iter().for_each(|(addr, word)| {
-        println!("0x{:08x}: 0x{:08x}", addr, word);
+        trace!("{:#010x}: {:#010x}", addr, word);
     });
 
     run_program(program.image, program.entry_point, private_inputs)


### PR DESCRIPTION
This PR adds tracing to the executor, replacing prints.
It only leaves the syscalls prints since we want prints from riscv programs to normally appear on stdout