### PR TITLE
Cache bitwise computation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ executor/shared_target/
 # Memory profiling
 **/dhat-heap.json
 
+# Precomputed cache files (if using LAMBDA_VM_CACHE_DIR in repo)
+*.precomputed.bin
+bitwise_precomputed.bin
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -118,7 +118,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1022,6 +1022,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,7 +1167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2013,7 +2034,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2151,11 +2172,14 @@ dependencies = [
  "criterion 0.5.1",
  "crypto",
  "dhat",
+ "dirs",
  "env_logger",
  "executor",
  "lazy_static",
+ "log",
  "math",
  "rayon",
+ "sha2",
  "stark",
 ]
 
@@ -2213,6 +2237,16 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+]
 
 [[package]]
 name = "libtest-mimic"
@@ -2417,7 +2451,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2502,6 +2536,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_str_bytes"
@@ -3197,6 +3237,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3391,7 +3442,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3890,7 +3941,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4443,7 +4494,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4513,12 +4564,78 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2169,6 +2169,7 @@ dependencies = [
 name = "lambda-vm-prover"
 version = "0.1.0"
 dependencies = [
+ "bincode 1.3.3",
  "criterion 0.5.1",
  "crypto",
  "dhat",
@@ -2179,6 +2180,7 @@ dependencies = [
  "log",
  "math",
  "rayon",
+ "serde",
  "sha2",
  "stark",
 ]

--- a/crypto/math/src/polynomial/mod.rs
+++ b/crypto/math/src/polynomial/mod.rs
@@ -9,6 +9,7 @@ pub mod sparse_multilinear_poly;
 /// Represents the polynomial c_0 + c_1 * X + c_2 * X^2 + ... + c_n * X^n
 /// as a vector of coefficients `[c_0, c_1, ... , c_n]`
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "lambdaworks-serde-binary", derive(serde::Serialize, serde::Deserialize))]
 pub struct Polynomial<FE> {
     pub coefficients: Vec<FE>,
 }

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -1,9 +1,12 @@
 use std::marker::PhantomData;
 
 use crypto::fiat_shamir::is_transcript::IsStarkTranscript;
-use math::field::{
-    element::FieldElement,
-    traits::{IsFFTField, IsField, IsSubFieldOf},
+use math::{
+    field::{
+        element::FieldElement,
+        traits::{IsFFTField, IsField, IsSubFieldOf},
+    },
+    polynomial::Polynomial,
 };
 
 use crate::{
@@ -475,8 +478,8 @@ impl BusValue {
 
 /// Struct representing an AIR with Lookup. Contains own implementation of boundary constraints and auxiliary trace building
 pub struct AirWithBuses<
-    F: IsFFTField + IsSubFieldOf<E> + Send + Sync,
-    E: IsField + Send + Sync,
+    F: IsFFTField + IsSubFieldOf<E> + Send + Sync + 'static,
+    E: IsField + Send + Sync + 'static,
     B: BoundaryConstraintBuilder<F, E, PI>,
     PI,
 > {
@@ -490,6 +493,10 @@ pub struct AirWithBuses<
     preprocessed_commitment: Option<crate::config::Commitment>,
     /// Number of precomputed columns (columns 0..n are precomputed, rest are multiplicities)
     num_precomputed_cols: Option<usize>,
+    /// Cached polynomial coefficients for precomputed columns (for OOD evaluation)
+    precomputed_polynomials: Option<&'static [Polynomial<FieldElement<F>>]>,
+    /// Cached bit-reversed LDE evaluations for precomputed columns (for Merkle tree rebuild)
+    precomputed_lde_columns: Option<&'static [Vec<FieldElement<F>>]>,
 }
 
 impl<
@@ -558,6 +565,8 @@ impl<
             boundary_constraint_builder: PhantomData,
             preprocessed_commitment: None,
             num_precomputed_cols: None,
+            precomputed_polynomials: None,
+            precomputed_lde_columns: None,
         }
     }
 
@@ -584,6 +593,35 @@ impl<
     ) -> Self {
         self.preprocessed_commitment = Some(commitment);
         self.num_precomputed_cols = Some(num_precomputed_cols);
+        self
+    }
+
+    /// Attaches cached precomputed data for optimization.
+    ///
+    /// When set, the prover uses cached polynomials and LDE columns instead of
+    /// recomputing them from the trace. This eliminates minutes of redundant
+    /// computation per proof.
+    ///
+    /// # Arguments
+    /// * `polynomials` - Cached polynomial coefficients (for OOD evaluation)
+    /// * `lde_columns` - Cached bit-reversed LDE evaluations (for Merkle tree rebuild)
+    ///
+    /// # Example
+    /// ```ignore
+    /// let air = AirWithBuses::new(num_cols, aux_data, opts, 1, constraints)
+    ///     .with_preprocessed(bitwise::preprocessed_commitment(), bitwise::NUM_PRECOMPUTED_COLS)
+    ///     .with_precomputed_cache(
+    ///         bitwise::precomputed_polynomials(),
+    ///         bitwise::precomputed_lde_columns(),
+    ///     );
+    /// ```
+    pub fn with_precomputed_cache(
+        mut self,
+        polynomials: &'static [Polynomial<FieldElement<F>>],
+        lde_columns: &'static [Vec<FieldElement<F>>],
+    ) -> Self {
+        self.precomputed_polynomials = Some(polynomials);
+        self.precomputed_lde_columns = Some(lde_columns);
         self
     }
 }
@@ -725,6 +763,14 @@ where
 
     fn precomputed_commitment(&self) -> crate::config::Commitment {
         self.preprocessed_commitment.unwrap_or([0u8; 32])
+    }
+
+    fn precomputed_polynomials(&self) -> Option<&'static [Polynomial<FieldElement<F>>]> {
+        self.precomputed_polynomials
+    }
+
+    fn precomputed_lde_columns(&self) -> Option<&'static [Vec<FieldElement<F>>]> {
+        self.precomputed_lde_columns
     }
 }
 

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -47,16 +47,16 @@ type MainCommitment<Field> = (Round1CommitmentData<Field>, Vec<Vec<FieldElement<
 
 /// A default STARK prover implementing `IsStarkProver`.
 pub struct Prover<
-    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsField,
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync + 'static,
+    FieldExtension: Send + Sync + IsField + 'static,
     PI,
 > {
     p: PhantomData<(Field, FieldExtension, PI)>,
 }
 
 impl<
-    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsField,
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync + 'static,
+    FieldExtension: Send + Sync + IsField + 'static,
     PI,
 > IsStarkProver<Field, FieldExtension, PI> for Prover<Field, FieldExtension, PI>
 {
@@ -202,8 +202,8 @@ where
 /// The default implementation is complete and is compatible with Stone prover
 /// https://github.com/starkware-libs/stone-prover
 pub trait IsStarkProver<
-    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsField,
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync + 'static,
+    FieldExtension: Send + Sync + IsField + 'static,
     PI,
 >
 {
@@ -493,6 +493,15 @@ pub trait IsStarkProver<
     /// - Multiplicity columns (num_precomputed_cols..): separate tree, root in proof
     ///
     /// Both commitments are added to the transcript for Fiat-Shamir binding.
+    ///
+    /// ## Optimization: Cached Precomputed Data
+    ///
+    /// When `cached_polynomials` and `cached_lde_columns` are provided, the prover
+    /// uses them instead of recomputing. This eliminates minutes of redundant computation
+    /// per proof for preprocessed tables like Bitwise.
+    ///
+    /// - `cached_polynomials`: Polynomial coefficients for precomputed columns (for OOD evaluation)
+    /// - `cached_lde_columns`: Bit-reversed LDE evaluations (for Merkle tree rebuild)
     #[allow(clippy::type_complexity)]
     fn round_1_commit_preprocessed_trace(
         trace: &TraceTable<Field, FieldExtension>,
@@ -500,24 +509,103 @@ pub trait IsStarkProver<
         transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
         precomputed_commitment: Commitment,
         num_precomputed_cols: usize,
+        cached_polynomials: Option<&'static [Polynomial<FieldElement<Field>>]>,
+        cached_lde_columns: Option<&'static [Vec<FieldElement<Field>>]>,
     ) -> Result<(Round1CommitmentData<Field>, Vec<Vec<FieldElement<Field>>>), ProvingError>
     where
         FieldElement<Field>: AsBytes,
         FieldElement<FieldExtension>: AsBytes,
     {
-        // Interpolate all columns (needed for constraint evaluation)
-        let Some((trace_polys, evaluations, _full_tree, _full_root)) =
-            Self::interpolate_and_commit_preprocessed(trace, domain)
-        else {
-            return Err(ProvingError::EmptyCommitment);
-        };
+        // Check if we have cached precomputed data
+        let (trace_polys, evaluations, precomputed_lde_permuted) =
+            if let (Some(cached_polys), Some(cached_lde)) = (cached_polynomials, cached_lde_columns)
+            {
+                // === OPTIMIZED PATH: Use cached polynomials and LDE ===
+                log::debug!(
+                    "Using cached precomputed data: {} polys, {} LDE columns",
+                    cached_polys.len(),
+                    cached_lde.len()
+                );
+                // What we SKIP (the expensive parts):
+                // - Precomputed polynomial interpolation (use cached)
+                // - Precomputed LDE evaluations (use cached)
+                // - Precomputed bit-reversal (cached is already bit-reversed)
+                //
+                // What we compute (varies per proof):
+                // - Multiplicity polynomial interpolation
+                // - Multiplicity LDE evaluations
 
-        // --- Build PRECOMPUTED tree (cols 0..num_precomputed) ---
-        let precomputed_evaluations: Vec<_> = evaluations[..num_precomputed_cols].to_vec();
-        let mut precomputed_lde_permuted = precomputed_evaluations.clone();
-        for col in precomputed_lde_permuted.iter_mut() {
-            in_place_bit_reverse_permute(col);
-        }
+                // Get multiplicity columns only (skip precomputed)
+                let all_columns = trace.columns_main();
+                let mult_columns = &all_columns[num_precomputed_cols..];
+
+                // Interpolate ONLY multiplicity columns using explicit turbofish
+                // to force Rust to use E=Field (not FieldExtension)
+                #[cfg(feature = "parallel")]
+                let mult_polys: Vec<Polynomial<FieldElement<Field>>> = mult_columns
+                    .par_iter()
+                    .map(|col| {
+                        <Polynomial<FieldElement<Field>>>::interpolate_fft::<Field>(col)
+                            .expect("FFT interpolation failed")
+                    })
+                    .collect();
+                #[cfg(not(feature = "parallel"))]
+                let mult_polys: Vec<Polynomial<FieldElement<Field>>> = mult_columns
+                    .iter()
+                    .map(|col| {
+                        <Polynomial<FieldElement<Field>>>::interpolate_fft::<Field>(col)
+                            .expect("FFT interpolation failed")
+                    })
+                    .collect();
+
+                // Compute LDE only for multiplicity polynomials
+                let mult_lde = Self::compute_lde_trace_evaluations::<Field>(&mult_polys, domain);
+
+                // Combine cached precomputed + fresh multiplicity polynomials
+                let mut all_polys: Vec<Polynomial<FieldElement<Field>>> =
+                    Vec::with_capacity(cached_polys.len() + mult_polys.len());
+                all_polys.extend(cached_polys.iter().cloned());
+                all_polys.extend(mult_polys);
+
+                // Combine cached precomputed LDE + fresh multiplicity LDE for evaluations
+                // Note: cached_lde is already bit-reversed, but evaluations need non-bit-reversed
+                let mut all_evaluations: Vec<Vec<FieldElement<Field>>> =
+                    Vec::with_capacity(cached_lde.len() + mult_lde.len());
+
+                // Un-bit-reverse cached LDE for evaluations (constraint evaluation needs original order)
+                for col in cached_lde.iter() {
+                    let mut unbitreversed = col.clone();
+                    in_place_bit_reverse_permute(&mut unbitreversed); // bit-reverse is self-inverse
+                    all_evaluations.push(unbitreversed);
+                }
+                all_evaluations.extend(mult_lde);
+
+                // Use cached bit-reversed LDE directly for precomputed tree
+                let precomputed_lde_permuted: Vec<Vec<FieldElement<Field>>> =
+                    cached_lde.iter().cloned().collect();
+
+                (all_polys, all_evaluations, precomputed_lde_permuted)
+            } else {
+                // === FALLBACK PATH: Recompute everything ===
+                log::debug!(
+                    "No cached precomputed data - recomputing all {} columns",
+                    trace.columns_main().len()
+                );
+                let Some((trace_polys, evaluations, _full_tree, _full_root)) =
+                    Self::interpolate_and_commit_preprocessed(trace, domain)
+                else {
+                    return Err(ProvingError::EmptyCommitment);
+                };
+
+                // Bit-reverse precomputed evaluations for Merkle tree
+                let precomputed_evaluations: Vec<_> = evaluations[..num_precomputed_cols].to_vec();
+                let mut precomputed_lde_permuted = precomputed_evaluations.clone();
+                for col in precomputed_lde_permuted.iter_mut() {
+                    in_place_bit_reverse_permute(col);
+                }
+
+                (trace_polys, evaluations, precomputed_lde_permuted)
+            };
         let precomputed_rows = columns2rows(precomputed_lde_permuted);
         let (precomputed_tree, precomputed_root) =
             Self::batch_commit_main(&precomputed_rows).ok_or(ProvingError::EmptyCommitment)?;
@@ -1219,12 +1307,15 @@ pub trait IsStarkProver<
 
             let (main, evaluations) = if air.is_preprocessed() {
                 // Preprocessed table: use hardcoded commitment for precomputed columns
+                // Pass cached data if available (eliminates recomputation)
                 Self::round_1_commit_preprocessed_trace(
                     *trace,
                     &domain,
                     transcript,
                     air.precomputed_commitment(),
                     air.num_precomputed_columns(),
+                    air.precomputed_polynomials(),
+                    air.precomputed_lde_columns(),
                 )?
             } else {
                 // Normal table: compute commitment as usual

--- a/crypto/stark/src/traits.rs
+++ b/crypto/stark/src/traits.rs
@@ -131,6 +131,28 @@ pub trait AIR: Send + Sync {
         [0u8; 32]
     }
 
+    /// Returns cached polynomial coefficients for precomputed columns.
+    ///
+    /// When available, the prover uses these instead of recomputing from trace.
+    /// The polynomials are needed for OOD (Out-of-Domain) evaluation.
+    ///
+    /// Returns `None` by default. Preprocessed AIRs should override this
+    /// to return a `'static` reference to cached data.
+    fn precomputed_polynomials(&self) -> Option<&'static [Polynomial<FieldElement<Self::Field>>]> {
+        None
+    }
+
+    /// Returns cached bit-reversed LDE evaluations for precomputed columns.
+    ///
+    /// When available, the prover uses these to rebuild the Merkle tree
+    /// instead of recomputing LDE from polynomials.
+    ///
+    /// Returns `None` by default. Preprocessed AIRs should override this
+    /// to return a `'static` reference to cached data.
+    fn precomputed_lde_columns(&self) -> Option<&'static [Vec<FieldElement<Self::Field>>]> {
+        None
+    }
+
     fn num_auxiliary_rap_columns(&self) -> usize {
         self.trace_layout().1
     }

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -11,10 +11,12 @@ dhat-heap = ["dhat"]
 [dependencies]
 stark = { path = "../crypto/stark" }
 crypto = { path = "../crypto/crypto" }
-math = { path = "../crypto/math" }
+math = { path = "../crypto/math", features = ["lambdaworks-serde-binary"] }
 executor = { path = "../executor" }
 lazy_static = "1.5.0"
 sha2 = { version = "0.10", default-features = false }
+bincode = "1.3"
+serde = { version = "1.0", features = ["derive"] }
 dirs = "5.0"
 log = "0.4"
 dhat = { version = "0.3", optional = true }

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -14,6 +14,9 @@ crypto = { path = "../crypto/crypto" }
 math = { path = "../crypto/math" }
 executor = { path = "../executor" }
 lazy_static = "1.5.0"
+sha2 = { version = "0.10", default-features = false }
+dirs = "5.0"
+log = "0.4"
 dhat = { version = "0.3", optional = true }
 rayon = { version = "1.8.0", optional = true }
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -130,10 +130,15 @@ impl VmAirs {
         let bitwise = if minimal_bitwise {
             create_bitwise_air(proof_options)
         } else {
-            create_bitwise_air(proof_options).with_preprocessed(
-                bitwise::preprocessed_commitment(),
-                bitwise::NUM_PRECOMPUTED_COLS,
-            )
+            create_bitwise_air(proof_options)
+                .with_preprocessed(
+                    bitwise::preprocessed_commitment(),
+                    bitwise::NUM_PRECOMPUTED_COLS,
+                )
+                .with_precomputed_cache(
+                    bitwise::precomputed_polynomials(),
+                    bitwise::precomputed_lde_columns(),
+                )
         };
         let lt = create_lt_air(proof_options);
         let memw = create_memw_air(proof_options);

--- a/prover/src/tables/bitwise.rs
+++ b/prover/src/tables/bitwise.rs
@@ -35,6 +35,11 @@ use stark::lookup::{BusInteraction, BusValue, Multiplicity, Packing};
 use stark::prover::evaluate_polynomial_on_lde_domain;
 use stark::trace::{TraceTable, columns2rows};
 
+use sha2::{Digest, Sha256};
+use std::fs::{self, File};
+use std::io::{BufReader, BufWriter, Read as IoRead, Write as IoWrite};
+use std::path::PathBuf;
+
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -169,23 +174,75 @@ pub const fn is_preprocessed() -> bool {
 }
 
 // =========================================================================
-// Preprocessed commitment (computed once, cached)
+// Preprocessed data (computed once, cached in memory)
 // =========================================================================
 
+/// Cached precomputed data for the Bitwise table.
+///
+/// Contains polynomial coefficients and LDE evaluations that are constant
+/// regardless of the program being proven. Caching these eliminates minutes
+/// of redundant computation per proof.
+///
+/// ## Memory Usage
+/// - `polynomials`: ~88 MB (11 polynomials × 2^20 coefficients × 8 bytes)
+/// - `lde_columns`: ~352 MB (11 columns × 2^22 evaluations × 8 bytes)
+/// - Total: ~440 MB in memory
+///
+/// ## What's NOT Cached
+/// - Merkle tree (~700 MB): Rebuilt from `lde_columns` during proving.
+///   This can be revisited based on benchmarks.
+pub struct PrecomputedBitwiseData {
+    /// Configuration hash for cache validation.
+    /// Hash of (LDE_BLOWUP_FACTOR, LDE_COSET_OFFSET, NUM_ROWS, code version).
+    pub config_hash: [u8; 32],
+
+    /// Merkle root commitment (32 bytes) - for verification.
+    pub commitment: Commitment,
+
+    /// Polynomial coefficients (88 MB).
+    /// Shape: 11 polynomials, needed for OOD evaluation.
+    pub polynomials: Vec<Polynomial<FE>>,
+
+    /// Bit-reversed LDE evaluations of precomputed columns (352 MB).
+    /// Shape: 11 columns × 2^22 evaluations.
+    /// Already bit-reversed for direct use in Merkle tree construction.
+    pub lde_columns: Vec<Vec<FE>>,
+}
+
+impl PrecomputedBitwiseData {
+    /// Validates that the cached data matches the current configuration.
+    pub fn is_valid(&self) -> bool {
+        self.config_hash == compute_config_hash()
+    }
+}
+
+/// Computes a hash of the configuration parameters that affect precomputed data.
+/// If any of these change, cached data must be recomputed.
+fn compute_config_hash() -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(b"bitwise_precomputed_v1");
+    hasher.update(LDE_BLOWUP_FACTOR.to_le_bytes());
+    hasher.update(LDE_COSET_OFFSET.to_le_bytes());
+    hasher.update(NUM_ROWS.to_le_bytes());
+    hasher.update(NUM_PRECOMPUTED_COLS.to_le_bytes());
+    hasher.finalize().into()
+}
+
 lazy_static! {
-    /// Commitment to the LDE of the precomputed bitwise table columns.
+    /// Fully cached precomputed data for the Bitwise table.
     ///
-    /// This is a Merkle root over 2^22 rows (2^20 * blowup_factor=4) of the
-    /// LDE-evaluated 11 precomputed columns (X, Y, Z, AND, OR, XOR, MSB8,
-    /// MSB16, ZERO, SLL, SLLC).
+    /// Contains:
+    /// - Merkle root commitment (32 bytes)
+    /// - Polynomial coefficients (88 MB) - needed for OOD evaluation
+    /// - Bit-reversed LDE columns (352 MB) - needed for Merkle tree rebuild
     ///
-    /// The commitment is over LDE values (not raw values) because FRI queries
-    /// can target any index in the extended domain [0, N*blowup). The verifier
-    /// checks that proofs open against this exact commitment.
-    ///
-    /// Computed once on first access and cached. Both prover and verifier
-    /// use this same value in the Fiat-Shamir transcript.
-    pub static ref BITWISE_TABLE_COMMITMENT: Commitment = compute_preprocessed_commitment();
+    /// Tries to load from disk cache first, falls back to computing if not available.
+    /// Both prover and verifier can use this data, though verifiers typically only need the commitment.
+    pub static ref BITWISE_PRECOMPUTED: PrecomputedBitwiseData = load_or_compute_precomputed_data();
+
+    /// Backward-compatible commitment accessor.
+    /// Prefer using `BITWISE_PRECOMPUTED.commitment` directly.
+    pub static ref BITWISE_TABLE_COMMITMENT: Commitment = BITWISE_PRECOMPUTED.commitment;
 }
 
 /// Standard blowup factor for LDE domain (matches proof options).
@@ -194,17 +251,235 @@ const LDE_BLOWUP_FACTOR: usize = 4;
 /// Standard coset offset for LDE domain (matches proof options).
 const LDE_COSET_OFFSET: u64 = 3;
 
-/// Computes the Merkle commitment over the precomputed bitwise table columns.
+// =========================================================================
+// Disk caching
+// =========================================================================
+
+/// Magic bytes for cache file identification.
+const CACHE_MAGIC: &[u8; 4] = b"BTWC";
+
+/// Cache file version. Increment when format changes.
+const CACHE_VERSION: u32 = 1;
+
+/// Returns the path to the disk cache file.
 ///
-/// This builds a Merkle tree over the LDE (Low Degree Extension) of the precomputed
-/// columns, matching exactly how the prover commits to traces. The tree has
-/// NUM_ROWS * LDE_BLOWUP_FACTOR = 2^22 leaves, enabling FRI queries at any index
-/// in the extended domain.
+/// Cache location priority:
+/// 1. `LAMBDA_VM_CACHE_DIR` environment variable
+/// 2. `$HOME/.lambda_vm/cache/`
+fn cache_path() -> Option<PathBuf> {
+    let cache_dir = if let Ok(dir) = std::env::var("LAMBDA_VM_CACHE_DIR") {
+        PathBuf::from(dir)
+    } else if let Some(home) = dirs::home_dir() {
+        home.join(".lambda_vm").join("cache")
+    } else {
+        return None;
+    };
+
+    Some(cache_dir.join("bitwise_precomputed.bin"))
+}
+
+/// Loads precomputed data from disk cache, or computes it if not available.
+fn load_or_compute_precomputed_data() -> PrecomputedBitwiseData {
+    // Try to load from disk
+    if let Some(path) = cache_path() {
+        if path.exists() {
+            match load_from_disk(&path) {
+                Ok(data) => {
+                    // Validate config hash
+                    if data.config_hash == compute_config_hash() {
+                        log::info!(
+                            "Loaded bitwise precomputed data from cache: {}",
+                            path.display()
+                        );
+                        return data;
+                    } else {
+                        log::info!(
+                            "Bitwise cache config mismatch, recomputing (path: {})",
+                            path.display()
+                        );
+                    }
+                }
+                Err(e) => {
+                    log::debug!("Failed to load bitwise cache: {} (path: {})", e, path.display());
+                }
+            }
+        }
+    }
+
+    // Compute from scratch
+    log::info!("Computing bitwise precomputed data (this may take a few minutes on first run)...");
+    let start = std::time::Instant::now();
+    let data = compute_all_precomputed_data();
+    log::info!("Bitwise precomputed data computed in {:?}", start.elapsed());
+
+    // Save to disk for next time
+    if let Some(path) = cache_path() {
+        if let Err(e) = save_to_disk(&data, &path) {
+            log::warn!("Failed to save bitwise cache: {} (path: {})", e, path.display());
+        } else {
+            log::info!("Saved bitwise precomputed data to cache: {}", path.display());
+        }
+    }
+
+    data
+}
+
+/// Saves precomputed data to disk in binary format.
+fn save_to_disk(data: &PrecomputedBitwiseData, path: &PathBuf) -> std::io::Result<()> {
+    // Ensure parent directory exists
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let file = File::create(path)?;
+    let mut writer = BufWriter::new(file);
+
+    // Write header
+    writer.write_all(CACHE_MAGIC)?;
+    writer.write_all(&CACHE_VERSION.to_le_bytes())?;
+    writer.write_all(&data.config_hash)?;
+    writer.write_all(&data.commitment)?;
+
+    // Write polynomial count and sizes
+    let num_polys = data.polynomials.len() as u32;
+    writer.write_all(&num_polys.to_le_bytes())?;
+
+    // Write each polynomial's coefficients
+    for poly in &data.polynomials {
+        let coeffs = poly.coefficients();
+        let num_coeffs = coeffs.len() as u32;
+        writer.write_all(&num_coeffs.to_le_bytes())?;
+
+        for coeff in coeffs {
+            let value: u64 = *coeff.value();
+            writer.write_all(&value.to_le_bytes())?;
+        }
+    }
+
+    // Write LDE column count and sizes
+    let num_lde_cols = data.lde_columns.len() as u32;
+    writer.write_all(&num_lde_cols.to_le_bytes())?;
+
+    // Write each LDE column
+    for col in &data.lde_columns {
+        let col_len = col.len() as u32;
+        writer.write_all(&col_len.to_le_bytes())?;
+
+        for elem in col {
+            let value: u64 = *elem.value();
+            writer.write_all(&value.to_le_bytes())?;
+        }
+    }
+
+    writer.flush()?;
+    Ok(())
+}
+
+/// Loads precomputed data from disk.
+fn load_from_disk(path: &PathBuf) -> std::io::Result<PrecomputedBitwiseData> {
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+
+    // Read and validate magic
+    let mut magic = [0u8; 4];
+    reader.read_exact(&mut magic)?;
+    if &magic != CACHE_MAGIC {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "Invalid cache magic bytes",
+        ));
+    }
+
+    // Read and validate version
+    let mut version_bytes = [0u8; 4];
+    reader.read_exact(&mut version_bytes)?;
+    let version = u32::from_le_bytes(version_bytes);
+    if version != CACHE_VERSION {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("Cache version mismatch: expected {}, got {}", CACHE_VERSION, version),
+        ));
+    }
+
+    // Read config hash and commitment
+    let mut config_hash = [0u8; 32];
+    reader.read_exact(&mut config_hash)?;
+
+    let mut commitment = [0u8; 32];
+    reader.read_exact(&mut commitment)?;
+
+    // Read polynomials
+    let mut num_polys_bytes = [0u8; 4];
+    reader.read_exact(&mut num_polys_bytes)?;
+    let num_polys = u32::from_le_bytes(num_polys_bytes) as usize;
+
+    let mut polynomials = Vec::with_capacity(num_polys);
+    for _ in 0..num_polys {
+        let mut num_coeffs_bytes = [0u8; 4];
+        reader.read_exact(&mut num_coeffs_bytes)?;
+        let num_coeffs = u32::from_le_bytes(num_coeffs_bytes) as usize;
+
+        let mut coeffs = Vec::with_capacity(num_coeffs);
+        for _ in 0..num_coeffs {
+            let mut value_bytes = [0u8; 8];
+            reader.read_exact(&mut value_bytes)?;
+            let value = u64::from_le_bytes(value_bytes);
+            coeffs.push(FE::from(value));
+        }
+
+        polynomials.push(Polynomial::new(&coeffs));
+    }
+
+    // Read LDE columns
+    let mut num_lde_cols_bytes = [0u8; 4];
+    reader.read_exact(&mut num_lde_cols_bytes)?;
+    let num_lde_cols = u32::from_le_bytes(num_lde_cols_bytes) as usize;
+
+    let mut lde_columns = Vec::with_capacity(num_lde_cols);
+    for _ in 0..num_lde_cols {
+        let mut col_len_bytes = [0u8; 4];
+        reader.read_exact(&mut col_len_bytes)?;
+        let col_len = u32::from_le_bytes(col_len_bytes) as usize;
+
+        let mut col = Vec::with_capacity(col_len);
+        for _ in 0..col_len {
+            let mut value_bytes = [0u8; 8];
+            reader.read_exact(&mut value_bytes)?;
+            let value = u64::from_le_bytes(value_bytes);
+            col.push(FE::from(value));
+        }
+
+        lde_columns.push(col);
+    }
+
+    Ok(PrecomputedBitwiseData {
+        config_hash,
+        commitment,
+        polynomials,
+        lde_columns,
+    })
+}
+
+/// Computes all precomputed data for the bitwise table.
 ///
-/// Critical for security: the commitment must be over LDE values (not raw values)
-/// because FRI queries can target any index in [0, N*blowup). A raw-value commitment
-/// would only have N leaves, unable to verify queries at indices >= N.
-fn compute_preprocessed_commitment() -> Commitment {
+/// This builds:
+/// 1. Polynomial coefficients from column values (for OOD evaluation)
+/// 2. LDE evaluations (for Merkle tree construction)
+/// 3. Merkle commitment (for verification)
+///
+/// The Merkle tree itself is NOT cached - it's rebuilt from LDE columns
+/// during proving. This trades ~2 seconds of Merkle tree rebuild time
+/// for ~700MB of memory savings.
+///
+/// ## Why Cache Polynomials?
+/// Polynomials are needed for OOD (Out-of-Domain) evaluation in the prover.
+/// The random challenge `z` is sampled AFTER commitment, so we cannot
+/// precompute OOD evaluations - we need the polynomial coefficients.
+///
+/// ## Why Cache LDE Columns?
+/// LDE columns are needed to rebuild the Merkle tree for FRI opening proofs.
+/// Recomputing LDE from polynomials is expensive (FFT over 2^22 points).
+fn compute_all_precomputed_data() -> PrecomputedBitwiseData {
     // Step 1: Generate precomputed columns in parallel
     // Each column is generated independently by iterating over all row indices
     #[cfg(feature = "parallel")]
@@ -235,8 +510,9 @@ fn compute_preprocessed_commitment() -> Commitment {
     };
 
     // Step 2: Interpolate each column to a polynomial (parallel)
+    // CACHED: These polynomials are needed for OOD evaluation
     #[cfg(feature = "parallel")]
-    let polys: Vec<Polynomial<FE>> = columns
+    let polynomials: Vec<Polynomial<FE>> = columns
         .par_iter()
         .map(|col| {
             Polynomial::interpolate_fft::<GoldilocksField>(col)
@@ -245,7 +521,7 @@ fn compute_preprocessed_commitment() -> Commitment {
         .collect();
 
     #[cfg(not(feature = "parallel"))]
-    let polys: Vec<Polynomial<FE>> = columns
+    let polynomials: Vec<Polynomial<FE>> = columns
         .iter()
         .map(|col| {
             Polynomial::interpolate_fft::<GoldilocksField>(col)
@@ -254,10 +530,11 @@ fn compute_preprocessed_commitment() -> Commitment {
         .collect();
 
     // Step 3: Evaluate polynomials on LDE domain (parallel)
+    // CACHED: These evaluations are needed to rebuild the Merkle tree
     let coset_offset = FE::from(LDE_COSET_OFFSET);
 
     #[cfg(feature = "parallel")]
-    let mut lde_columns: Vec<Vec<FE>> = polys
+    let mut lde_columns: Vec<Vec<FE>> = polynomials
         .par_iter()
         .map(|poly| {
             evaluate_polynomial_on_lde_domain(poly, LDE_BLOWUP_FACTOR, NUM_ROWS, &coset_offset)
@@ -266,7 +543,7 @@ fn compute_preprocessed_commitment() -> Commitment {
         .collect();
 
     #[cfg(not(feature = "parallel"))]
-    let mut lde_columns: Vec<Vec<FE>> = polys
+    let mut lde_columns: Vec<Vec<FE>> = polynomials
         .iter()
         .map(|poly| {
             evaluate_polynomial_on_lde_domain(poly, LDE_BLOWUP_FACTOR, NUM_ROWS, &coset_offset)
@@ -275,6 +552,7 @@ fn compute_preprocessed_commitment() -> Commitment {
         .collect();
 
     // Step 4: Bit-reverse permute (parallel)
+    // CACHED: LDE columns are stored in bit-reversed order for direct Merkle tree use
     #[cfg(feature = "parallel")]
     lde_columns.par_iter_mut().for_each(|col| {
         in_place_bit_reverse_permute(col);
@@ -286,21 +564,46 @@ fn compute_preprocessed_commitment() -> Commitment {
     }
 
     // Step 5: Convert columns to rows for Merkle tree
-    let lde_rows = columns2rows(lde_columns);
+    // NOT CACHED: This is a view transformation, cheap to redo
+    let lde_rows = columns2rows(lde_columns.clone());
 
     // Step 6: Build Merkle tree over LDE (N * blowup leaves)
+    // NOT CACHED: Tree is rebuilt from lde_columns during proving (~2 seconds)
     let tree = BatchedMerkleTree::<GoldilocksField>::build(&lde_rows)
         .expect("Failed to build Merkle tree for bitwise LDE");
 
-    tree.root
+    PrecomputedBitwiseData {
+        config_hash: compute_config_hash(),
+        commitment: tree.root,
+        polynomials,
+        lde_columns,
+    }
 }
 
 /// Returns the preprocessed commitment for the bitwise table.
 ///
-/// This is a convenience function that dereferences the lazy_static.
+/// This is a convenience function that accesses the cached precomputed data.
 #[inline]
 pub fn preprocessed_commitment() -> Commitment {
-    *BITWISE_TABLE_COMMITMENT
+    BITWISE_PRECOMPUTED.commitment
+}
+
+/// Returns a reference to the cached polynomial coefficients.
+///
+/// These polynomials are needed for OOD (Out-of-Domain) evaluation.
+/// Returns a `'static` reference since the data lives in `lazy_static`.
+#[inline]
+pub fn precomputed_polynomials() -> &'static [Polynomial<FE>] {
+    &BITWISE_PRECOMPUTED.polynomials
+}
+
+/// Returns a reference to the cached bit-reversed LDE columns.
+///
+/// These are needed to rebuild the Merkle tree for FRI opening proofs.
+/// Returns a `'static` reference since the data lives in `lazy_static`.
+#[inline]
+pub fn precomputed_lde_columns() -> &'static [Vec<FE>] {
+    &BITWISE_PRECOMPUTED.lde_columns
 }
 
 // =========================================================================

--- a/prover/src/tables/bitwise.rs
+++ b/prover/src/tables/bitwise.rs
@@ -35,9 +35,10 @@ use stark::lookup::{BusInteraction, BusValue, Multiplicity, Packing};
 use stark::prover::evaluate_polynomial_on_lde_domain;
 use stark::trace::{TraceTable, columns2rows};
 
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fs::{self, File};
-use std::io::{BufReader, BufWriter, Read as IoRead, Write as IoWrite};
+use std::io::{BufReader, BufWriter, Write as IoWrite};
 use std::path::PathBuf;
 
 #[cfg(feature = "parallel")]
@@ -191,6 +192,7 @@ pub const fn is_preprocessed() -> bool {
 /// ## What's NOT Cached
 /// - Merkle tree (~700 MB): Rebuilt from `lde_columns` during proving.
 ///   This can be revisited based on benchmarks.
+#[derive(Serialize, Deserialize)]
 pub struct PrecomputedBitwiseData {
     /// Configuration hash for cache validation.
     /// Hash of (LDE_BLOWUP_FACTOR, LDE_COSET_OFFSET, NUM_ROWS, code version).
@@ -259,7 +261,8 @@ const LDE_COSET_OFFSET: u64 = 3;
 const CACHE_MAGIC: &[u8; 4] = b"BTWC";
 
 /// Cache file version. Increment when format changes.
-const CACHE_VERSION: u32 = 1;
+/// v2: Switched from manual binary serialization to bincode.
+const CACHE_VERSION: u32 = 2;
 
 /// Returns the path to the disk cache file.
 ///
@@ -324,7 +327,7 @@ fn load_or_compute_precomputed_data() -> PrecomputedBitwiseData {
     data
 }
 
-/// Saves precomputed data to disk in binary format.
+/// Saves precomputed data to disk using bincode.
 fn save_to_disk(data: &PrecomputedBitwiseData, path: &PathBuf) -> std::io::Result<()> {
     // Ensure parent directory exists
     if let Some(parent) = path.parent() {
@@ -334,49 +337,22 @@ fn save_to_disk(data: &PrecomputedBitwiseData, path: &PathBuf) -> std::io::Resul
     let file = File::create(path)?;
     let mut writer = BufWriter::new(file);
 
-    // Write header
+    // Write header for quick validation without full deserialization
     writer.write_all(CACHE_MAGIC)?;
     writer.write_all(&CACHE_VERSION.to_le_bytes())?;
-    writer.write_all(&data.config_hash)?;
-    writer.write_all(&data.commitment)?;
 
-    // Write polynomial count and sizes
-    let num_polys = data.polynomials.len() as u32;
-    writer.write_all(&num_polys.to_le_bytes())?;
-
-    // Write each polynomial's coefficients
-    for poly in &data.polynomials {
-        let coeffs = poly.coefficients();
-        let num_coeffs = coeffs.len() as u32;
-        writer.write_all(&num_coeffs.to_le_bytes())?;
-
-        for coeff in coeffs {
-            let value: u64 = *coeff.value();
-            writer.write_all(&value.to_le_bytes())?;
-        }
-    }
-
-    // Write LDE column count and sizes
-    let num_lde_cols = data.lde_columns.len() as u32;
-    writer.write_all(&num_lde_cols.to_le_bytes())?;
-
-    // Write each LDE column
-    for col in &data.lde_columns {
-        let col_len = col.len() as u32;
-        writer.write_all(&col_len.to_le_bytes())?;
-
-        for elem in col {
-            let value: u64 = *elem.value();
-            writer.write_all(&value.to_le_bytes())?;
-        }
-    }
+    // Serialize data with bincode
+    bincode::serialize_into(&mut writer, data)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
 
     writer.flush()?;
     Ok(())
 }
 
-/// Loads precomputed data from disk.
+/// Loads precomputed data from disk using bincode.
 fn load_from_disk(path: &PathBuf) -> std::io::Result<PrecomputedBitwiseData> {
+    use std::io::Read as IoRead;
+
     let file = File::open(path)?;
     let mut reader = BufReader::new(file);
 
@@ -401,63 +377,9 @@ fn load_from_disk(path: &PathBuf) -> std::io::Result<PrecomputedBitwiseData> {
         ));
     }
 
-    // Read config hash and commitment
-    let mut config_hash = [0u8; 32];
-    reader.read_exact(&mut config_hash)?;
-
-    let mut commitment = [0u8; 32];
-    reader.read_exact(&mut commitment)?;
-
-    // Read polynomials
-    let mut num_polys_bytes = [0u8; 4];
-    reader.read_exact(&mut num_polys_bytes)?;
-    let num_polys = u32::from_le_bytes(num_polys_bytes) as usize;
-
-    let mut polynomials = Vec::with_capacity(num_polys);
-    for _ in 0..num_polys {
-        let mut num_coeffs_bytes = [0u8; 4];
-        reader.read_exact(&mut num_coeffs_bytes)?;
-        let num_coeffs = u32::from_le_bytes(num_coeffs_bytes) as usize;
-
-        let mut coeffs = Vec::with_capacity(num_coeffs);
-        for _ in 0..num_coeffs {
-            let mut value_bytes = [0u8; 8];
-            reader.read_exact(&mut value_bytes)?;
-            let value = u64::from_le_bytes(value_bytes);
-            coeffs.push(FE::from(value));
-        }
-
-        polynomials.push(Polynomial::new(&coeffs));
-    }
-
-    // Read LDE columns
-    let mut num_lde_cols_bytes = [0u8; 4];
-    reader.read_exact(&mut num_lde_cols_bytes)?;
-    let num_lde_cols = u32::from_le_bytes(num_lde_cols_bytes) as usize;
-
-    let mut lde_columns = Vec::with_capacity(num_lde_cols);
-    for _ in 0..num_lde_cols {
-        let mut col_len_bytes = [0u8; 4];
-        reader.read_exact(&mut col_len_bytes)?;
-        let col_len = u32::from_le_bytes(col_len_bytes) as usize;
-
-        let mut col = Vec::with_capacity(col_len);
-        for _ in 0..col_len {
-            let mut value_bytes = [0u8; 8];
-            reader.read_exact(&mut value_bytes)?;
-            let value = u64::from_le_bytes(value_bytes);
-            col.push(FE::from(value));
-        }
-
-        lde_columns.push(col);
-    }
-
-    Ok(PrecomputedBitwiseData {
-        config_hash,
-        commitment,
-        polynomials,
-        lde_columns,
-    })
+    // Deserialize data with bincode
+    bincode::deserialize_from(reader)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
 }
 
 /// Computes all precomputed data for the bitwise table.

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -536,6 +536,54 @@ fn test_prove_elfs_all_instructions_64_full() {
     );
 }
 
+/// Timing test for bitwise precomputed cache optimization.
+///
+/// Runs prove twice:
+/// - First prove: Initializes lazy_static cache (pays full computation cost)
+/// - Second prove: Uses cached polynomials and LDE (should be faster)
+///
+/// The time difference shows the savings from caching precomputed data.
+///
+/// Run with:
+/// ```
+/// cargo test -p lambda-vm-prover --release test_bitwise_cache_timing -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore] // Slow: run with --release --ignored --nocapture
+fn test_bitwise_cache_timing() {
+    use std::time::Instant;
+
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let elf_bytes = crate::test_utils::asm_elf_bytes("all_instructions_64");
+
+    // First prove - initializes the lazy_static cache
+    println!("\n=== First prove (initializes cache) ===");
+    let start1 = Instant::now();
+    let result1 = crate::prove_and_verify(&elf_bytes).expect("first prove failed");
+    let elapsed1 = start1.elapsed();
+    assert!(result1, "first prove failed verification");
+    println!("First prove: {:?}", elapsed1);
+
+    // Second prove - uses cached data
+    println!("\n=== Second prove (uses cache) ===");
+    let start2 = Instant::now();
+    let result2 = crate::prove_and_verify(&elf_bytes).expect("second prove failed");
+    let elapsed2 = start2.elapsed();
+    assert!(result2, "second prove failed verification");
+    println!("Second prove: {:?}", elapsed2);
+
+    // Report savings
+    println!("\n=== Results ===");
+    println!("First prove:  {:?}", elapsed1);
+    println!("Second prove: {:?}", elapsed2);
+    if elapsed1 > elapsed2 {
+        let saved = elapsed1 - elapsed2;
+        println!("Time saved:   {:?} ({:.1}%)", saved,
+            (saved.as_secs_f64() / elapsed1.as_secs_f64()) * 100.0);
+    }
+}
+
 /// Memory profiling test using dhat.
 ///
 /// Run with:


### PR DESCRIPTION
Caches bitwise computations giving a 10% speedup by not recomputing the interpolation over the LDE and the trace of the table