### PR TITLE
Perf/split cpu bitwise

### DIFF
--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -40,9 +40,9 @@ use crate::tables::trace_builder::Traces;
 use crate::tables::types::BusId;
 use crate::test_utils::{
     E, F, VmAir, create_bitwise_air, create_branch_air, create_commit_air, create_cpu_air,
-    create_decode_air, create_dvrm_air, create_halt_air, create_load_air, create_lt_air,
-    create_memw_air, create_memw_aligned_air, create_memw_register_air, create_mul_air,
-    create_page_air, create_register_air, create_shift_air,
+    create_cpu_bitwise_air, create_decode_air, create_dvrm_air, create_halt_air, create_load_air,
+    create_lt_air, create_memw_air, create_memw_aligned_air, create_memw_register_air,
+    create_mul_air, create_page_air, create_register_air, create_shift_air,
 };
 
 use stark::proof::options::{GoldilocksCubicProofOptions, ProofOptions};
@@ -65,6 +65,7 @@ pub struct RuntimePageRange {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TableCounts {
     pub cpu: usize,
+    pub cpu_bitwise: usize,
     pub lt: usize,
     pub memw: usize,
     pub memw_aligned: usize,
@@ -84,6 +85,7 @@ impl TableCounts {
     /// Sum of all chunk counts across split tables.
     pub fn total(&self) -> usize {
         self.cpu
+            + self.cpu_bitwise
             + self.lt
             + self.memw
             + self.memw_aligned
@@ -184,6 +186,7 @@ type AirTracePair<'a> = (
 /// All VM AIR instances, grouped by table.
 pub(crate) struct VmAirs {
     pub cpus: Vec<VmAir>,
+    pub cpu_bitwises: Vec<VmAir>,
     pub bitwise: VmAir,
     pub lts: Vec<VmAir>,
     pub shifts: Vec<VmAir>,
@@ -213,6 +216,13 @@ impl VmAirs {
         ];
 
         for (air, trace) in self.cpus.iter().zip(traces.cpus.iter_mut()) {
+            pairs.push((air, trace, &()));
+        }
+        for (air, trace) in self
+            .cpu_bitwises
+            .iter()
+            .zip(traces.cpu_bitwises.iter_mut())
+        {
             pairs.push((air, trace, &()));
         }
         for (air, trace) in self.lts.iter().zip(traces.lts.iter_mut()) {
@@ -270,6 +280,9 @@ impl VmAirs {
         for air in &self.cpus {
             refs.push(air);
         }
+        for air in &self.cpu_bitwises {
+            refs.push(air);
+        }
         for air in &self.lts {
             refs.push(air);
         }
@@ -319,6 +332,11 @@ impl VmAirs {
     ) -> Self {
         let cpus: Vec<_> = (0..table_counts.cpu)
             .map(|i| create_cpu_air(proof_options).with_name(&format!("CPU[{}]", i)))
+            .collect();
+        let cpu_bitwises: Vec<_> = (0..table_counts.cpu_bitwise)
+            .map(|i| {
+                create_cpu_bitwise_air(proof_options).with_name(&format!("CPU_BITWISE[{}]", i))
+            })
             .collect();
         let bitwise = if minimal_bitwise {
             create_bitwise_air(proof_options)
@@ -381,6 +399,7 @@ impl VmAirs {
 
         Self {
             cpus,
+            cpu_bitwises,
             bitwise,
             lts,
             shifts,

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -104,6 +104,7 @@ impl TableCounts {
     pub fn validate(&self) -> Result<(), Error> {
         let checks = [
             ("cpu", self.cpu),
+            ("cpu_bitwise", self.cpu_bitwise),
             ("lt", self.lt),
             ("memw", self.memw),
             ("memw_aligned", self.memw_aligned),
@@ -218,11 +219,7 @@ impl VmAirs {
         for (air, trace) in self.cpus.iter().zip(traces.cpus.iter_mut()) {
             pairs.push((air, trace, &()));
         }
-        for (air, trace) in self
-            .cpu_bitwises
-            .iter()
-            .zip(traces.cpu_bitwises.iter_mut())
-        {
+        for (air, trace) in self.cpu_bitwises.iter().zip(traces.cpu_bitwises.iter_mut()) {
             pairs.push((air, trace, &()));
         }
         for (air, trace) in self.lts.iter().zip(traces.lts.iter_mut()) {

--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -306,6 +306,12 @@ impl CpuOperation {
         Self::default()
     }
 
+    /// Returns true if this operation is a bitwise instruction (AND, OR, XOR).
+    /// Used to route operations to the CPU_BITWISE chip.
+    pub fn is_bitwise(&self) -> bool {
+        self.decode.op_and || self.decode.op_or || self.decode.op_xor
+    }
+
     // =========================================================================
     // Convenience accessors for decode fields (reduces verbosity)
     // =========================================================================
@@ -2030,6 +2036,44 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
     ));
 
     interactions
+}
+
+/// Bus interactions for the CPU table WITHOUT AND/OR/XOR byte operations.
+///
+/// Used when bitwise instructions (AND, OR, XOR) are routed to a separate
+/// CPU_BITWISE chip. This reduces the CPU effective width by 72 (24 × 3).
+pub fn bus_interactions_without_bitwise_bytes() -> Vec<BusInteraction> {
+    let and_byte_id: u64 = BusId::AndByte.into();
+    let or_byte_id: u64 = BusId::OrByte.into();
+    let xor_byte_id: u64 = BusId::XorByte.into();
+
+    bus_interactions()
+        .into_iter()
+        .filter(|i| i.bus_id != and_byte_id && i.bus_id != or_byte_id && i.bus_id != xor_byte_id)
+        .collect()
+}
+
+/// Bus interactions for the CPU_BITWISE chip (AND, OR, XOR instructions).
+///
+/// Includes only interactions needed for bitwise operations:
+/// - DECODE (instruction validation)
+/// - IS_BYTE (range checks for rs1, rs2, rd, arg1, arg2, res)
+/// - AND_BYTE, OR_BYTE, XOR_BYTE (byte-level bitwise operations)
+/// - MEMW (register reads for rs1/rs2, register write for rd, PC update)
+pub fn bus_interactions_bitwise_chip() -> Vec<BusInteraction> {
+    let keep_ids: Vec<u64> = vec![
+        BusId::Decode.into(),
+        BusId::IsByte.into(),
+        BusId::AndByte.into(),
+        BusId::OrByte.into(),
+        BusId::XorByte.into(),
+        BusId::Memw.into(),
+    ];
+
+    bus_interactions()
+        .into_iter()
+        .filter(|i| keep_ids.contains(&i.bus_id))
+        .collect()
 }
 
 // =========================================================================

--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -2067,6 +2067,7 @@ pub fn bus_interactions_bitwise_chip() -> Vec<BusInteraction> {
         BusId::AndByte.into(),
         BusId::OrByte.into(),
         BusId::XorByte.into(),
+        BusId::Msb16.into(), // ANDW/ORW/XORW set word_instr=1, triggering MSB16 lookups
         BusId::Memw.into(),
     ];
 

--- a/prover/src/tables/cpu_bitwise.rs
+++ b/prover/src/tables/cpu_bitwise.rs
@@ -8,7 +8,7 @@
 //! constraints (conditional constraints are automatically satisfied since
 //! non-bitwise selectors are always 0).
 
-pub use super::cpu::{cols, generate_cpu_trace, CpuOperation};
+pub use super::cpu::{CpuOperation, cols, generate_cpu_trace};
 
 use stark::lookup::BusInteraction;
 

--- a/prover/src/tables/cpu_bitwise.rs
+++ b/prover/src/tables/cpu_bitwise.rs
@@ -1,8 +1,8 @@
 //! CPU_BITWISE chip — handles AND, OR, XOR instruction execution.
 //!
 //! Split from the main CPU table to reduce effective width. The CPU table
-//! drops 24 bus interactions (AND_BYTE×8, OR_BYTE×8, XOR_BYTE×8), going
-//! from 278 to 206 effective width.
+//! drops 72 effective-width columns (24 interactions × 3 extension-field values each:
+//! AND_BYTE×8, OR_BYTE×8, XOR_BYTE×8), going from 278 to 206 effective width.
 //!
 //! This chip uses the same 74-column layout as CPU and reuses the same
 //! constraints (conditional constraints are automatically satisfied since
@@ -14,8 +14,8 @@ use stark::lookup::BusInteraction;
 
 /// Bus interactions for the CPU_BITWISE chip.
 ///
-/// Includes: DECODE, IS_BYTE, AND_BYTE×8, OR_BYTE×8, XOR_BYTE×8, MEMW (register + PC).
-/// Excludes: MSB16, ZERO, LT, MUL, DVRM, SHIFT, LOAD, STORE, BRANCH, ECALL.
+/// Includes: DECODE, IS_BYTE, AND_BYTE×8, OR_BYTE×8, XOR_BYTE×8, MSB16×3, MEMW (register + PC).
+/// Excludes: ZERO, LT, MUL, DVRM, SHIFT, LOAD, STORE, BRANCH, ECALL.
 pub fn bus_interactions() -> Vec<BusInteraction> {
     super::cpu::bus_interactions_bitwise_chip()
 }

--- a/prover/src/tables/cpu_bitwise.rs
+++ b/prover/src/tables/cpu_bitwise.rs
@@ -1,0 +1,21 @@
+//! CPU_BITWISE chip — handles AND, OR, XOR instruction execution.
+//!
+//! Split from the main CPU table to reduce effective width. The CPU table
+//! drops 24 bus interactions (AND_BYTE×8, OR_BYTE×8, XOR_BYTE×8), going
+//! from 278 to 206 effective width.
+//!
+//! This chip uses the same 74-column layout as CPU and reuses the same
+//! constraints (conditional constraints are automatically satisfied since
+//! non-bitwise selectors are always 0).
+
+pub use super::cpu::{cols, generate_cpu_trace, CpuOperation};
+
+use stark::lookup::BusInteraction;
+
+/// Bus interactions for the CPU_BITWISE chip.
+///
+/// Includes: DECODE, IS_BYTE, AND_BYTE×8, OR_BYTE×8, XOR_BYTE×8, MEMW (register + PC).
+/// Excludes: MSB16, ZERO, LT, MUL, DVRM, SHIFT, LOAD, STORE, BRANCH, ECALL.
+pub fn bus_interactions() -> Vec<BusInteraction> {
+    super::cpu::bus_interactions_bitwise_chip()
+}

--- a/prover/src/tables/mod.rs
+++ b/prover/src/tables/mod.rs
@@ -25,6 +25,7 @@ pub mod bitwise;
 pub mod branch;
 pub mod commit;
 pub mod cpu;
+pub mod cpu_bitwise;
 pub mod decode;
 pub mod dvrm;
 pub mod halt;

--- a/prover/src/tables/mod.rs
+++ b/prover/src/tables/mod.rs
@@ -6,7 +6,8 @@
 //!
 //! - **BITWISE**: Precomputed lookup table for bitwise operations (2^20 rows)
 //! - **LT**: Less-than comparison table
-//! - **CPU**: Main execution table
+//! - **CPU**: Main execution table (non-bitwise instructions)
+//! - **CPU_BITWISE**: CPU table for AND, OR, XOR instructions
 //! - **DECODE**: Instruction decode table
 //! - **BRANCH**: Branch target calculation table
 //! - **HALT**: Single-row halt table
@@ -54,7 +55,8 @@ pub use types::BusId;
 /// |---------|------|-----|-----------|----------|
 /// | MEMW    |  49  |  26 |    127    |  2^19    |
 /// | MEMW_A  |  29  |  20 |     89    |  2^19 *  |
-/// | CPU     |  74  |  40 |    194    |  2^19    |
+/// | CPU     |  74  |  44 |    206    |  2^19    |
+/// | CPU_BIT |  74  |  60 |    254    |  2^19    |
 /// | DVRM    |  34  |  34 |    136    |  2^19    |
 /// | MUL     |  26  |  16 |     74    |  2^20    |
 /// | LT      |  15  |   9 |     42    |  2^21    |
@@ -63,7 +65,8 @@ pub use types::BusId;
 /// | BRANCH  |  14  |   6 |     32    |  2^21    |
 /// | MEMW_R  |  10  |   7 |     31    |  2^21    |
 pub mod max_rows {
-    pub const CPU: usize = 1 << 19; // 524,288   — eff. width 194
+    pub const CPU: usize = 1 << 19; // 524,288   — eff. width 206
+    pub const CPU_BITWISE: usize = 1 << 19; // 524,288 — eff. width 254
     pub const MEMW: usize = 1 << 19; // 524,288  — eff. width 127 (baseline)
     pub const MEMW_A: usize = 1 << 19; // 524,288 — eff. width 89
     pub const DVRM: usize = 1 << 19; // 524,288  — eff. width 136

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -1576,6 +1576,9 @@ pub struct Traces {
     /// CPU execution traces (split into chunks of max_rows::CPU)
     pub cpus: Vec<TraceTable<GoldilocksField, GoldilocksExtension>>,
 
+    /// CPU_BITWISE traces for AND/OR/XOR instructions (split into chunks)
+    pub cpu_bitwises: Vec<TraceTable<GoldilocksField, GoldilocksExtension>>,
+
     /// BITWISE precomputed lookup table (2^20 rows)
     pub bitwise: TraceTable<GoldilocksField, GoldilocksExtension>,
 
@@ -1646,6 +1649,7 @@ impl Traces {
     pub fn table_counts(&self) -> crate::TableCounts {
         crate::TableCounts {
             cpu: self.cpus.len(),
+            cpu_bitwise: self.cpu_bitwises.len(),
             lt: self.lts.len(),
             memw: self.memws.len(),
             memw_aligned: self.memw_aligneds.len(),
@@ -1908,14 +1912,6 @@ impl Traces {
         // COMMIT table sends IsByte and IsHalfword lookups
         bitwise_ops.extend(collect_bitwise_from_commit(&commit_ops));
 
-        // CPU padding rows send IS_BYTE with all-zero values.
-        // Add corresponding ops so the bitwise table multiplicities balance.
-        let num_padding_rows: usize = cpu_ops
-            .chunks(max_rows.cpu)
-            .map(|chunk| chunk.len().next_power_of_two().max(4) - chunk.len())
-            .sum();
-        bitwise_ops.extend(collect_byte_check_ops_for_padding(num_padding_rows));
-
         // =====================================================================
         // PHASE 5: Generate final traces (parallelized)
         // =====================================================================
@@ -1928,7 +1924,28 @@ impl Traces {
             .ok_or(Error::MissingHaltEcall)?;
         let halt_timestamp = halt_op.timestamp;
 
+        // Route bitwise instructions (AND, OR, XOR) to CPU_BITWISE chip
+        let (cpu_bitwise_ops, cpu_ops): (Vec<_>, Vec<_>) =
+            cpu_ops.into_iter().partition(|op| op.is_bitwise());
+
+        // CPU and CPU_BITWISE padding rows send IS_BYTE with all-zero values.
+        // Computed after partition so padding reflects actual chunk sizes.
+        let num_padding_rows: usize = cpu_ops
+            .chunks(max_rows.cpu)
+            .map(|chunk| chunk.len().next_power_of_two().max(4) - chunk.len())
+            .sum::<usize>()
+            + cpu_bitwise_ops
+                .chunks(max_rows.cpu)
+                .map(|chunk| chunk.len().next_power_of_two().max(4) - chunk.len())
+                .sum::<usize>();
+        bitwise_ops.extend(collect_byte_check_ops_for_padding(num_padding_rows));
+
         let cpus = chunk_and_generate(&cpu_ops, max_rows.cpu, cpu::generate_cpu_trace);
+        let cpu_bitwises = if cpu_bitwise_ops.is_empty() {
+            Vec::new()
+        } else {
+            chunk_and_generate(&cpu_bitwise_ops, max_rows.cpu, cpu::generate_cpu_trace)
+        };
         let memws = chunk_and_generate(&memw_ops, max_rows.memw, memw::generate_memw_trace);
         let memw_aligneds = chunk_and_generate(
             &memw_aligned_ops,
@@ -1952,16 +1969,21 @@ impl Traces {
         bitwise::update_multiplicities(&mut bitwise, &bitwise_ops);
 
         // Update DECODE multiplicities
-        // Each CPU operation looks up the DECODE table once
-        // Padding rows also look up pc=1 (the CPU padding entry)
-        // When CPU is split, each chunk pads independently
+        // Each CPU operation (from both CPU and CPU_BITWISE chips) looks up the DECODE table once.
+        // Padding rows also look up pc=1 (the CPU padding entry).
+        // When CPU is split, each chunk pads independently.
         let mut decode = decode_trace;
         let pc_to_row = decode_pc_to_row;
         let num_padding_rows: usize = cpu_ops
             .chunks(max_rows.cpu)
             .map(|chunk| chunk.len().next_power_of_two().max(4) - chunk.len())
-            .sum();
+            .sum::<usize>()
+            + cpu_bitwise_ops
+                .chunks(max_rows.cpu)
+                .map(|chunk| chunk.len().next_power_of_two().max(4) - chunk.len())
+                .sum::<usize>();
         let mut decode_lookups: Vec<u64> = cpu_ops.iter().map(|op| op.decode.pc).collect();
+        decode_lookups.extend(cpu_bitwise_ops.iter().map(|op| op.decode.pc));
         decode_lookups.extend(std::iter::repeat_n(cpu::CPU_PADDING_PC, num_padding_rows));
         decode::update_multiplicities(&mut decode, &pc_to_row, &decode_lookups);
 
@@ -2006,6 +2028,7 @@ impl Traces {
 
         Ok(Traces {
             cpus,
+            cpu_bitwises,
             bitwise,
             lts,
             shifts,
@@ -2152,13 +2175,6 @@ impl Traces {
         // COMMIT table sends IsHalfword lookups
         bitwise_ops.extend(collect_bitwise_from_commit(&commit_ops));
 
-        // CPU padding rows send IS_BYTE with all-zero values.
-        let num_padding_rows: usize = cpu_ops
-            .chunks(max_rows.cpu)
-            .map(|chunk| chunk.len().next_power_of_two().max(4) - chunk.len())
-            .sum();
-        bitwise_ops.extend(collect_byte_check_ops_for_padding(num_padding_rows));
-
         // =====================================================================
         // PHASE 5: Generate final traces (parallelized)
         // =====================================================================
@@ -2171,7 +2187,27 @@ impl Traces {
             .ok_or(Error::MissingHaltEcall)?;
         let halt_timestamp = halt_op.timestamp;
 
+        // Route bitwise instructions (AND, OR, XOR) to CPU_BITWISE chip
+        let (cpu_bitwise_ops, cpu_ops): (Vec<_>, Vec<_>) =
+            cpu_ops.into_iter().partition(|op| op.is_bitwise());
+
+        // CPU and CPU_BITWISE padding rows send IS_BYTE with all-zero values.
+        let num_padding_rows: usize = cpu_ops
+            .chunks(max_rows.cpu)
+            .map(|chunk| chunk.len().next_power_of_two().max(4) - chunk.len())
+            .sum::<usize>()
+            + cpu_bitwise_ops
+                .chunks(max_rows.cpu)
+                .map(|chunk| chunk.len().next_power_of_two().max(4) - chunk.len())
+                .sum::<usize>();
+        bitwise_ops.extend(collect_byte_check_ops_for_padding(num_padding_rows));
+
         let cpus = chunk_and_generate(&cpu_ops, max_rows.cpu, cpu::generate_cpu_trace);
+        let cpu_bitwises = if cpu_bitwise_ops.is_empty() {
+            Vec::new()
+        } else {
+            chunk_and_generate(&cpu_bitwise_ops, max_rows.cpu, cpu::generate_cpu_trace)
+        };
         let memws = chunk_and_generate(&memw_ops, max_rows.memw, memw::generate_memw_trace);
         let memw_aligneds = chunk_and_generate(
             &memw_aligned_ops,
@@ -2195,15 +2231,18 @@ impl Traces {
         bitwise::update_multiplicities(&mut bitwise, &bitwise_ops);
 
         // Generate DECODE trace and update multiplicities
-        // Each CPU operation looks up the DECODE table once
-        // Padding rows also look up pc=1 (the CPU padding entry)
-        // When CPU is split, each chunk pads independently
+        // Both CPU and CPU_BITWISE chips look up DECODE once per row
         let (mut decode, pc_to_row) = decode::generate_decode_trace(&instructions);
         let num_padding_rows: usize = cpu_ops
             .chunks(max_rows.cpu)
             .map(|chunk| chunk.len().next_power_of_two().max(4) - chunk.len())
-            .sum();
+            .sum::<usize>()
+            + cpu_bitwise_ops
+                .chunks(max_rows.cpu)
+                .map(|chunk| chunk.len().next_power_of_two().max(4) - chunk.len())
+                .sum::<usize>();
         let mut decode_lookups: Vec<u64> = cpu_ops.iter().map(|op| op.decode.pc).collect();
+        decode_lookups.extend(cpu_bitwise_ops.iter().map(|op| op.decode.pc));
         decode_lookups.extend(std::iter::repeat_n(cpu::CPU_PADDING_PC, num_padding_rows));
         decode::update_multiplicities(&mut decode, &pc_to_row, &decode_lookups);
         let register_final_state = register_state.to_final_state_map();
@@ -2235,6 +2274,7 @@ impl Traces {
 
         Ok(Traces {
             cpus,
+            cpu_bitwises,
             bitwise,
             lts,
             shifts,

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -1631,6 +1631,19 @@ pub struct Traces {
     pub memw_registers: Vec<TraceTable<GoldilocksField, GoldilocksExtension>>,
 }
 
+/// Count total padding rows that `chunk_and_generate` would produce.
+///
+/// Matches `chunk_and_generate` behavior: empty input produces 1 chunk of 4 padding rows.
+fn count_padding_rows<T>(ops: &[T], max_rows: usize) -> usize {
+    if ops.is_empty() {
+        4 // chunk_and_generate generates 1 chunk, generate_*_trace pads 0 ops to 4
+    } else {
+        ops.chunks(max_rows)
+            .map(|chunk| chunk.len().next_power_of_two().max(4) - chunk.len())
+            .sum()
+    }
+}
+
 /// Chunk raw ops and generate one trace table per chunk.
 fn chunk_and_generate<T>(
     ops: &[T],
@@ -1929,23 +1942,19 @@ impl Traces {
             cpu_ops.into_iter().partition(|op| op.is_bitwise());
 
         // CPU and CPU_BITWISE padding rows send IS_BYTE with all-zero values.
-        // Computed after partition so padding reflects actual chunk sizes.
-        let num_padding_rows: usize = cpu_ops
-            .chunks(max_rows.cpu)
-            .map(|chunk| chunk.len().next_power_of_two().max(4) - chunk.len())
-            .sum::<usize>()
-            + cpu_bitwise_ops
-                .chunks(max_rows.cpu)
-                .map(|chunk| chunk.len().next_power_of_two().max(4) - chunk.len())
-                .sum::<usize>();
+        // Uses count_padding_rows to match chunk_and_generate's behavior
+        // (including the phantom 4-row chunk for empty input).
+        let num_padding_rows: usize = count_padding_rows(&cpu_ops, max_rows.cpu)
+            + count_padding_rows(&cpu_bitwise_ops, max_rows.cpu);
         bitwise_ops.extend(collect_byte_check_ops_for_padding(num_padding_rows));
 
         let cpus = chunk_and_generate(&cpu_ops, max_rows.cpu, cpu::generate_cpu_trace);
-        let cpu_bitwises = if cpu_bitwise_ops.is_empty() {
-            Vec::new()
-        } else {
-            chunk_and_generate(&cpu_bitwise_ops, max_rows.cpu, cpu::generate_cpu_trace)
-        };
+        // Always generate at least one CPU_BITWISE chunk (even if empty/padding-only).
+        // This is required for soundness: without a CPU_BITWISE AIR, the verifier
+        // cannot enforce AND/OR/XOR byte lookups. A malicious prover could omit
+        // the chip and forge bitwise results.
+        let cpu_bitwises =
+            chunk_and_generate(&cpu_bitwise_ops, max_rows.cpu, cpu::generate_cpu_trace);
         let memws = chunk_and_generate(&memw_ops, max_rows.memw, memw::generate_memw_trace);
         let memw_aligneds = chunk_and_generate(
             &memw_aligned_ops,
@@ -1968,20 +1977,9 @@ impl Traces {
         let mut bitwise = bitwise::generate_bitwise_trace();
         bitwise::update_multiplicities(&mut bitwise, &bitwise_ops);
 
-        // Update DECODE multiplicities
-        // Each CPU operation (from both CPU and CPU_BITWISE chips) looks up the DECODE table once.
-        // Padding rows also look up pc=1 (the CPU padding entry).
-        // When CPU is split, each chunk pads independently.
+        // Update DECODE multiplicities (reuses num_padding_rows from IS_BYTE calculation above).
         let mut decode = decode_trace;
         let pc_to_row = decode_pc_to_row;
-        let num_padding_rows: usize = cpu_ops
-            .chunks(max_rows.cpu)
-            .map(|chunk| chunk.len().next_power_of_two().max(4) - chunk.len())
-            .sum::<usize>()
-            + cpu_bitwise_ops
-                .chunks(max_rows.cpu)
-                .map(|chunk| chunk.len().next_power_of_two().max(4) - chunk.len())
-                .sum::<usize>();
         let mut decode_lookups: Vec<u64> = cpu_ops.iter().map(|op| op.decode.pc).collect();
         decode_lookups.extend(cpu_bitwise_ops.iter().map(|op| op.decode.pc));
         decode_lookups.extend(std::iter::repeat_n(cpu::CPU_PADDING_PC, num_padding_rows));
@@ -2192,22 +2190,17 @@ impl Traces {
             cpu_ops.into_iter().partition(|op| op.is_bitwise());
 
         // CPU and CPU_BITWISE padding rows send IS_BYTE with all-zero values.
-        let num_padding_rows: usize = cpu_ops
-            .chunks(max_rows.cpu)
-            .map(|chunk| chunk.len().next_power_of_two().max(4) - chunk.len())
-            .sum::<usize>()
-            + cpu_bitwise_ops
-                .chunks(max_rows.cpu)
-                .map(|chunk| chunk.len().next_power_of_two().max(4) - chunk.len())
-                .sum::<usize>();
+        let num_padding_rows: usize = count_padding_rows(&cpu_ops, max_rows.cpu)
+            + count_padding_rows(&cpu_bitwise_ops, max_rows.cpu);
         bitwise_ops.extend(collect_byte_check_ops_for_padding(num_padding_rows));
 
         let cpus = chunk_and_generate(&cpu_ops, max_rows.cpu, cpu::generate_cpu_trace);
-        let cpu_bitwises = if cpu_bitwise_ops.is_empty() {
-            Vec::new()
-        } else {
-            chunk_and_generate(&cpu_bitwise_ops, max_rows.cpu, cpu::generate_cpu_trace)
-        };
+        // Always generate at least one CPU_BITWISE chunk (even if empty/padding-only).
+        // This is required for soundness: without a CPU_BITWISE AIR, the verifier
+        // cannot enforce AND/OR/XOR byte lookups. A malicious prover could omit
+        // the chip and forge bitwise results.
+        let cpu_bitwises =
+            chunk_and_generate(&cpu_bitwise_ops, max_rows.cpu, cpu::generate_cpu_trace);
         let memws = chunk_and_generate(&memw_ops, max_rows.memw, memw::generate_memw_trace);
         let memw_aligneds = chunk_and_generate(
             &memw_aligned_ops,
@@ -2230,17 +2223,8 @@ impl Traces {
         let mut bitwise = bitwise::generate_bitwise_trace();
         bitwise::update_multiplicities(&mut bitwise, &bitwise_ops);
 
-        // Generate DECODE trace and update multiplicities
-        // Both CPU and CPU_BITWISE chips look up DECODE once per row
+        // Generate DECODE trace and update multiplicities (reuses num_padding_rows from above).
         let (mut decode, pc_to_row) = decode::generate_decode_trace(&instructions);
-        let num_padding_rows: usize = cpu_ops
-            .chunks(max_rows.cpu)
-            .map(|chunk| chunk.len().next_power_of_two().max(4) - chunk.len())
-            .sum::<usize>()
-            + cpu_bitwise_ops
-                .chunks(max_rows.cpu)
-                .map(|chunk| chunk.len().next_power_of_two().max(4) - chunk.len())
-                .sum::<usize>();
         let mut decode_lookups: Vec<u64> = cpu_ops.iter().map(|op| op.decode.pc).collect();
         decode_lookups.extend(cpu_bitwise_ops.iter().map(|op| op.decode.pc));
         decode_lookups.extend(std::iter::repeat_n(cpu::CPU_PADDING_PC, num_padding_rows));

--- a/prover/src/test_utils.rs
+++ b/prover/src/test_utils.rs
@@ -35,9 +35,7 @@ use crate::tables::commit::{
     bus_interactions as commit_bus_interactions, cols as commit_cols,
     create_constraints as commit_constraints,
 };
-use crate::tables::cpu::{
-    CpuOperation, bus_interactions as cpu_bus_interactions, cols as cpu_cols,
-};
+use crate::tables::cpu::{CpuOperation, cols as cpu_cols};
 use crate::tables::decode::{bus_interactions as decode_bus_interactions, cols as decode_cols};
 use crate::tables::dvrm::{
     bus_interactions as dvrm_bus_interactions, cols as dvrm_cols, dvrm_constraints,
@@ -475,7 +473,7 @@ pub fn create_cpu_air(proof_options: &ProofOptions) -> VmAir {
     }
 
     let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
-        interactions: cpu_bus_interactions(),
+        interactions: crate::tables::cpu::bus_interactions_without_bitwise_bytes(),
     };
 
     AirWithBuses::new(
@@ -486,6 +484,38 @@ pub fn create_cpu_air(proof_options: &ProofOptions) -> VmAir {
         transition_constraints,
     )
     .with_name("CPU")
+}
+
+/// Create CPU_BITWISE AIR for AND/OR/XOR instructions.
+///
+/// Uses the same 74 columns and constraints as CPU, but with a different
+/// set of bus interactions (only bitwise-relevant ones).
+pub fn create_cpu_bitwise_air(proof_options: &ProofOptions) -> VmAir {
+    let (is_bit, add, other, _) = create_all_cpu_constraints();
+
+    let mut transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> = Vec::new();
+    for c in is_bit {
+        transition_constraints.push(Box::new(c));
+    }
+    for c in add {
+        transition_constraints.push(Box::new(c));
+    }
+    for c in other {
+        transition_constraints.push(c);
+    }
+
+    let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
+        interactions: crate::tables::cpu_bitwise::bus_interactions(),
+    };
+
+    AirWithBuses::new(
+        cpu_cols::NUM_COLUMNS,
+        auxiliary_trace_build_data,
+        proof_options,
+        1,
+        transition_constraints,
+    )
+    .with_name("CPU_BITWISE")
 }
 
 /// Create Bitwise AIR with bus interactions.

--- a/prover/src/tests/cpu_tests.rs
+++ b/prover/src/tests/cpu_tests.rs
@@ -5,7 +5,10 @@
 //! - Trace generation tests
 //! - Integration tests for CpuOperation::from_log (ELF execution)
 
-use crate::tables::cpu::{CpuOperation, bus_interactions, cols, generate_cpu_trace};
+use crate::tables::cpu::{
+    CpuOperation, bus_interactions, bus_interactions_bitwise_chip,
+    bus_interactions_without_bitwise_bytes, cols, generate_cpu_trace,
+};
 use crate::tables::trace_builder::Traces;
 use crate::tables::types::{DecodeEntry, FE};
 
@@ -332,6 +335,72 @@ fn test_bus_interactions_count() {
     // - 27 IS_BYTE (byte range checks: RS1, RS2, RD, ARG1[0..7], ARG2[0..7], RES[0..7])
     // Total: 8 + 8 + 8 + 2 + 1 + 1 + 1 + 1 + 5 + 1 + 1 + 1 + 1 + 1 + 1 + 27 = 68
     assert_eq!(interactions.len(), 68);
+}
+
+/// Verify the interaction counts after the CPU/CPU_BITWISE split match the expected values.
+///
+/// | Function                            | Interactions | Eff. width (74 + 3×n) |
+/// |-------------------------------------|:------------:|:---------------------:|
+/// | bus_interactions()                  |      68      |          278          |
+/// | bus_interactions_without_bitwise_bytes() |   44      |          206          |
+/// | bus_interactions_bitwise_chip()     |      60      |          254          |
+#[test]
+fn test_bus_interactions_split_counts() {
+    assert_eq!(bus_interactions_without_bitwise_bytes().len(), 44);
+    assert_eq!(bus_interactions_bitwise_chip().len(), 60);
+}
+
+/// Verify that AND_BYTE, OR_BYTE, and XOR_BYTE interactions are exclusive to
+/// CPU_BITWISE: absent from the main CPU, present in the bitwise chip.
+///
+/// This is the invariant that was violated when MSB16 was initially missing
+/// from bus_interactions_bitwise_chip — adding a new bus ID to bus_interactions()
+/// requires manually deciding which chip it belongs to.
+#[test]
+fn test_bus_interactions_bitwise_exclusivity() {
+    use std::collections::HashSet;
+
+    let and_id: u64 = crate::tables::types::BusId::AndByte.into();
+    let or_id: u64 = crate::tables::types::BusId::OrByte.into();
+    let xor_id: u64 = crate::tables::types::BusId::XorByte.into();
+    let bitwise_byte_ids: HashSet<u64> = [and_id, or_id, xor_id].into();
+
+    let cpu_ids: HashSet<u64> = bus_interactions_without_bitwise_bytes()
+        .iter()
+        .map(|i| i.bus_id)
+        .collect();
+    let bitwise_ids: HashSet<u64> = bus_interactions_bitwise_chip()
+        .iter()
+        .map(|i| i.bus_id)
+        .collect();
+
+    // AND/OR/XOR byte IDs must be absent from the main CPU chip.
+    for id in &bitwise_byte_ids {
+        assert!(
+            !cpu_ids.contains(id),
+            "bus_id {id} (AND/OR/XOR byte) should not appear in bus_interactions_without_bitwise_bytes"
+        );
+    }
+
+    // AND/OR/XOR byte IDs must be present in the bitwise chip.
+    for id in &bitwise_byte_ids {
+        assert!(
+            bitwise_ids.contains(id),
+            "bus_id {id} (AND/OR/XOR byte) must be present in bus_interactions_bitwise_chip"
+        );
+    }
+
+    // Every other ID in the bitwise chip must also appear in the main CPU chip
+    // (shared interactions such as DECODE, IS_BYTE, MSB16, MEMW).
+    for id in &bitwise_ids {
+        if bitwise_byte_ids.contains(id) {
+            continue;
+        }
+        assert!(
+            cpu_ids.contains(id),
+            "bus_id {id} is in bus_interactions_bitwise_chip but missing from bus_interactions_without_bitwise_bytes — was it added to bus_interactions() without updating both split functions?"
+        );
+    }
 }
 
 #[test]

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -1901,6 +1901,34 @@ fn test_verify_rejects_inflated_table_counts() {
     );
 }
 
+/// A program with no bitwise instructions must still produce a CPU_BITWISE
+/// phantom chunk and verify successfully. This exercises the soundness fix
+/// that always generates a CPU_BITWISE chunk: without it a malicious prover
+/// could omit the chip and bypass AND/OR/XOR byte-lookup constraints.
+#[test]
+fn test_prove_elfs_no_bitwise_instructions() {
+    let (elf, logs, instructions) = run_asm_elf("sub_neg_result");
+    let mut traces =
+        Traces::from_logs_minimal(&logs, instructions.clone(), &Default::default()).unwrap();
+
+    // Confirm no bitwise ops were generated — the only CPU_BITWISE chunk must
+    // be the phantom padding chunk (4 rows).
+    assert_eq!(
+        traces.cpu_bitwises.len(),
+        1,
+        "Expected exactly 1 phantom CPU_BITWISE chunk for zero-bitwise program"
+    );
+    assert_eq!(
+        traces.cpu_bitwises[0].main_table.height, 4,
+        "Phantom chunk should contain 4 padding rows"
+    );
+
+    assert!(
+        prove_and_verify_vm_minimal(&elf, &mut traces),
+        "Proof verification failed for zero-bitwise program (phantom CPU_BITWISE chunk)"
+    );
+}
+
 /// Regression test: addiw with negative immediate must verify.
 /// arg2_sign_bit is the sign bit of rv2 (bit 31), not of arg2, per spec
 /// constraint CPU-CE61: MSB16[arg2_sign_bit; rv2[1]].

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -1708,6 +1708,7 @@ fn test_verify_rejects_zero_table_counts() {
     let tampered_proof = crate::VmProof {
         table_counts: crate::TableCounts {
             cpu: 0,
+            cpu_bitwise: 0,
             lt: 0,
             memw: 0,
             memw_aligned: 0,
@@ -1776,6 +1777,7 @@ fn test_crafted_zero_count_proof_must_not_verify() {
 
     let zero_counts = crate::TableCounts {
         cpu: 0,
+        cpu_bitwise: 0,
         lt: 0,
         memw: 0,
         memw_aligned: 0,

--- a/prover/src/tests/trace_builder_tests.rs
+++ b/prover/src/tests/trace_builder_tests.rs
@@ -350,6 +350,47 @@ fn test_mixed_instructions() {
     assert!(traces.lts[0].main_table.height >= 2);
 }
 
+#[test]
+fn test_no_bitwise_ops_produce_phantom_chunk() {
+    // A program with only ADD and ECALL — no AND, OR, or XOR instructions.
+    // The trace builder must still emit exactly one CPU_BITWISE chunk (the
+    // phantom padding chunk) so the verifier can instantiate the CPU_BITWISE
+    // AIR and enforce byte-lookup soundness even when no bitwise ops executed.
+    let mut logs = vec![
+        make_add_log(0x1000, 10, 20, 30),
+        make_add_log(0x1004, 1, 2, 3),
+    ];
+    let mut instrs = vec![
+        Instruction::Arith {
+            dst: 1,
+            src1: 2,
+            src2: 3,
+            op: ArithOp::Add,
+        },
+        Instruction::Arith {
+            dst: 1,
+            src1: 2,
+            src2: 3,
+            op: ArithOp::Add,
+        },
+    ];
+    append_ecall(&mut logs, &mut instrs);
+    let instructions = make_instructions(&logs, &instrs);
+
+    let traces = Traces::from_logs(&logs, instructions, &Default::default()).unwrap();
+
+    // No bitwise ops: must produce exactly 1 phantom chunk of 4 padding rows.
+    assert_eq!(
+        traces.cpu_bitwises.len(),
+        1,
+        "Expected exactly 1 phantom CPU_BITWISE chunk for a zero-bitwise program"
+    );
+    assert_eq!(
+        traces.cpu_bitwises[0].main_table.height, 4,
+        "Phantom chunk should contain 4 padding rows"
+    );
+}
+
 // =============================================================================
 // Phase 2 Tests: CPU ops → MEMW, LOAD, LT, Bitwise
 // =============================================================================

--- a/prover/src/tests/trace_builder_tests.rs
+++ b/prover/src/tests/trace_builder_tests.rs
@@ -341,8 +341,10 @@ fn test_mixed_instructions() {
 
     let traces = Traces::from_logs(&logs, instructions, &Default::default()).unwrap();
 
-    // 5 ops (4 + ecall) padded to 8
-    assert_eq!(traces.cpus[0].main_table.height, 8);
+    // 4 non-bitwise ops (ADD, SLT, BLT, ECALL) padded to 4
+    assert_eq!(traces.cpus[0].main_table.height, 4);
+    // 1 bitwise op (AND) padded to 4
+    assert_eq!(traces.cpu_bitwises[0].main_table.height, 4);
     assert_eq!(traces.bitwise.main_table.height, bitwise::NUM_ROWS);
     // 1 SLT + 1 BLT = 2 LT ops
     assert!(traces.lts[0].main_table.height >= 2);


### PR DESCRIPTION
This PR Splits AND/OR/XOR instructions from the unified CPU table into a new CPU_BITWISE chip.

AND, OR, and XOR instructions each need 8 byte-level lookups (AND_BYTE×8, OR_BYTE×8, XOR_BYTE×8) to prove the result byte-by-byte. Each bus interaction needs 3 extension-field columns for the fingerprint polynomial. That's 24 bus interactions × 3 = 72 extension columns.

Before the split, every row was proven at width 278:

Non-bitwise rows: 278 each
Bitwise rows: 278 each

After the split:

Non-bitwise rows: 206 each (−72)
Bitwise rows: 254 each (−24)


