### PR TITLE
Strided barycentric OOD eval, skip per-column LDE pre-extraction

### DIFF
--- a/crypto/math/src/polynomial/mod.rs
+++ b/crypto/math/src/polynomial/mod.rs
@@ -812,6 +812,75 @@ where
     &scalar * &(vanishing * &sum) // F × E → E
 }
 
+/// Strided variant of `interpolate_coset_eval_with_g_n_inv`.
+///
+/// Reads `full_evaluations[0], full_evaluations[stride], …, full_evaluations[(N-1)*stride]`
+/// instead of requiring the caller to pre-extract a contiguous `Vec` of length N.
+/// Avoids allocating N field elements per column when the source data already lives
+/// in a larger buffer (e.g. LDE evaluations striped by `blowup_factor`).
+pub fn interpolate_coset_eval_strided_with_g_n_inv<F, E>(
+    z_pow_n: &FieldElement<E>,
+    coset_offset_pow_n: &FieldElement<F>,
+    n_inv: &FieldElement<F>,
+    g_n_inv: &FieldElement<F>,
+    coset_points: &[FieldElement<F>],
+    full_evaluations: &[FieldElement<F>],
+    stride: usize,
+    inv_denoms: &[FieldElement<E>],
+) -> FieldElement<E>
+where
+    F: IsSubFieldOf<E>,
+    E: IsField,
+{
+    debug_assert_eq!(coset_points.len(), inv_denoms.len());
+    debug_assert!(full_evaluations.len() >= coset_points.len() * stride);
+
+    let n = coset_points.len();
+    let sum: FieldElement<E> = (0..n).fold(FieldElement::<E>::zero(), |acc, i| {
+        let point = &coset_points[i];
+        let eval = &full_evaluations[i * stride];
+        let inv_d = &inv_denoms[i];
+        acc + (point * eval) * inv_d
+    });
+
+    let vanishing = z_pow_n.sub_subfield(coset_offset_pow_n);
+    let scalar = n_inv * g_n_inv;
+    &scalar * &(vanishing * &sum)
+}
+
+/// Strided variant of `interpolate_coset_eval_ext_with_g_n_inv`. Same contract as
+/// `interpolate_coset_eval_strided_with_g_n_inv`, but for extension-field columns.
+#[cfg(feature = "alloc")]
+pub fn interpolate_coset_eval_ext_strided_with_g_n_inv<F, E>(
+    z_pow_n: &FieldElement<E>,
+    coset_offset_pow_n: &FieldElement<F>,
+    n_inv: &FieldElement<F>,
+    g_n_inv: &FieldElement<F>,
+    coset_points: &[FieldElement<F>],
+    full_evaluations: &[FieldElement<E>],
+    stride: usize,
+    inv_denoms: &[FieldElement<E>],
+) -> FieldElement<E>
+where
+    F: IsSubFieldOf<E>,
+    E: IsField,
+{
+    debug_assert_eq!(coset_points.len(), inv_denoms.len());
+    debug_assert!(full_evaluations.len() >= coset_points.len() * stride);
+
+    let n = coset_points.len();
+    let sum: FieldElement<E> = (0..n).fold(FieldElement::<E>::zero(), |acc, i| {
+        let point = &coset_points[i];
+        let eval = &full_evaluations[i * stride];
+        let inv_d = &inv_denoms[i];
+        acc + (point * eval) * inv_d
+    });
+
+    let vanishing = z_pow_n.sub_subfield(coset_offset_pow_n);
+    let scalar = n_inv * g_n_inv;
+    &scalar * &(vanishing * &sum)
+}
+
 #[cfg(test)]
 impl<F: IsField> Polynomial<FieldElement<F>> {
     /// Returns a polynomial that interpolates the points with x coordinates and y coordinates given by

--- a/crypto/stark/src/trace.rs
+++ b/crypto/stark/src/trace.rs
@@ -4,15 +4,15 @@ use itertools::Itertools;
 use math::fft::errors::FFTError;
 use math::field::traits::{IsField, IsSubFieldOf};
 use math::polynomial::{
-    barycentric_inv_denoms, interpolate_coset_eval_ext_with_g_n_inv,
-    interpolate_coset_eval_with_g_n_inv,
+    barycentric_inv_denoms, interpolate_coset_eval_ext_strided_with_g_n_inv,
+    interpolate_coset_eval_strided_with_g_n_inv,
 };
 use math::{
     field::{element::FieldElement, traits::IsFFTField},
     polynomial::Polynomial,
 };
 #[cfg(feature = "parallel")]
-use rayon::prelude::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 
 /// A two-dimensional representation of an execution trace of the STARK
 /// protocol.
@@ -404,74 +404,49 @@ where
 
     // Coset points stay in base field — mixed F×E arithmetic is cheaper than E×E.
 
-    // Extract trace-size evaluations from LDE for each column (stride = blowup_factor)
-    #[cfg(feature = "parallel")]
-    let main_iter = (0..num_main_cols).into_par_iter();
-    #[cfg(not(feature = "parallel"))]
-    let main_iter = 0..num_main_cols;
-    let main_col_evals: Vec<Vec<FieldElement<F>>> = main_iter
-        .map(|col| {
-            (0..n)
-                .map(|i| lde_trace.get_main(i * bf, col).clone())
-                .collect()
-        })
-        .collect();
-
-    #[cfg(feature = "parallel")]
-    let aux_iter = (0..num_aux_cols).into_par_iter();
-    #[cfg(not(feature = "parallel"))]
-    let aux_iter = 0..num_aux_cols;
-    let aux_col_evals: Vec<Vec<FieldElement<E>>> = aux_iter
-        .map(|col| {
-            (0..n)
-                .map(|i| lde_trace.get_aux(i * bf, col).clone())
-                .collect()
-        })
-        .collect();
-
+    // Evaluate every column directly on the LDE with stride = blowup_factor, skipping
+    // the per-column `Vec` pre-extraction that used to clone ~(num_main + num_aux)*n
+    // field elements out of already column-major LDE storage.
     let mut table_data = Vec::with_capacity(evaluation_points.len() * table_width);
 
     for eval_point in &evaluation_points {
-        // z_pow_n for this evaluation point
         let z_pow_n = eval_point.pow(n);
-
-        // Precompute inv_denoms = 1/(eval_point - coset_point_i) — shared across all columns
         let inv_denoms = barycentric_inv_denoms(eval_point, &coset_points);
 
-        // Evaluate all main columns (parallel when feature enabled)
         #[cfg(feature = "parallel")]
-        let main_iter = main_col_evals.par_iter();
+        let main_iter = lde_trace.main_columns.par_iter();
         #[cfg(not(feature = "parallel"))]
-        let main_iter = main_col_evals.iter();
+        let main_iter = lde_trace.main_columns.iter();
         let main_evals: Vec<FieldElement<E>> = main_iter
-            .map(|col_evals| {
-                interpolate_coset_eval_with_g_n_inv(
+            .map(|lde_col| {
+                interpolate_coset_eval_strided_with_g_n_inv(
                     &z_pow_n,
                     &coset_offset_pow_n,
                     &n_inv,
                     &g_n_inv,
                     &coset_points,
-                    col_evals,
+                    lde_col,
+                    bf,
                     &inv_denoms,
                 )
             })
             .collect();
         table_data.extend(main_evals);
 
-        // Evaluate all aux columns
         #[cfg(feature = "parallel")]
-        let aux_iter = aux_col_evals.par_iter();
+        let aux_iter = lde_trace.aux_columns.par_iter();
         #[cfg(not(feature = "parallel"))]
-        let aux_iter = aux_col_evals.iter();
+        let aux_iter = lde_trace.aux_columns.iter();
         let aux_evals: Vec<FieldElement<E>> = aux_iter
-            .map(|col_evals| {
-                interpolate_coset_eval_ext_with_g_n_inv(
+            .map(|lde_col| {
+                interpolate_coset_eval_ext_strided_with_g_n_inv(
                     &z_pow_n,
                     &coset_offset_pow_n,
                     &n_inv,
                     &g_n_inv,
                     &coset_points,
-                    col_evals,
+                    lde_col,
+                    bf,
                     &inv_denoms,
                 )
             })


### PR DESCRIPTION
Replace the per-column `Vec<FieldElement>` pre-extraction in `get_trace_evaluations_from_lde` with a strided variant of the barycentric interpolator that reads directly from the already column-major LDE storage with `stride = blowup_factor`. Same values, no intermediate clone.

On `fib_iterative_2M`: R3 OOD evaluation 5.66s _ 4.66s (-17.7%). Avoids cloning ~(`num_main` + `num_aux`) * `trace_size` field elements per proof.