### PR TITLE
Experimental/fri optimizations

### DIFF
--- a/crypto/stark/benches/profile_prover.rs
+++ b/crypto/stark/benches/profile_prover.rs
@@ -21,6 +21,8 @@ fn main() {
         fri_number_of_queries: 100,
         coset_offset: 3,
         grinding_factor: 0,
+        fri_last_layer_degree_bound: 0,
+        fri_folding_factor: 2,
     };
 
     let num_columns = 16;

--- a/crypto/stark/benches/prover_benchmark.rs
+++ b/crypto/stark/benches/prover_benchmark.rs
@@ -54,24 +54,52 @@ fn create_initial_values(num_columns: usize) -> Vec<(FE, FE)> {
         .collect()
 }
 
-/// Creates proof options suitable for benchmarking
-fn benchmark_proof_options() -> ProofOptions {
+/// FRI parameter set for benchmarking
+struct FriParams {
+    name: &'static str,
+    folding_factor: usize,
+    degree_bound: usize,
+}
+
+const FRI_PARAMS: &[FriParams] = &[
+    FriParams {
+        name: "default",
+        folding_factor: 2,
+        degree_bound: 0,
+    },
+    FriParams {
+        name: "ff4_deg7",
+        folding_factor: 4,
+        degree_bound: 7,
+    },
+    FriParams {
+        name: "ff8_deg7",
+        folding_factor: 8,
+        degree_bound: 7,
+    },
+];
+
+/// Creates proof options with the given FRI parameters
+fn benchmark_proof_options(fri: &FriParams) -> ProofOptions {
     ProofOptions {
         blowup_factor: 4,
         fri_number_of_queries: 30,
         coset_offset: 3,
         grinding_factor: 0,
+        fri_last_layer_degree_bound: fri.degree_bound,
+        fri_folding_factor: fri.folding_factor,
     }
 }
 
-/// Generates a proof for the given configuration
+/// Generates a proof for the given configuration and FRI parameters
 fn generate_proof(
     config: &BenchConfig,
+    fri: &FriParams,
 ) -> (
     StarkProof<F, E, FibonacciMultiColumnPublicInputs<F>>,
     FibonacciMultiColumnAIR<F, E>,
 ) {
-    let proof_options = benchmark_proof_options();
+    let proof_options = benchmark_proof_options(fri);
     let initial_values = create_initial_values(config.num_columns);
     let mut trace = compute_trace::<F, E>(&initial_values, config.trace_length);
     let pub_inputs = create_public_inputs(initial_values);
@@ -88,12 +116,13 @@ fn generate_proof(
     (proof, air)
 }
 
-/// Benchmark proving for a single configuration
-fn bench_prove(c: &mut Criterion, group_name: &str, config: &BenchConfig) {
-    let proof_options = benchmark_proof_options();
+/// Benchmark proving for a single configuration and FRI parameter set
+fn bench_prove(c: &mut Criterion, group_name: &str, config: &BenchConfig, fri: &FriParams) {
+    let proof_options = benchmark_proof_options(fri);
+    let id = format!("{}_{}", config.name, fri.name);
 
     c.bench_with_input(
-        BenchmarkId::new(format!("{}/prove", group_name), config.name),
+        BenchmarkId::new(format!("{}/prove", group_name), &id),
         config,
         |b, config| {
             b.iter_with_setup(
@@ -121,13 +150,13 @@ fn bench_prove(c: &mut Criterion, group_name: &str, config: &BenchConfig) {
     );
 }
 
-/// Benchmark verification for a single configuration
-fn bench_verify(c: &mut Criterion, group_name: &str, config: &BenchConfig) {
-    // Pre-generate the proof
-    let (proof, air) = generate_proof(config);
+/// Benchmark verification for a single configuration and FRI parameter set
+fn bench_verify(c: &mut Criterion, group_name: &str, config: &BenchConfig, fri: &FriParams) {
+    let (proof, air) = generate_proof(config, fri);
+    let id = format!("{}_{}", config.name, fri.name);
 
     c.bench_with_input(
-        BenchmarkId::new(format!("{}/verify", group_name), config.name),
+        BenchmarkId::new(format!("{}/verify", group_name), &id),
         &(proof, air),
         |b, (proof, air)| {
             b.iter(|| {
@@ -137,19 +166,23 @@ fn bench_verify(c: &mut Criterion, group_name: &str, config: &BenchConfig) {
     );
 }
 
-/// Quick benchmarks
+/// Quick benchmarks — all FRI parameter sets × quick configs
 fn quick_benchmarks(c: &mut Criterion) {
     for config in QUICK_CONFIGS {
-        bench_prove(c, "quick", config);
-        bench_verify(c, "quick", config);
+        for fri in FRI_PARAMS {
+            bench_prove(c, "quick", config, fri);
+            bench_verify(c, "quick", config, fri);
+        }
     }
 }
 
-/// Thorough benchmarks
+/// Thorough benchmarks — all FRI parameter sets × thorough configs
 fn thorough_benchmarks(c: &mut Criterion) {
     for config in THOROUGH_CONFIGS {
-        bench_prove(c, "thorough", config);
-        bench_verify(c, "thorough", config);
+        for fri in FRI_PARAMS {
+            bench_prove(c, "thorough", config, fri);
+            bench_verify(c, "thorough", config, fri);
+        }
     }
 }
 

--- a/crypto/stark/src/config.rs
+++ b/crypto/stark/src/config.rs
@@ -1,5 +1,5 @@
 use crypto::merkle_tree::{
-    backends::types::{BatchKeccak256Backend, Keccak256Backend, PairKeccak256Backend},
+    backends::types::{BatchKeccak256Backend, Keccak256Backend},
     merkle::MerkleTree,
 };
 
@@ -19,6 +19,6 @@ pub type Commitment = [u8; COMMITMENT_SIZE];
 pub type BatchedMerkleTreeBackend<F> = BatchKeccak256Backend<F>;
 pub type BatchedMerkleTree<F> = MerkleTree<BatchedMerkleTreeBackend<F>>;
 
-// FRI layer uses fixed-size pairs for efficiency (avoids Vec allocation per pair)
-pub type FriLayerMerkleTreeBackend<F> = PairKeccak256Backend<F>;
+// FRI layer uses Vec-based leaves to support configurable folding factors (>2 elements per leaf)
+pub type FriLayerMerkleTreeBackend<F> = BatchKeccak256Backend<F>;
 pub type FriLayerMerkleTree<F> = MerkleTree<FriLayerMerkleTreeBackend<F>>;

--- a/crypto/stark/src/fri/fri_decommit.rs
+++ b/crypto/stark/src/fri/fri_decommit.rs
@@ -8,5 +8,8 @@ use crate::config::Commitment;
 #[serde(bound = "")]
 pub struct FriDecommitment<F: IsField> {
     pub layers_auth_paths: Vec<Proof<Commitment>>,
-    pub layers_evaluations_sym: Vec<FieldElement<F>>,
+    /// For each committed FRI layer: the sibling evaluations within the leaf
+    /// that the verifier cannot compute. With folding_factor=2, each entry has 1 element.
+    /// With folding_factor=f, each entry has f-1 elements.
+    pub layers_evaluations_sym: Vec<Vec<FieldElement<F>>>,
 }

--- a/crypto/stark/src/fri/mod.rs
+++ b/crypto/stark/src/fri/mod.rs
@@ -182,6 +182,11 @@ where
 
     in_place_bit_reverse_permute(&mut evaluation);
 
+    debug_assert_eq!(
+        evaluation.len() % folding_factor,
+        0,
+        "domain_size must be divisible by folding_factor"
+    );
     let leaves: Vec<Vec<FieldElement<E>>> = evaluation
         .chunks_exact(folding_factor)
         .map(|chunk| chunk.to_vec())

--- a/crypto/stark/src/fri/mod.rs
+++ b/crypto/stark/src/fri/mod.rs
@@ -14,6 +14,11 @@ use self::fri_commitment::FriLayer;
 use self::fri_decommit::FriDecommitment;
 use self::fri_functions::fold_polynomial_doubled_inplace;
 
+type CommitResult<E> = (
+    Vec<FieldElement<E>>,
+    Vec<FriLayer<E, FriLayerMerkleTreeBackend<E>>>,
+);
+
 /// FRI commit phase with configurable folding factor and early stopping.
 ///
 /// - `number_layers`: total number of binary folds (= log2(trace_length))
@@ -29,10 +34,7 @@ pub fn commit_phase<F: IsFFTField + IsSubFieldOf<E>, E: IsField>(
     domain_size: usize,
     folding_factor: usize,
     last_layer_degree_bound: usize,
-) -> (
-    Vec<FieldElement<E>>,
-    Vec<FriLayer<E, FriLayerMerkleTreeBackend<E>>>,
-)
+) -> CommitResult<E>
 where
     FieldElement<F>: AsBytes + Sync + Send,
     FieldElement<E>: AsBytes + Sync + Send,

--- a/crypto/stark/src/fri/mod.rs
+++ b/crypto/stark/src/fri/mod.rs
@@ -14,59 +14,96 @@ use self::fri_commitment::FriLayer;
 use self::fri_decommit::FriDecommitment;
 use self::fri_functions::fold_polynomial_doubled_inplace;
 
+/// FRI commit phase with configurable folding factor and early stopping.
+///
+/// - `number_layers`: total number of binary folds (= log2(trace_length))
+/// - `folding_factor`: number of evaluations per Merkle leaf (power of 2, >= 2)
+/// - `last_layer_degree_bound`: stop folding when degree <= this bound (0 = fold to constant)
+///
+/// Returns the coefficients of the last polynomial and the committed FRI layers.
 pub fn commit_phase<F: IsFFTField + IsSubFieldOf<E>, E: IsField>(
     number_layers: usize,
     p_0: Polynomial<FieldElement<E>>,
     transcript: &mut impl IsStarkTranscript<E, F>,
     coset_offset: &FieldElement<F>,
     domain_size: usize,
+    folding_factor: usize,
+    last_layer_degree_bound: usize,
 ) -> (
-    FieldElement<E>,
+    Vec<FieldElement<E>>,
     Vec<FriLayer<E, FriLayerMerkleTreeBackend<E>>>,
 )
 where
     FieldElement<F>: AsBytes + Sync + Send,
     FieldElement<E>: AsBytes + Sync + Send,
 {
+    let log_f = folding_factor.trailing_zeros() as usize;
+
+    // How many binary folds are absorbed by the last polynomial (not committed)
+    let last_poly_log = if last_layer_degree_bound == 0 {
+        0
+    } else {
+        (last_layer_degree_bound + 1).trailing_zeros() as usize
+    };
+
+    // Handle edge case: very small traces (number_layers <= 1)
+    if number_layers == 0 {
+        let last_value = p_0.coefficients().to_vec();
+        for coeff in &last_value {
+            transcript.append_field_element(coeff);
+        }
+        return (last_value, Vec::new());
+    }
+
+    // Total folds to perform = number_layers - last_poly_log.
+    // Early stopping skips the last `last_poly_log` folds; the remaining polynomial
+    // (degree <= last_layer_degree_bound) is sent directly.
+    let folds_to_perform = number_layers.saturating_sub(last_poly_log);
+
+    // The -1 accounts for the initial fold (zetas[0]) before the first committed layer.
+    // Only folds that fit into complete committed layers are performed; any remainder
+    // is absorbed by the last polynomial (slightly higher degree than degree_bound).
+    let non_initial_folds = folds_to_perform.saturating_sub(1);
+    let num_committed_layers = non_initial_folds / log_f;
+
     let mut domain_size = domain_size;
-
-    let mut fri_layer_list = Vec::with_capacity(number_layers);
-    let mut current_layer: FriLayer<E, FriLayerMerkleTreeBackend<E>>;
+    let mut fri_layer_list = Vec::with_capacity(num_committed_layers);
     let mut current_poly = p_0;
-
     let mut coset_offset = coset_offset.clone();
 
-    for _ in 1..number_layers {
-        // <<<< Receive challenge 𝜁ₖ₋₁
-        let zeta = transcript.sample_field_element();
-        coset_offset = coset_offset.square();
-        domain_size /= 2;
+    // Initial fold with zetas[0] (no commitment for this one)
+    let zeta_0 = transcript.sample_field_element();
+    coset_offset = coset_offset.square();
+    domain_size /= 2;
+    fold_polynomial_doubled_inplace(&mut current_poly, &zeta_0);
 
-        // In-place folding avoids memory allocation
-        fold_polynomial_doubled_inplace(&mut current_poly, &zeta);
-        current_layer = new_fri_layer(&current_poly, &coset_offset, domain_size);
-        // Copy just the root (small, 32 bytes) before moving the layer
+    // Committed layers: each does log_f folds and one Merkle commitment
+    for _ in 0..num_committed_layers {
+        // Build Merkle tree for current state (after previous folds)
+        let current_layer =
+            new_fri_layer(&current_poly, &coset_offset, domain_size, folding_factor);
         let new_data = current_layer.merkle_tree.root;
         fri_layer_list.push(current_layer);
 
         // >>>> Send commitment: [pₖ]
         transcript.append_bytes(&new_data);
+
+        // Apply log_f binary folds (one challenge per fold)
+        for _ in 0..log_f {
+            let zeta = transcript.sample_field_element();
+            coset_offset = coset_offset.square();
+            domain_size /= 2;
+            fold_polynomial_doubled_inplace(&mut current_poly, &zeta);
+        }
     }
 
-    // <<<< Receive challenge: 𝜁ₙ₋₁
-    let zeta = transcript.sample_field_element();
+    // Extract last polynomial coefficients
+    let last_value = current_poly.coefficients().to_vec();
 
-    // Final fold - still in-place
-    fold_polynomial_doubled_inplace(&mut current_poly, &zeta);
-
-    let last_value = current_poly
-        .coefficients()
-        .first()
-        .unwrap_or(&FieldElement::zero())
-        .clone();
-
-    // >>>> Send value: pₙ
-    transcript.append_field_element(&last_value);
+    // >>>> Send last polynomial coefficients
+    for coeff in &last_value {
+        transcript.append_field_element(coeff);
+    }
 
     (last_value, fri_layer_list)
 }
@@ -74,10 +111,13 @@ where
 pub fn query_phase<F: IsField>(
     fri_layers: &Vec<FriLayer<F, FriLayerMerkleTreeBackend<F>>>,
     iotas: &[usize],
+    folding_factor: usize,
 ) -> Vec<FriDecommitment<F>>
 where
     FieldElement<F>: AsBytes + Sync + Send,
 {
+    let log_f = folding_factor.trailing_zeros() as usize;
+
     if !fri_layers.is_empty() {
         let num_layers = fri_layers.len();
         iotas
@@ -88,13 +128,23 @@ where
 
                 let mut index = *iota_s;
                 for layer in fri_layers {
-                    // symmetric element
-                    let evaluation_sym = layer.evaluation[index ^ 1].clone();
-                    let auth_path_sym = layer.merkle_tree.get_proof_by_pos(index >> 1).unwrap();
-                    layers_evaluations_sym.push(evaluation_sym);
-                    layers_auth_paths_sym.push(auth_path_sym);
+                    let leaf_index = index >> log_f;
+                    let known_pos = index % folding_factor;
 
-                    index >>= 1;
+                    // Collect all sibling evaluations except the one the verifier computes
+                    let mut sym_evals = Vec::with_capacity(folding_factor - 1);
+                    for pos in 0..folding_factor {
+                        if pos != known_pos {
+                            let eval_index = leaf_index * folding_factor + pos;
+                            sym_evals.push(layer.evaluation[eval_index].clone());
+                        }
+                    }
+
+                    let auth_path = layer.merkle_tree.get_proof_by_pos(leaf_index).unwrap();
+                    layers_evaluations_sym.push(sym_evals);
+                    layers_auth_paths_sym.push(auth_path);
+
+                    index = leaf_index;
                 }
 
                 FriDecommitment {
@@ -105,8 +155,6 @@ where
             .collect()
     } else {
         // For 0 FRI layers (small traces), return empty decommitments for each query.
-        // The verifier still needs one decommitment entry per query, even if the
-        // FRI layer data is empty.
         iotas
             .iter()
             .map(|_| FriDecommitment {
@@ -121,6 +169,7 @@ pub fn new_fri_layer<F: IsFFTField + IsSubFieldOf<E>, E: IsField>(
     poly: &Polynomial<FieldElement<E>>,
     coset_offset: &FieldElement<F>,
     domain_size: usize,
+    folding_factor: usize,
 ) -> FriLayer<E, FriLayerMerkleTreeBackend<E>>
 where
     FieldElement<F>: AsBytes + Sync + Send,
@@ -131,10 +180,9 @@ where
 
     in_place_bit_reverse_permute(&mut evaluation);
 
-    // Use fixed-size arrays instead of Vec for each pair (avoids allocation per pair)
-    let leaves: Vec<[FieldElement<E>; 2]> = evaluation
-        .chunks_exact(2)
-        .map(|chunk| [chunk[0].clone(), chunk[1].clone()])
+    let leaves: Vec<Vec<FieldElement<E>>> = evaluation
+        .chunks_exact(folding_factor)
+        .map(|chunk| chunk.to_vec())
         .collect();
 
     let merkle_tree = FriLayerMerkleTree::build(&leaves).unwrap();

--- a/crypto/stark/src/proof/options.rs
+++ b/crypto/stark/src/proof/options.rs
@@ -156,8 +156,8 @@ impl GoldilocksCubicProofOptions {
             fri_number_of_queries,
             coset_offset: 3,
             grinding_factor,
-            fri_last_layer_degree_bound: 0,
-            fri_folding_factor: 2,
+            fri_last_layer_degree_bound: 7,
+            fri_folding_factor: 4,
         };
         opts.validate()?;
         Ok(opts)

--- a/crypto/stark/src/proof/options.rs
+++ b/crypto/stark/src/proof/options.rs
@@ -13,6 +13,10 @@ pub enum ProofOptionsError {
         security_bits: u8,
         grinding_factor: u8,
     },
+    /// fri_folding_factor must be a power of 2 >= 2
+    InvalidFoldingFactor(usize),
+    /// fri_last_layer_degree_bound must be 0 or (bound+1) must be a power of 2
+    InvalidDegreeBound(usize),
 }
 
 impl fmt::Display for ProofOptionsError {
@@ -28,6 +32,18 @@ impl fmt::Display for ProofOptionsError {
                 f,
                 "security_bits ({security_bits}) must exceed grinding_factor ({grinding_factor})"
             ),
+            Self::InvalidFoldingFactor(f_val) => {
+                write!(
+                    f,
+                    "fri_folding_factor must be a power of 2 >= 2, got {f_val}"
+                )
+            }
+            Self::InvalidDegreeBound(b) => {
+                write!(
+                    f,
+                    "fri_last_layer_degree_bound must be 0 or (bound+1) must be a power of 2, got {b}"
+                )
+            }
         }
     }
 }
@@ -45,6 +61,12 @@ pub struct ProofOptions {
     pub fri_number_of_queries: usize,
     pub coset_offset: u64,
     pub grinding_factor: u8,
+    /// Stop FRI folding when polynomial degree reaches this bound.
+    /// 0 = fold to constant (current behavior). Must be 0 or `(bound+1)` must be a power of 2.
+    pub fri_last_layer_degree_bound: usize,
+    /// Number of binary folds per FRI committed layer. Must be a power of 2 >= 2.
+    /// 2 = one fold per layer (current behavior). 4 = two folds per layer, etc.
+    pub fri_folding_factor: usize,
 }
 
 impl ProofOptions {
@@ -56,7 +78,29 @@ impl ProofOptions {
             fri_number_of_queries: 3,
             coset_offset: 3,
             grinding_factor: 1,
+            fri_last_layer_degree_bound: 0,
+            fri_folding_factor: 2,
         }
+    }
+
+    /// Validates the FRI-related fields.
+    ///
+    /// - `fri_folding_factor` must be a power of 2 >= 2.
+    /// - `fri_last_layer_degree_bound` must be 0 or `(bound + 1)` must be a power of 2.
+    pub fn validate(&self) -> Result<(), ProofOptionsError> {
+        if !self.fri_folding_factor.is_power_of_two() || self.fri_folding_factor < 2 {
+            return Err(ProofOptionsError::InvalidFoldingFactor(
+                self.fri_folding_factor,
+            ));
+        }
+        if self.fri_last_layer_degree_bound != 0
+            && !(self.fri_last_layer_degree_bound + 1).is_power_of_two()
+        {
+            return Err(ProofOptionsError::InvalidDegreeBound(
+                self.fri_last_layer_degree_bound,
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -107,11 +151,15 @@ impl GoldilocksCubicProofOptions {
         let fri_number_of_queries =
             ((security_bits as f64 - grinding_factor as f64) / bits_per_query).ceil() as usize;
 
-        Ok(ProofOptions {
+        let opts = ProofOptions {
             blowup_factor,
             fri_number_of_queries,
             coset_offset: 3,
             grinding_factor,
-        })
+            fri_last_layer_degree_bound: 0,
+            fri_folding_factor: 2,
+        };
+        opts.validate()?;
+        Ok(opts)
     }
 }

--- a/crypto/stark/src/proof/stark.rs
+++ b/crypto/stark/src/proof/stark.rs
@@ -52,8 +52,8 @@ pub struct StarkProof<F: IsSubFieldOf<E>, E: IsField, PI> {
     pub composition_poly_parts_ood_evaluation: Vec<FieldElement<E>>,
     // [pₖ]
     pub fri_layers_merkle_roots: Vec<Commitment>,
-    // pₙ
-    pub fri_last_value: FieldElement<E>,
+    // pₙ — coefficients of the last FRI polynomial (degree <= fri_last_layer_degree_bound)
+    pub fri_last_value: Vec<FieldElement<E>>,
     // Open(pₖ(Dₖ), −𝜐ₛ^(2ᵏ))
     pub query_list: Vec<FriDecommitment<E>>,
     // Open(H₁(D_LDE, 𝜐ᵢ), Open(H₂(D_LDE, 𝜐ᵢ), Open(tⱼ(D_LDE), 𝜐ᵢ)

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -165,8 +165,8 @@ pub struct Round3<F: IsField> {
 
 /// A container for the results of the fourth round of the STARK Prove protocol.
 pub struct Round4<F: IsSubFieldOf<E>, E: IsField> {
-    /// The final value resulting from folding the Deep composition polynomial all the way down to a constant value.
-    fri_last_value: FieldElement<E>,
+    /// Coefficients of the last FRI polynomial after folding.
+    fri_last_value: Vec<FieldElement<E>>,
     /// The commitments to the fold polynomials of the inner layers of FRI.
     fri_layers_merkle_roots: Vec<Commitment>,
     /// The values and proofs of validity of the evaluations of the trace polynomials and the composition polynomials
@@ -797,12 +797,16 @@ pub trait IsStarkProver<
         let domain_size = domain.lde_roots_of_unity_coset.len();
 
         // FRI commit and query phases
+        let folding_factor = air.context().proof_options.fri_folding_factor;
+        let last_layer_degree_bound = air.context().proof_options.fri_last_layer_degree_bound;
         let (fri_last_value, fri_layers) = fri::commit_phase::<Field, FieldExtension>(
             domain.root_order as usize,
             deep_composition_poly,
             transcript,
             &coset_offset,
             domain_size,
+            folding_factor,
+            last_layer_degree_bound,
         );
 
         // grinding: generate nonce and append it to the transcript
@@ -818,7 +822,7 @@ pub trait IsStarkProver<
         let number_of_queries = air.options().fri_number_of_queries;
         let iotas = Self::sample_query_indexes(number_of_queries, domain, transcript);
 
-        let query_list = fri::query_phase(&fri_layers, &iotas);
+        let query_list = fri::query_phase(&fri_layers, &iotas, folding_factor);
 
         let fri_layers_merkle_roots: Vec<_> = fri_layers
             .iter()
@@ -1646,6 +1650,8 @@ mod tests {
             fri_number_of_queries: 1,
             coset_offset,
             grinding_factor,
+            fri_last_layer_degree_bound: 0,
+            fri_folding_factor: 2,
         };
 
         let domain = Domain::new(

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -1180,6 +1180,14 @@ pub trait IsStarkProver<
     {
         info!("Started proof generation...");
 
+        // Validate FRI options early to prevent panics from invalid parameters
+        for (air, _, _) in &air_trace_pairs {
+            air.context()
+                .proof_options
+                .validate()
+                .map_err(|e| ProvingError::WrongParameter(e.to_string()))?;
+        }
+
         let num_airs = air_trace_pairs.len();
 
         // Check if any AIR has an auxiliary trace

--- a/crypto/stark/src/tests/fri_options_tests.rs
+++ b/crypto/stark/src/tests/fri_options_tests.rs
@@ -4,39 +4,45 @@
 //! These tests verify that non-default FRI parameters produce valid proofs
 //! that pass verification.
 
-use math::field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField;
+use crypto::fiat_shamir::default_transcript::DefaultTranscript;
+use math::field::{
+    element::FieldElement,
+    fields::fft_friendly::{
+        extensions_goldilocks::Degree3GoldilocksExtensionField, u64_goldilocks::GoldilocksField,
+    },
+};
 
 use crate::{
-    Felt252,
     examples::simple_fibonacci::{self, FibonacciAIR, FibonacciPublicInputs},
     proof::options::ProofOptions,
     prover::{IsStarkProver, Prover},
     traits::AIR,
-    transcript::StoneProverTranscript,
     verifier::{IsStarkVerifier, Verifier},
 };
 
+type F = GoldilocksField;
+type Felt = FieldElement<GoldilocksField>;
+
 fn prove_and_verify_fib(trace_length: usize, proof_options: ProofOptions) {
-    let mut trace =
-        simple_fibonacci::fibonacci_trace([Felt252::from(1), Felt252::from(1)], trace_length);
+    let mut trace = simple_fibonacci::fibonacci_trace([Felt::from(1), Felt::from(1)], trace_length);
 
     let pub_inputs = FibonacciPublicInputs {
-        a0: Felt252::one(),
-        a1: Felt252::one(),
+        a0: Felt::one(),
+        a1: Felt::one(),
     };
 
-    let air = FibonacciAIR::<Stark252PrimeField>::new(&proof_options);
+    let air = FibonacciAIR::<F>::new(&proof_options);
 
     let proof = Prover::prove(
         &air,
         &mut trace,
         &pub_inputs,
-        &mut StoneProverTranscript::new(&[]),
+        &mut DefaultTranscript::<F>::new(&[]),
     )
     .unwrap();
 
     assert!(
-        Verifier::verify(&proof, &air, &mut StoneProverTranscript::new(&[])),
+        Verifier::verify(&proof, &air, &mut DefaultTranscript::<F>::new(&[])),
         "Verification failed with options: blowup={}, folding_factor={}, degree_bound={}, trace_len={}",
         proof_options.blowup_factor,
         proof_options.fri_folding_factor,
@@ -123,18 +129,8 @@ fn test_fri_default_options_256() {
 
 #[test_log::test]
 fn test_fri_extension_field_folding_4_degree_bound_3() {
-    use crypto::fiat_shamir::default_transcript::DefaultTranscript;
-    use math::field::{
-        element::FieldElement,
-        fields::fft_friendly::{
-            extensions_goldilocks::Degree3GoldilocksExtensionField,
-            u64_goldilocks::GoldilocksField as GoldilocksBaseField,
-        },
-    };
-
     use crate::examples::fibonacci_multi_column::{self, FibonacciMultiColumnAIR};
 
-    type GoldilocksField = GoldilocksBaseField;
     type GoldilocksExt = Degree3GoldilocksExtensionField;
     type GoldilocksFE = FieldElement<GoldilocksField>;
 

--- a/crypto/stark/src/tests/fri_options_tests.rs
+++ b/crypto/stark/src/tests/fri_options_tests.rs
@@ -1,0 +1,187 @@
+//! Tests for FRI optimizations: early stopping (last_layer_degree_bound)
+//! and higher folding factor (fri_folding_factor).
+//!
+//! These tests verify that non-default FRI parameters produce valid proofs
+//! that pass verification.
+
+use math::field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField;
+
+use crate::{
+    Felt252,
+    examples::simple_fibonacci::{self, FibonacciAIR, FibonacciPublicInputs},
+    proof::options::ProofOptions,
+    prover::{IsStarkProver, Prover},
+    traits::AIR,
+    transcript::StoneProverTranscript,
+    verifier::{IsStarkVerifier, Verifier},
+};
+
+fn prove_and_verify_fib(trace_length: usize, proof_options: ProofOptions) {
+    let mut trace =
+        simple_fibonacci::fibonacci_trace([Felt252::from(1), Felt252::from(1)], trace_length);
+
+    let pub_inputs = FibonacciPublicInputs {
+        a0: Felt252::one(),
+        a1: Felt252::one(),
+    };
+
+    let air = FibonacciAIR::<Stark252PrimeField>::new(&proof_options);
+
+    let proof = Prover::prove(
+        &air,
+        &mut trace,
+        &pub_inputs,
+        &mut StoneProverTranscript::new(&[]),
+    )
+    .unwrap();
+
+    assert!(
+        Verifier::verify(&proof, &air, &mut StoneProverTranscript::new(&[])),
+        "Verification failed with options: blowup={}, folding_factor={}, degree_bound={}, trace_len={}",
+        proof_options.blowup_factor,
+        proof_options.fri_folding_factor,
+        proof_options.fri_last_layer_degree_bound,
+        trace_length,
+    );
+}
+
+fn options_with_fri(folding_factor: usize, degree_bound: usize) -> ProofOptions {
+    ProofOptions {
+        blowup_factor: 4,
+        fri_number_of_queries: 3,
+        coset_offset: 3,
+        grinding_factor: 0,
+        fri_last_layer_degree_bound: degree_bound,
+        fri_folding_factor: folding_factor,
+    }
+}
+
+// --- Optimization 1: Early stopping (last_layer_degree_bound) ---
+
+#[test_log::test]
+fn test_fri_early_stop_degree_bound_1() {
+    prove_and_verify_fib(64, options_with_fri(2, 1));
+}
+
+#[test_log::test]
+fn test_fri_early_stop_degree_bound_3() {
+    prove_and_verify_fib(64, options_with_fri(2, 3));
+}
+
+#[test_log::test]
+fn test_fri_early_stop_degree_bound_7() {
+    prove_and_verify_fib(64, options_with_fri(2, 7));
+}
+
+#[test_log::test]
+fn test_fri_early_stop_degree_bound_15() {
+    prove_and_verify_fib(256, options_with_fri(2, 15));
+}
+
+// --- Optimization 2: Higher folding factor ---
+
+#[test_log::test]
+fn test_fri_folding_factor_4() {
+    prove_and_verify_fib(64, options_with_fri(4, 0));
+}
+
+#[test_log::test]
+fn test_fri_folding_factor_8() {
+    prove_and_verify_fib(256, options_with_fri(8, 0));
+}
+
+// --- Both optimizations combined ---
+
+#[test_log::test]
+fn test_fri_folding_4_degree_bound_3() {
+    prove_and_verify_fib(64, options_with_fri(4, 3));
+}
+
+#[test_log::test]
+fn test_fri_folding_4_degree_bound_7() {
+    prove_and_verify_fib(256, options_with_fri(4, 7));
+}
+
+#[test_log::test]
+fn test_fri_folding_8_degree_bound_7() {
+    prove_and_verify_fib(256, options_with_fri(8, 7));
+}
+
+// --- Default parameters (backward compatibility sanity check) ---
+
+#[test_log::test]
+fn test_fri_default_options_64() {
+    prove_and_verify_fib(64, options_with_fri(2, 0));
+}
+
+#[test_log::test]
+fn test_fri_default_options_256() {
+    prove_and_verify_fib(256, options_with_fri(2, 0));
+}
+
+// --- Extension field test: exercises ff>2 path where Field != FieldExtension ---
+
+#[test_log::test]
+fn test_fri_extension_field_folding_4_degree_bound_3() {
+    use crypto::fiat_shamir::default_transcript::DefaultTranscript;
+    use math::field::{
+        element::FieldElement,
+        fields::fft_friendly::{
+            extensions_goldilocks::Degree3GoldilocksExtensionField,
+            u64_goldilocks::GoldilocksField as GoldilocksBaseField,
+        },
+    };
+
+    use crate::examples::fibonacci_multi_column::{self, FibonacciMultiColumnAIR};
+
+    type GoldilocksField = GoldilocksBaseField;
+    type GoldilocksExt = Degree3GoldilocksExtensionField;
+    type GoldilocksFE = FieldElement<GoldilocksField>;
+
+    let proof_options = ProofOptions {
+        blowup_factor: 4,
+        fri_number_of_queries: 3,
+        coset_offset: 3,
+        grinding_factor: 0,
+        fri_last_layer_degree_bound: 3,
+        fri_folding_factor: 4,
+    };
+    let num_columns = 2;
+    let trace_length = 16;
+
+    let initial_values: Vec<(GoldilocksFE, GoldilocksFE)> = (0..num_columns)
+        .map(|i| {
+            (
+                GoldilocksFE::from((i + 1) as u64),
+                GoldilocksFE::from((i + 2) as u64),
+            )
+        })
+        .collect();
+
+    let mut trace = fibonacci_multi_column::compute_trace::<GoldilocksField, GoldilocksExt>(
+        &initial_values,
+        trace_length,
+    );
+    let pub_inputs = fibonacci_multi_column::create_public_inputs(initial_values);
+    let air = FibonacciMultiColumnAIR::<GoldilocksField, GoldilocksExt>::with_num_columns(
+        &proof_options,
+        num_columns,
+    );
+
+    let proof = Prover::<GoldilocksField, GoldilocksExt, _>::prove(
+        &air,
+        &mut trace,
+        &pub_inputs,
+        &mut DefaultTranscript::<GoldilocksExt>::new(&[]),
+    )
+    .unwrap();
+
+    assert!(
+        Verifier::<GoldilocksField, GoldilocksExt, _>::verify(
+            &proof,
+            &air,
+            &mut DefaultTranscript::<GoldilocksExt>::new(&[])
+        ),
+        "Extension field verification failed with ff=4, degree_bound=3"
+    );
+}

--- a/crypto/stark/src/tests/mod.rs
+++ b/crypto/stark/src/tests/mod.rs
@@ -1,5 +1,6 @@
 pub mod air_tests;
 pub mod bus_tests;
+pub mod fri_options_tests;
 pub mod proof_options_tests;
 pub mod prove_verify_roundtrip_tests;
 pub mod small_trace_tests;

--- a/crypto/stark/src/tests/proof_options_tests.rs
+++ b/crypto/stark/src/tests/proof_options_tests.rs
@@ -123,3 +123,80 @@ fn test_options_unchanged() {
     assert_eq!(opts.fri_number_of_queries, 3);
     assert_eq!(opts.grinding_factor, 1);
 }
+
+// --- ProofOptions::validate() tests ---
+
+#[test]
+fn rejects_non_power_of_two_folding_factor() {
+    let mut opts = ProofOptions::default_test_options();
+    opts.fri_folding_factor = 3;
+    assert!(matches!(
+        opts.validate(),
+        Err(ProofOptionsError::InvalidFoldingFactor(3))
+    ));
+
+    opts.fri_folding_factor = 6;
+    assert!(matches!(
+        opts.validate(),
+        Err(ProofOptionsError::InvalidFoldingFactor(6))
+    ));
+}
+
+#[test]
+fn rejects_folding_factor_one() {
+    let mut opts = ProofOptions::default_test_options();
+    opts.fri_folding_factor = 1;
+    assert!(matches!(
+        opts.validate(),
+        Err(ProofOptionsError::InvalidFoldingFactor(1))
+    ));
+}
+
+#[test]
+fn rejects_invalid_degree_bound() {
+    let mut opts = ProofOptions::default_test_options();
+    // 2 is invalid: bound+1 = 3 which is not a power of 2
+    opts.fri_last_layer_degree_bound = 2;
+    assert!(matches!(
+        opts.validate(),
+        Err(ProofOptionsError::InvalidDegreeBound(2))
+    ));
+
+    // 4 is invalid: bound+1 = 5 which is not a power of 2
+    opts.fri_last_layer_degree_bound = 4;
+    assert!(matches!(
+        opts.validate(),
+        Err(ProofOptionsError::InvalidDegreeBound(4))
+    ));
+}
+
+#[test]
+fn accepts_valid_fri_options() {
+    let mut opts = ProofOptions::default_test_options();
+
+    // Default values (ff=2, bound=0) are valid
+    assert!(opts.validate().is_ok());
+
+    // ff=4, bound=0
+    opts.fri_folding_factor = 4;
+    assert!(opts.validate().is_ok());
+
+    // ff=8, bound=0
+    opts.fri_folding_factor = 8;
+    assert!(opts.validate().is_ok());
+
+    // ff=2, bound=1 (bound+1=2 is power of 2)
+    opts.fri_folding_factor = 2;
+    opts.fri_last_layer_degree_bound = 1;
+    assert!(opts.validate().is_ok());
+
+    // ff=4, bound=3 (bound+1=4 is power of 2)
+    opts.fri_folding_factor = 4;
+    opts.fri_last_layer_degree_bound = 3;
+    assert!(opts.validate().is_ok());
+
+    // ff=2, bound=7 (bound+1=8 is power of 2)
+    opts.fri_folding_factor = 2;
+    opts.fri_last_layer_degree_bound = 7;
+    assert!(opts.validate().is_ok());
+}

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -400,11 +400,31 @@ pub trait IsStarkVerifier<
         domain: &VerifierDomain<Field>,
         challenges: &Challenges<FieldExtension>,
         folding_factor: usize,
+        last_layer_degree_bound: usize,
     ) -> bool
     where
         FieldElement<Field>: AsBytes + Sync + Send,
         FieldElement<FieldExtension>: AsBytes + Sync + Send,
     {
+        // Reject proofs where the last polynomial has more coefficients than expected.
+        // The prover performs 1 + num_committed_layers * log_f total folds; any remainder
+        // folds are absorbed into the last polynomial, making it slightly larger than
+        // last_layer_degree_bound.
+        let log_f = folding_factor.trailing_zeros() as usize;
+        let number_layers = domain.root_order as usize;
+        let last_poly_log = if last_layer_degree_bound == 0 {
+            0
+        } else {
+            (last_layer_degree_bound + 1).trailing_zeros() as usize
+        };
+        let folds_to_perform = number_layers.saturating_sub(last_poly_log);
+        let non_initial_folds = folds_to_perform.saturating_sub(1);
+        let remainder = non_initial_folds % log_f;
+        let max_coeffs = 1usize << (last_poly_log + remainder);
+        if proof.fri_last_value.len() > max_coeffs {
+            return false;
+        }
+
         let (deep_poly_evaluations, deep_poly_evaluations_sym) =
             Self::reconstruct_deep_composition_poly_evaluations_for_all_queries(
                 challenges, domain, proof,
@@ -672,8 +692,10 @@ pub trait IsStarkVerifier<
             if proof.fri_last_value.len() == 1 {
                 return *p0_eval == proof.fri_last_value[0];
             }
-            let eval_point: FieldElement<FieldExtension> =
-                evaluation_point_inv.inv().unwrap().to_extension();
+            let eval_point: FieldElement<FieldExtension> = match evaluation_point_inv.inv() {
+                Ok(ep) => ep.to_extension(),
+                Err(_) => return false,
+            };
             let last_poly_eval = proof
                 .fri_last_value
                 .iter()
@@ -696,8 +718,10 @@ pub trait IsStarkVerifier<
             if proof.fri_last_value.len() == 1 {
                 return v == proof.fri_last_value[0];
             }
-            let eval_point: FieldElement<FieldExtension> =
-                eval_point_inv.inv().unwrap().to_extension();
+            let eval_point: FieldElement<FieldExtension> = match eval_point_inv.inv() {
+                Ok(ep) => ep.to_extension(),
+                Err(_) => return false,
+            };
             let last_poly_eval = proof
                 .fri_last_value
                 .iter()
@@ -706,10 +730,23 @@ pub trait IsStarkVerifier<
             return v == last_poly_eval;
         }
 
+        // Reject malformed proofs with mismatched layer counts
+        let num_roots = fri_layers_merkle_roots.len();
+        if fri_decommitment.layers_auth_paths.len() < num_roots
+            || fri_decommitment.layers_evaluations_sym.len() < num_roots
+        {
+            return false;
+        }
+
         // For each committed FRI layer
         for (layer_idx, merkle_root) in fri_layers_merkle_roots.iter().enumerate() {
             let auth_path = &fri_decommitment.layers_auth_paths[layer_idx];
             let sym_evals = &fri_decommitment.layers_evaluations_sym[layer_idx];
+
+            // Each layer should have exactly folding_factor - 1 sibling evaluations
+            if sym_evals.len() != folding_factor - 1 {
+                return false;
+            }
 
             // Verify Merkle opening for this layer
             let openings_ok = Self::verify_fri_layer_openings(
@@ -808,8 +845,10 @@ pub trait IsStarkVerifier<
         if proof.fri_last_value.len() == 1 {
             result &= v == proof.fri_last_value[0];
         } else {
-            let eval_point: FieldElement<FieldExtension> =
-                eval_point_inv.inv().unwrap().to_extension();
+            let eval_point: FieldElement<FieldExtension> = match eval_point_inv.inv() {
+                Ok(ep) => ep.to_extension(),
+                Err(_) => return false,
+            };
             let last_poly_eval = proof
                 .fri_last_value
                 .iter()
@@ -1354,7 +1393,14 @@ pub trait IsStarkVerifier<
         let timer3 = Instant::now();
 
         let folding_factor = air.context().proof_options.fri_folding_factor;
-        if !Self::step_3_verify_fri(proof, &domain, &challenges, folding_factor) {
+        let last_layer_degree_bound = air.context().proof_options.fri_last_layer_degree_bound;
+        if !Self::step_3_verify_fri(
+            proof,
+            &domain,
+            &challenges,
+            folding_factor,
+            last_layer_degree_bound,
+        ) {
             #[cfg(not(feature = "test_fiat_shamir"))]
             error!("FRI verification failed");
             return false;

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -29,6 +29,18 @@ use std::marker::PhantomData;
 #[cfg(feature = "instruments")]
 use std::time::Instant;
 
+/// Reverse the lowest `num_bits` bits of `val`.
+/// Used to map leaf positions to evaluation-point powers in bit-reversed NTT layout.
+fn bit_reverse(val: usize, num_bits: usize) -> usize {
+    let mut result = 0;
+    let mut v = val;
+    for _ in 0..num_bits {
+        result = (result << 1) | (v & 1);
+        v >>= 1;
+    }
+    result
+}
+
 /// A default STARK verifier implementing `IsStarkVerifier`.
 pub struct Verifier<
     Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
@@ -91,6 +103,50 @@ pub trait IsStarkVerifier<
         (0..number_of_queries)
             .map(|_| (transcript.sample_u64(domain_size >> 1)) as usize)
             .collect::<Vec<usize>>()
+    }
+
+    /// Replays the FRI commit phase on the transcript, returning the folding challenges (zetas).
+    ///
+    /// Shared between `step_1_replay_rounds_and_recover_challenges` and
+    /// `replay_rounds_after_round_1` to avoid duplicating the FRI transcript replay logic.
+    fn replay_fri_commit_phase(
+        proof: &StarkProof<Field, FieldExtension, PI>,
+        air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,
+        domain: &VerifierDomain<Field>,
+        transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
+    ) -> Vec<FieldElement<FieldExtension>>
+    where
+        FieldElement<Field>: AsBytes,
+        FieldElement<FieldExtension>: AsBytes,
+    {
+        let folding_factor = air.context().proof_options.fri_folding_factor;
+        let last_layer_degree_bound = air.context().proof_options.fri_last_layer_degree_bound;
+        let log_f = folding_factor.trailing_zeros() as usize;
+        let merkle_roots = &proof.fri_layers_merkle_roots;
+
+        let number_layers = domain.root_order as usize;
+        let last_poly_log = if last_layer_degree_bound == 0 {
+            0
+        } else {
+            (last_layer_degree_bound + 1).trailing_zeros() as usize
+        };
+        let folds_to_perform = number_layers.saturating_sub(last_poly_log);
+        let mut zetas = Vec::new();
+
+        if folds_to_perform > 0 {
+            // Initial fold challenge (zetas[0])
+            zetas.push(transcript.sample_field_element());
+
+            // For each committed FRI layer: append root, then sample log_f challenges
+            for root in merkle_roots {
+                transcript.append_bytes(root);
+                for _ in 0..log_f {
+                    zetas.push(transcript.sample_field_element());
+                }
+            }
+        }
+
+        zetas
     }
 
     /// Returns the list of challenges sent to the prover.
@@ -195,23 +251,12 @@ pub trait IsStarkVerifier<
         let gammas = deep_composition_coefficients;
 
         // FRI commit phase
-        let merkle_roots = &proof.fri_layers_merkle_roots;
-        let mut zetas = merkle_roots
-            .iter()
-            .map(|root| {
-                // >>>> Send challenge 𝜁ₖ
-                let element = transcript.sample_field_element();
-                // <<<< Receive commitment: [pₖ] (the first one is [p₀])
-                transcript.append_bytes(root);
-                element
-            })
-            .collect::<Vec<FieldElement<FieldExtension>>>();
+        let zetas = Self::replay_fri_commit_phase(proof, air, domain, transcript);
 
-        // >>>> Send challenge 𝜁ₙ₋₁
-        zetas.push(transcript.sample_field_element());
-
-        // <<<< Receive value: pₙ
-        transcript.append_field_element(&proof.fri_last_value);
+        // <<<< Receive last polynomial coefficients
+        for coeff in &proof.fri_last_value {
+            transcript.append_field_element(coeff);
+        }
 
         // Receive grinding value
         let security_bits = air.context().proof_options.grinding_factor;
@@ -224,7 +269,6 @@ pub trait IsStarkVerifier<
         }
 
         // FRI query phase
-        // <<<< Send challenges 𝜄ₛ (iota_s)
         let number_of_queries = air.options().fri_number_of_queries;
         let iotas = Self::sample_query_indexes(number_of_queries, domain, transcript);
 
@@ -355,6 +399,7 @@ pub trait IsStarkVerifier<
         proof: &StarkProof<Field, FieldExtension, PI>,
         domain: &VerifierDomain<Field>,
         challenges: &Challenges<FieldExtension>,
+        folding_factor: usize,
     ) -> bool
     where
         FieldElement<Field>: AsBytes + Sync + Send,
@@ -388,6 +433,7 @@ pub trait IsStarkVerifier<
                     eval,
                     &deep_poly_evaluations[i],
                     &deep_poly_evaluations_sym[i],
+                    folding_factor,
                 );
                 result
             })
@@ -560,38 +606,45 @@ pub trait IsStarkVerifier<
     }
 
     /// Verifies the openings of a fold polynomial of an inner layer of FRI.
+    /// `known_eval`: the evaluation the verifier computed (at position `iota % folding_factor` within the leaf).
+    /// `sym_evals`: the other `folding_factor - 1` evaluations from the decommitment.
     fn verify_fri_layer_openings(
         merkle_root: &Commitment,
-        auth_path_sym: &Proof<Commitment>,
-        evaluation: &FieldElement<FieldExtension>,
-        evaluation_sym: &FieldElement<FieldExtension>,
+        auth_path: &Proof<Commitment>,
+        known_eval: &FieldElement<FieldExtension>,
+        sym_evals: &[FieldElement<FieldExtension>],
         iota: usize,
+        folding_factor: usize,
     ) -> bool
     where
         FieldElement<Field>: AsBytes + Sync + Send,
         FieldElement<FieldExtension>: AsBytes + Sync + Send,
     {
-        let evaluations = if iota % 2 == 1 {
-            vec![evaluation_sym.clone(), evaluation.clone()]
-        } else {
-            vec![evaluation.clone(), evaluation_sym.clone()]
-        };
+        let log_f = folding_factor.trailing_zeros() as usize;
+        let leaf_index = iota >> log_f;
+        let known_pos = iota % folding_factor;
 
-        auth_path_sym.verify::<BatchedMerkleTreeBackend<FieldExtension>>(
-            merkle_root,
-            iota >> 1,
-            &evaluations,
-        )
+        // Reconstruct the full leaf in order
+        let mut leaf = Vec::with_capacity(folding_factor);
+        let mut sym_idx = 0;
+        for pos in 0..folding_factor {
+            if pos == known_pos {
+                leaf.push(known_eval.clone());
+            } else {
+                leaf.push(sym_evals[sym_idx].clone());
+                sym_idx += 1;
+            }
+        }
+
+        auth_path.verify::<BatchedMerkleTreeBackend<FieldExtension>>(merkle_root, leaf_index, &leaf)
     }
 
-    /// Verify a single FRI query
-    /// `zetas`: the vector of all challenges sent by the verifier to the prover at the commit
-    /// phase to fold polynomials.
-    /// `iota`: the index challenge of this FRI query. This index uniquely determines two elements 𝜐 and -𝜐
-    /// of the evaluation domain of FRI layer 0.
-    /// `evaluation_point_inv`: precomputed value of 𝜐⁻¹.
-    /// `deep_composition_evaluation`: precomputed value of p₀(𝜐), where p₀ is the deep composition polynomial.
-    /// `deep_composition_evaluation_sym`: precomputed value of p₀(-𝜐), where p₀ is the deep composition polynomial.
+    /// Verify a single FRI query with configurable folding factor and early stopping.
+    ///
+    /// The fold formula `(v + sym) + eval_pt_inv * zeta * (v - sym)` is used for each
+    /// binary fold. This works because `eval_pt_inv` tracks the inverse of `v`'s actual
+    /// evaluation point. When `v` is at the "negative" position (odd index), the double
+    /// negation (negative eval_pt_inv times negative difference) cancels out.
     fn verify_query_and_sym_openings(
         proof: &StarkProof<Field, FieldExtension, PI>,
         zetas: &[FieldElement<FieldExtension>],
@@ -600,77 +653,171 @@ pub trait IsStarkVerifier<
         evaluation_point_inv: FieldElement<Field>,
         deep_composition_evaluation: &FieldElement<FieldExtension>,
         deep_composition_evaluation_sym: &FieldElement<FieldExtension>,
+        folding_factor: usize,
     ) -> bool
     where
         FieldElement<Field>: AsBytes + Sync + Send,
         FieldElement<FieldExtension>: AsBytes + Sync + Send,
     {
+        let log_f = folding_factor.trailing_zeros() as usize;
         let fri_layers_merkle_roots = &proof.fri_layers_merkle_roots;
-        let evaluation_point_vec: Vec<FieldElement<Field>> =
-            core::iter::successors(Some(evaluation_point_inv.square()), |evaluation_point| {
-                Some(evaluation_point.square())
-            })
-            .take(fri_layers_merkle_roots.len())
-            .collect();
 
         let p0_eval = deep_composition_evaluation;
         let p0_eval_sym = deep_composition_evaluation_sym;
 
-        // Reconstruct p₁(𝜐²)
-        let mut v =
-            (p0_eval + p0_eval_sym) + evaluation_point_inv * &zetas[0] * (p0_eval - p0_eval_sym);
-        let mut index = iota;
-
-        // Handle case with 0 FRI layers (trace_length <= 2)
-        // In this case, the fold loop below doesn't iterate, so we need to verify
-        // the final value directly here.
-        if fri_layers_merkle_roots.is_empty() {
-            return v == proof.fri_last_value;
+        // Handle case with 0 folds (number_layers == 0, e.g. single-row trace)
+        if zetas.is_empty() {
+            // No folding at all — deep composition eval IS the last polynomial eval
+            if proof.fri_last_value.len() == 1 {
+                return *p0_eval == proof.fri_last_value[0];
+            }
+            let eval_point: FieldElement<FieldExtension> =
+                evaluation_point_inv.inv().unwrap().to_extension();
+            let last_poly_eval = proof
+                .fri_last_value
+                .iter()
+                .rev()
+                .fold(FieldElement::zero(), |acc, coeff| acc * &eval_point + coeff);
+            return *p0_eval == last_poly_eval;
         }
 
-        // For each FRI layer, starting from the layer 1: use the proof to verify the validity of values pᵢ(−𝜐^(2ⁱ)) (given by the prover) and
-        // pᵢ(𝜐^(2ⁱ)) (computed on the previous iteration by the verifier). Then use them to obtain pᵢ₊₁(𝜐^(2ⁱ⁺¹)).
-        // Finally, check that the final value coincides with the given by the prover.
-        fri_layers_merkle_roots
-            .iter()
-            .enumerate()
-            .zip(&fri_decommitment.layers_auth_paths)
-            .zip(&fri_decommitment.layers_evaluations_sym)
-            .zip(evaluation_point_vec)
-            .fold(
-                true,
-                |result,
-                 (
-                    (((i, merkle_root), auth_path_sym), evaluation_sym),
-                    evaluation_point_inv,
-                )| {
-                    // Verify opening Open(pᵢ(Dₖ), −𝜐^(2ⁱ)) and Open(pᵢ(Dₖ), 𝜐^(2ⁱ)).
-                    // `v` is pᵢ(𝜐^(2ⁱ)).
-                    // `evaluation_sym` is pᵢ(−𝜐^(2ⁱ)).
-                    let openings_ok = Self::verify_fri_layer_openings(
-                        merkle_root,
-                        auth_path_sym,
-                        &v,
-                        evaluation_sym,
-                        index,
-                    );
+        // Initial fold with zetas[0]
+        let mut v =
+            (p0_eval + p0_eval_sym) + &evaluation_point_inv * &zetas[0] * (p0_eval - p0_eval_sym);
+        let mut index = iota;
+        let mut eval_point_inv = evaluation_point_inv.square();
+        let mut zeta_idx = 1; // next zeta to use
 
-                    // Update `v` with next value pᵢ₊₁(𝜐^(2ⁱ⁺¹)).
-                    v = (&v + evaluation_sym) + evaluation_point_inv * &zetas[i + 1] * (&v - evaluation_sym);
+        let mut result = true;
 
-                    // Update index for next iteration. The index of the squares in the next layer
-                    // is obtained by halving the current index. This is due to the bit-reverse
-                    // ordering of the elements in the Merkle tree.
-                    index >>= 1;
+        // Handle case with 0 FRI layers but >=1 fold (small trace)
+        if fri_layers_merkle_roots.is_empty() {
+            if proof.fri_last_value.len() == 1 {
+                return v == proof.fri_last_value[0];
+            }
+            let eval_point: FieldElement<FieldExtension> =
+                eval_point_inv.inv().unwrap().to_extension();
+            let last_poly_eval = proof
+                .fri_last_value
+                .iter()
+                .rev()
+                .fold(FieldElement::zero(), |acc, coeff| acc * &eval_point + coeff);
+            return v == last_poly_eval;
+        }
 
-                    if i < fri_decommitment.layers_evaluations_sym.len() - 1 {
-                        result & openings_ok
+        // For each committed FRI layer
+        for (layer_idx, merkle_root) in fri_layers_merkle_roots.iter().enumerate() {
+            let auth_path = &fri_decommitment.layers_auth_paths[layer_idx];
+            let sym_evals = &fri_decommitment.layers_evaluations_sym[layer_idx];
+
+            // Verify Merkle opening for this layer
+            let openings_ok = Self::verify_fri_layer_openings(
+                merkle_root,
+                auth_path,
+                &v,
+                sym_evals,
+                index,
+                folding_factor,
+            );
+            result &= openings_ok;
+
+            // Apply log_f binary folds using the (v + sym) + eval_pt_inv * zeta * (v - sym) formula.
+            // For folding_factor=2: single fold with the one sibling.
+            // For folding_factor>2: apply log_f sequential folds, each time using the
+            // appropriate sibling from the reconstructed leaf.
+            if folding_factor == 2 {
+                // Simple case: one fold with the single sibling
+                let sym = &sym_evals[0];
+                v = (&v + sym) + &eval_point_inv * &zetas[zeta_idx] * (&v - sym);
+                zeta_idx += 1;
+            } else {
+                // General case (ff>2): reconstruct leaf and apply log_f binary folds.
+                //
+                // In the bit-reversed NTT layout, the ff evaluations in a leaf
+                // correspond to evaluation points:
+                //   eval_pt(p) = x_L * omega^{bit_rev(p, log_f)}
+                // where x_L is the base eval point for the leaf and omega is a
+                // primitive ff-th root of unity.
+                //
+                // Consecutive pairs (2j, 2j+1) always form (x, -x) fold pairs.
+                // Each pair has a different x, so we track eval_pt_inv per pair.
+                let known_pos = index % folding_factor;
+                let mut leaf = Vec::with_capacity(folding_factor);
+                let mut sym_idx = 0;
+                for pos in 0..folding_factor {
+                    if pos == known_pos {
+                        leaf.push(v.clone());
                     } else {
-                        // Check that final value is the given by the prover
-                        result & (v == proof.fri_last_value) & openings_ok
+                        leaf.push(sym_evals[sym_idx].clone());
+                        sym_idx += 1;
                     }
-                },
-            )
+                }
+
+                // Compute the ff-th primitive root of unity
+                let omega: FieldElement<Field> =
+                    Field::get_primitive_root_of_unity(log_f as u64).unwrap();
+
+                // Derive 1/x_L from eval_point_inv at known_pos:
+                // eval_pt_inv = 1/(x_L * omega^{bit_rev(known_pos, log_f)})
+                // => 1/x_L = eval_pt_inv * omega^{bit_rev(known_pos, log_f)}
+                let known_br = bit_reverse(known_pos, log_f);
+                let x_l_inv: FieldElement<Field> = &eval_point_inv * &omega.pow(known_br as u64);
+
+                // Compute eval_pt_inv for each position in the leaf:
+                // eval_pt_inv(p) = 1/(x_L * omega^{bit_rev(p, log_f)})
+                //                = x_l_inv * omega^{ff - bit_rev(p, log_f)}
+                let mut current_invs: Vec<FieldElement<Field>> = (0..folding_factor)
+                    .map(|p| {
+                        let br = bit_reverse(p, log_f);
+                        let neg_br = (folding_factor - br) % folding_factor;
+                        &x_l_inv * &omega.pow(neg_br as u64)
+                    })
+                    .collect();
+
+                // Apply log_f binary folds with consecutive pairing
+                let mut current_evals = leaf;
+                for _step in 0..log_f {
+                    let half = current_evals.len() / 2;
+                    let mut next_evals = Vec::with_capacity(half);
+                    let mut next_invs = Vec::with_capacity(half);
+                    for j in 0..half {
+                        let left = &current_evals[2 * j];
+                        let right = &current_evals[2 * j + 1];
+                        let pair_inv = &current_invs[2 * j];
+                        let folded = (left + right) + pair_inv * &zetas[zeta_idx] * (left - right);
+                        next_evals.push(folded);
+                        next_invs.push(current_invs[2 * j].square());
+                    }
+                    current_evals = next_evals;
+                    current_invs = next_invs;
+                    zeta_idx += 1;
+                }
+
+                v = current_evals[0].clone();
+            }
+
+            index >>= log_f;
+            for _ in 0..log_f {
+                eval_point_inv = eval_point_inv.square();
+            }
+        }
+
+        // Final check: evaluate the last polynomial at the current evaluation point
+        // and verify it matches v.
+        if proof.fri_last_value.len() == 1 {
+            result &= v == proof.fri_last_value[0];
+        } else {
+            let eval_point: FieldElement<FieldExtension> =
+                eval_point_inv.inv().unwrap().to_extension();
+            let last_poly_eval = proof
+                .fri_last_value
+                .iter()
+                .rev()
+                .fold(FieldElement::zero(), |acc, coeff| acc * &eval_point + coeff);
+            result &= v == last_poly_eval;
+        }
+
+        result
     }
 
     fn reconstruct_deep_composition_poly_evaluations_for_all_queries(
@@ -1106,23 +1253,12 @@ pub trait IsStarkVerifier<
         let gammas = deep_composition_coefficients;
 
         // FRI commit phase
-        let merkle_roots = &proof.fri_layers_merkle_roots;
-        let mut zetas = merkle_roots
-            .iter()
-            .map(|root| {
-                // >>>> Send challenge 𝜁ₖ
-                let element = transcript.sample_field_element();
-                // <<<< Receive commitment: [pₖ] (the first one is [p₀])
-                transcript.append_bytes(root);
-                element
-            })
-            .collect::<Vec<FieldElement<FieldExtension>>>();
+        let zetas = Self::replay_fri_commit_phase(proof, air, domain, transcript);
 
-        // >>>> Send challenge 𝜁ₙ₋₁
-        zetas.push(transcript.sample_field_element());
-
-        // <<<< Receive value: pₙ
-        transcript.append_field_element(&proof.fri_last_value);
+        // <<<< Receive last polynomial coefficients
+        for coeff in &proof.fri_last_value {
+            transcript.append_field_element(coeff);
+        }
 
         // Receive grinding value
         let security_bits = air.context().proof_options.grinding_factor;
@@ -1135,7 +1271,6 @@ pub trait IsStarkVerifier<
         }
 
         // FRI query phase
-        // <<<< Send challenges 𝜄ₛ (iota_s)
         let number_of_queries = air.options().fri_number_of_queries;
         let iotas = Self::sample_query_indexes(number_of_queries, domain, transcript);
 
@@ -1217,7 +1352,8 @@ pub trait IsStarkVerifier<
         #[cfg(feature = "instruments")]
         let timer3 = Instant::now();
 
-        if !Self::step_3_verify_fri(proof, &domain, &challenges) {
+        let folding_factor = air.context().proof_options.fri_folding_factor;
+        if !Self::step_3_verify_fri(proof, &domain, &challenges, folding_factor) {
             #[cfg(not(feature = "test_fiat_shamir"))]
             error!("FRI verification failed");
             return false;

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -645,6 +645,7 @@ pub trait IsStarkVerifier<
     /// binary fold. This works because `eval_pt_inv` tracks the inverse of `v`'s actual
     /// evaluation point. When `v` is at the "negative" position (odd index), the double
     /// negation (negative eval_pt_inv times negative difference) cancels out.
+    #[allow(clippy::too_many_arguments)]
     fn verify_query_and_sym_openings(
         proof: &StarkProof<Field, FieldExtension, PI>,
         zetas: &[FieldElement<FieldExtension>],


### PR DESCRIPTION
Benchmark-only PR to measure end-to-end proving impact of FRI optimizations

Optimizations made:
- Early stopping: stop folding when the polynomial degree drops below a configurable bound (`last_layer_degree_bound`), sending the remaining coefficients directly instead of committing more Merkle layers.
- Higher folding factor: fold multiple times per FRI round (configurable power-of-2 `folding_factor`), reducing the number of committed layers and Merkle tree operations.