### PR TITLE
perf: unify AND/OR/XOR byte lookups into single BITWISE bus

### DIFF
--- a/prover/src/tables/bitwise.rs
+++ b/prover/src/tables/bitwise.rs
@@ -51,57 +51,62 @@ pub mod cols {
     pub const X: usize = 0;
     /// Y: Byte input (0-255)
     pub const Y: usize = 1;
-    /// Z: 4-bit input (0-15) for shift amount
+    /// Z: 4-bit discriminator (0-15).
+    ///
+    /// For shift ops (SLL/SLLC/HWSL) Z is the shift amount 0..15.
+    /// For AND/OR/XOR lookups, Z doubles as the op selector sent by the
+    /// Bitwise sender: Z = 1 → AND, Z = 2 → OR, Z = 4 → XOR.
+    /// Z values 3, 5-15 have `RESULT = 0` and zero `MU_BITWISE` — no valid
+    /// sender ever emits a token targeting those rows on `BusId::Bitwise`.
     pub const Z: usize = 2;
 
-    /// AND result: X & Y
-    pub const AND: usize = 3;
-    /// OR result: X | Y
-    pub const OR: usize = 4;
-    /// XOR result: X ^ Y
-    pub const XOR: usize = 5;
+    /// Unified result column for `BusId::Bitwise` lookups.
+    ///
+    /// Populated as:
+    /// - Z = 1: RESULT = X & Y     (AND)
+    /// - Z = 2: RESULT = X | Y     (OR)
+    /// - Z = 4: RESULT = X ^ Y     (XOR)
+    /// - otherwise: RESULT = 0     (irrelevant; MU_BITWISE = 0 on those rows)
+    pub const RESULT: usize = 3;
     /// MSB of byte X: (X >> 7) & 1
-    pub const MSB8: usize = 6;
+    pub const MSB8: usize = 4;
     /// MSB of halfword (X + 256*Y): ((X + 256*Y) >> 15) & 1
-    pub const MSB16: usize = 7;
+    pub const MSB16: usize = 5;
     /// Zero check: (X == 0 && Y == 0) ? 1 : 0
-    pub const ZERO: usize = 8;
+    pub const ZERO: usize = 6;
     /// Shift left result: ((X + 256*Y) << Z) & 0xFFFF
-    pub const SLL: usize = 9;
+    pub const SLL: usize = 7;
     /// Shift left carry: (X + 256*Y) >> (16 - Z)
-    pub const SLLC: usize = 10;
+    pub const SLLC: usize = 8;
 
-    // Multiplicity columns for each lookup type
-    /// Multiplicity for AND_BYTE lookups
-    pub const MU_AND: usize = 11;
-    /// Multiplicity for OR_BYTE lookups
-    pub const MU_OR: usize = 12;
-    /// Multiplicity for XOR_BYTE lookups
-    pub const MU_XOR: usize = 13;
+    // Multiplicity columns
+    /// Unified multiplicity for `BusId::Bitwise` (AND, OR, XOR lookups).
+    /// AND increments at row (x, y, 1); OR at (x, y, 2); XOR at (x, y, 4).
+    pub const MU_BITWISE: usize = 9;
     /// Multiplicity for MSB8 lookups
-    pub const MU_MSB8: usize = 14;
+    pub const MU_MSB8: usize = 10;
     /// Multiplicity for MSB16 lookups
-    pub const MU_MSB16: usize = 15;
+    pub const MU_MSB16: usize = 11;
     /// Multiplicity for ZERO lookups
-    pub const MU_ZERO: usize = 16;
+    pub const MU_ZERO: usize = 12;
     /// Multiplicity for IS_BYTE lookups. Each lookup checks X and Y; pass Y=0
     /// for a single-byte range check.
-    pub const MU_IS_BYTE: usize = 17;
+    pub const MU_IS_BYTE: usize = 13;
     /// Multiplicity for IS_HALF lookups
-    pub const MU_IS_HALF: usize = 18;
+    pub const MU_IS_HALF: usize = 14;
     /// Multiplicity for IS_B20 lookups
-    pub const MU_IS_B20: usize = 19;
+    pub const MU_IS_B20: usize = 15;
     /// Multiplicity for HWSL lookups
-    pub const MU_HWSL: usize = 20;
+    pub const MU_HWSL: usize = 16;
     /// Total number of columns
-    pub const NUM_COLUMNS: usize = 21;
+    pub const NUM_COLUMNS: usize = 17;
 }
 
 /// Number of rows in the BITWISE table: 256 * 256 * 16 = 2^20
 pub const NUM_ROWS: usize = 256 * 256 * 16;
 
 /// Number of precomputed (non-multiplicity) columns
-pub const NUM_PRECOMPUTED_COLS: usize = 11;
+pub const NUM_PRECOMPUTED_COLS: usize = 9;
 
 // =========================================================================
 // Compile-time row generation
@@ -115,17 +120,25 @@ pub const NUM_PRECOMPUTED_COLS: usize = 11;
 /// Index encoding: `index = x + y * 256 + z * 65536`
 /// where x, y ∈ [0, 255] and z ∈ [0, 15]
 ///
-/// Returns the 11 precomputed columns: [X, Y, Z, AND, OR, XOR, MSB8, MSB16, ZERO, SLL, SLLC]
+/// Returns the 9 precomputed columns: [X, Y, Z, RESULT, MSB8, MSB16, ZERO, SLL, SLLC]
+///
+/// `RESULT` encodes the three bitwise byte ops via `Z`:
+///   Z = 1 → X & Y    Z = 2 → X | Y    Z = 4 → X ^ Y    otherwise → 0
 #[inline]
 pub const fn generate_bitwise_row(index: usize) -> [u64; NUM_PRECOMPUTED_COLS] {
     let x = (index & 0xFF) as u32;
     let y = ((index >> 8) & 0xFF) as u32;
     let z = ((index >> 16) & 0xF) as u32;
 
-    // Bitwise operations on bytes
-    let and_val = x & y;
-    let or_val = x | y;
-    let xor_val = x ^ y;
+    // Bitwise op selected by Z (disjoint-bit encoding matches the sender's
+    // op_id = AND + 2*OR + 4*XOR). Any other Z leaves RESULT at 0; those
+    // rows carry zero MU_BITWISE so the choice never matches a real sender.
+    let result = match z {
+        1 => x & y,
+        2 => x | y,
+        4 => x ^ y,
+        _ => 0,
+    };
 
     // MSB extractions
     let msb8 = (x >> 7) & 1;
@@ -147,9 +160,7 @@ pub const fn generate_bitwise_row(index: usize) -> [u64; NUM_PRECOMPUTED_COLS] {
         x as u64,       // X
         y as u64,       // Y
         z as u64,       // Z
-        and_val as u64, // AND
-        or_val as u64,  // OR
-        xor_val as u64, // XOR
+        result as u64,  // RESULT
         msb8 as u64,    // MSB8
         msb16 as u64,   // MSB16
         is_zero as u64, // ZERO
@@ -312,10 +323,15 @@ pub fn generate_bitwise_trace() -> TraceTable<GoldilocksField, GoldilocksExtensi
                 data[base + cols::Y] = FE::from(y as u64);
                 data[base + cols::Z] = FE::from(z as u64);
 
-                // Bitwise operation results
-                data[base + cols::AND] = FE::from((x & y) as u64);
-                data[base + cols::OR] = FE::from((x | y) as u64);
-                data[base + cols::XOR] = FE::from((x ^ y) as u64);
+                // Unified bitwise result: Z selects the op
+                // (Z=1 AND, Z=2 OR, Z=4 XOR, otherwise 0 — never matched).
+                let result = match z {
+                    1 => x & y,
+                    2 => x | y,
+                    4 => x ^ y,
+                    _ => 0,
+                };
+                data[base + cols::RESULT] = FE::from(result as u64);
 
                 // MSB extractions
                 let msb8 = (x >> 7) & 1;
@@ -370,18 +386,20 @@ pub fn update_multiplicities(
     ops: &[BitwiseOperation],
 ) {
     for op in ops {
-        let row = row_index(op.x, op.y, op.z);
-        let mu_col = match op.lookup_type {
-            BitwiseOperationType::AndByte => cols::MU_AND,
-            BitwiseOperationType::OrByte => cols::MU_OR,
-            BitwiseOperationType::XorByte => cols::MU_XOR,
-            BitwiseOperationType::Msb8 => cols::MU_MSB8,
-            BitwiseOperationType::Msb16 => cols::MU_MSB16,
-            BitwiseOperationType::Zero => cols::MU_ZERO,
-            BitwiseOperationType::IsByte => cols::MU_IS_BYTE,
-            BitwiseOperationType::IsHalf => cols::MU_IS_HALF,
-            BitwiseOperationType::IsB20 => cols::MU_IS_B20,
-            BitwiseOperationType::Hwsl => cols::MU_HWSL,
+        // AND/OR/XOR share MU_BITWISE on BusId::Bitwise and route to
+        // z = 1 / 2 / 4 respectively (disjoint-bit op_id). All other ops
+        // keep their dedicated multiplicity column at their own `z`.
+        let (row, mu_col) = match op.lookup_type {
+            BitwiseOperationType::AndByte => (row_index(op.x, op.y, 1), cols::MU_BITWISE),
+            BitwiseOperationType::OrByte => (row_index(op.x, op.y, 2), cols::MU_BITWISE),
+            BitwiseOperationType::XorByte => (row_index(op.x, op.y, 4), cols::MU_BITWISE),
+            BitwiseOperationType::Msb8 => (row_index(op.x, op.y, op.z), cols::MU_MSB8),
+            BitwiseOperationType::Msb16 => (row_index(op.x, op.y, op.z), cols::MU_MSB16),
+            BitwiseOperationType::Zero => (row_index(op.x, op.y, op.z), cols::MU_ZERO),
+            BitwiseOperationType::IsByte => (row_index(op.x, op.y, op.z), cols::MU_IS_BYTE),
+            BitwiseOperationType::IsHalf => (row_index(op.x, op.y, op.z), cols::MU_IS_HALF),
+            BitwiseOperationType::IsB20 => (row_index(op.x, op.y, op.z), cols::MU_IS_B20),
+            BitwiseOperationType::Hwsl => (row_index(op.x, op.y, op.z), cols::MU_HWSL),
         };
 
         // Increment multiplicity
@@ -418,7 +436,7 @@ pub(crate) fn trim_zero_rows(
         .filter(|&row| {
             let row_data = trace.main_table.get_row(row);
             // Check all multiplicity columns (indices 11-20)
-            (cols::MU_AND..=cols::MU_HWSL).any(|col| row_data[col] != FE::zero())
+            (cols::MU_BITWISE..=cols::MU_HWSL).any(|col| row_data[col] != FE::zero())
         })
         .collect();
 
@@ -547,11 +565,24 @@ impl BitwiseOperation {
 /// in the spec corresponds to receiving lookups from other tables).
 pub fn bus_interactions() -> Vec<BusInteraction> {
     vec![
-        // AND_BYTE[X, Y] -> AND
+        // BITWISE[Z, X, Y] -> RESULT
+        //
+        // Single receiver for AND/OR/XOR byte lookups. The sender side
+        // (CPU, branch.rs, shift.rs) emits `op_id = AND + 2*OR + 4*XOR`
+        // as the first token element, matching this row's Z. Z=1 → AND,
+        // Z=2 → OR, Z=4 → XOR. IS_BIT on each op flag + disjoint-bit
+        // encoding ⇒ valid `op_id ∈ {0, 1, 2, 4}`; invalid combinations
+        // (3, 5, 6, 7) never match a row with non-zero MU_BITWISE, so
+        // the memory argument enforces at-most-one without a dedicated
+        // algebraic constraint.
         BusInteraction::receiver(
-            BusId::AndByte,
-            Multiplicity::Column(cols::MU_AND),
+            BusId::Bitwise,
+            Multiplicity::Column(cols::MU_BITWISE),
             vec![
+                BusValue::Packed {
+                    start_column: cols::Z,
+                    packing: Packing::Direct,
+                },
                 BusValue::Packed {
                     start_column: cols::X,
                     packing: Packing::Direct,
@@ -561,45 +592,7 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
                     packing: Packing::Direct,
                 },
                 BusValue::Packed {
-                    start_column: cols::AND,
-                    packing: Packing::Direct,
-                },
-            ],
-        ),
-        // OR_BYTE[X, Y] -> OR
-        BusInteraction::receiver(
-            BusId::OrByte,
-            Multiplicity::Column(cols::MU_OR),
-            vec![
-                BusValue::Packed {
-                    start_column: cols::X,
-                    packing: Packing::Direct,
-                },
-                BusValue::Packed {
-                    start_column: cols::Y,
-                    packing: Packing::Direct,
-                },
-                BusValue::Packed {
-                    start_column: cols::OR,
-                    packing: Packing::Direct,
-                },
-            ],
-        ),
-        // XOR_BYTE[X, Y] -> XOR
-        BusInteraction::receiver(
-            BusId::XorByte,
-            Multiplicity::Column(cols::MU_XOR),
-            vec![
-                BusValue::Packed {
-                    start_column: cols::X,
-                    packing: Packing::Direct,
-                },
-                BusValue::Packed {
-                    start_column: cols::Y,
-                    packing: Packing::Direct,
-                },
-                BusValue::Packed {
-                    start_column: cols::XOR,
+                    start_column: cols::RESULT,
                     packing: Packing::Direct,
                 },
             ],

--- a/prover/src/tables/bitwise.rs
+++ b/prover/src/tables/bitwise.rs
@@ -436,7 +436,7 @@ pub(crate) fn trim_zero_rows(
     let kept_rows: Vec<usize> = (0..num_rows)
         .filter(|&row| {
             let row_data = trace.main_table.get_row(row);
-            // Check all multiplicity columns (indices 11-20)
+            // Check all multiplicity columns (MU_BITWISE..=MU_HWSL = 9..=16)
             (cols::MU_BITWISE..=cols::MU_HWSL).any(|col| row_data[col] != FE::zero())
         })
         .collect();

--- a/prover/src/tables/bitwise.rs
+++ b/prover/src/tables/bitwise.rs
@@ -56,8 +56,9 @@ pub mod cols {
     /// For shift ops (SLL/SLLC/HWSL) Z is the shift amount 0..15.
     /// For AND/OR/XOR lookups, Z doubles as the op selector sent by the
     /// Bitwise sender: Z = 1 → AND, Z = 2 → OR, Z = 4 → XOR.
-    /// Z values 3, 5-15 have `RESULT = 0` and zero `MU_BITWISE` — no valid
-    /// sender ever emits a token targeting those rows on `BusId::Bitwise`.
+    /// Z values 3, 5-15 have `RESULT = 0`. In honest traces no sender emits
+    /// a token with op_id outside {1, 2, 4} (see the soundness comment on
+    /// the BusId::Bitwise receiver below for the IS_BIT + DECODE chain).
     pub const Z: usize = 2;
 
     /// Unified result column for `BusId::Bitwise` lookups.
@@ -66,7 +67,7 @@ pub mod cols {
     /// - Z = 1: RESULT = X & Y     (AND)
     /// - Z = 2: RESULT = X | Y     (OR)
     /// - Z = 4: RESULT = X ^ Y     (XOR)
-    /// - otherwise: RESULT = 0     (irrelevant; MU_BITWISE = 0 on those rows)
+    /// - otherwise: RESULT = 0     (no honest sender targets these rows)
     pub const RESULT: usize = 3;
     /// MSB of byte X: (X >> 7) & 1
     pub const MSB8: usize = 4;
@@ -570,11 +571,19 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
         // Single receiver for AND/OR/XOR byte lookups. The sender side
         // (CPU, branch.rs, shift.rs) emits `op_id = AND + 2*OR + 4*XOR`
         // as the first token element, matching this row's Z. Z=1 → AND,
-        // Z=2 → OR, Z=4 → XOR. IS_BIT on each op flag + disjoint-bit
-        // encoding ⇒ valid `op_id ∈ {0, 1, 2, 4}`; invalid combinations
-        // (3, 5, 6, 7) never match a row with non-zero MU_BITWISE, so
-        // the memory argument enforces at-most-one without a dedicated
-        // algebraic constraint.
+        // Z=2 → OR, Z=4 → XOR.
+        //
+        // Soundness chain (why op_id is forced into {1, 2, 4} for the CPU
+        // sender; branch.rs and shift.rs use the literal constant 1):
+        //   1. IS_BIT (in CPU constraints) forces AND, OR, XOR ∈ {0, 1}.
+        //   2. DECODE lookup ties the CPU's packed_decode (which embeds
+        //      bits OP_AND/OP_OR/OP_XOR) to the precomputed program table,
+        //      where DecodeEntry::set_arith_op sets exactly one of the
+        //      three flags per instruction.
+        // The memory argument alone is NOT load-bearing: MU_BITWISE is a
+        // witness column and rows with z ∈ {0, 3, 5..15} have RESULT = 0,
+        // so without (1)+(2) a prover could absorb a multi-flag token by
+        // emitting RES[i] = 0 and pumping MU_BITWISE on z = 3.
         BusInteraction::receiver(
             BusId::Bitwise,
             Multiplicity::Column(cols::MU_BITWISE),

--- a/prover/src/tables/branch.rs
+++ b/prover/src/tables/branch.rs
@@ -247,12 +247,14 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
                 BusValue::constant(0),
             ],
         ),
-        // AND_BYTE[next_pc_low[0]; unmasked_low_byte, 254]
+        // BITWISE[op_id=1, unmasked_low_byte, 254] -> next_pc_low[0]
         // Verifies: next_pc_low[0] = unmasked_low_byte & 0xFE
+        // Unified bitwise bus; constant op_id = 1 selects the AND row (z=1).
         BusInteraction::sender(
-            BusId::AndByte,
+            BusId::Bitwise,
             Multiplicity::Column(cols::MU),
             vec![
+                BusValue::constant(1),
                 BusValue::Packed {
                     start_column: cols::UNMASKED_LOW_BYTE,
                     packing: Packing::Direct,

--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -1043,12 +1043,25 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
     // Unified bitwise lookup. Token: (op_id, X, Y, RESULT) with
     //   op_id = AND + 2*OR + 4*XOR        (disjoint-bit encoding)
     //   RESULT = RES[i]                   (matches x&y / x|y / x^y)
-    //   multiplicity = AND + OR + XOR     (at most one, enforced by IS_BIT)
+    //   multiplicity = AND + OR + XOR     (at most one in honest traces)
     // Receiver on BITWISE table uses Z as the op_id discriminator: the
     // sender's op_id ∈ {1, 2, 4} lands on rows z = 1 (AND), 2 (OR), 4 (XOR).
-    // Invalid op_ids (3, 5, 6, 7) from multi-flag settings never match a
-    // preprocessed row with non-zero MU_BITWISE, so the memory argument
-    // enforces at-most-one without a dedicated algebraic constraint.
+    //
+    // Why op_id ∈ {1, 2, 4} (and never the multi-flag values 3, 5, 6, 7):
+    //   1. IS_BIT constraints (constraints/cpu.rs, BIT_FLAG_COLUMNS) force
+    //      AND, OR, XOR ∈ {0, 1} unconditionally.
+    //   2. The DECODE bus lookup ties the CPU's reconstructed packed_decode
+    //      (bits OP_AND/OP_OR/OP_XOR per types::packed_decode) to the
+    //      precomputed program table. DecodeEntry::set_arith_op
+    //      (types.rs) is exhaustive over ArithOp and sets exactly one of
+    //      {op_and, op_or, op_xor} per instruction, so the precomputed
+    //      packed_decode is one-hot over those bits.
+    // (1) + (2) ⇒ at most one of AND/OR/XOR is 1, so op_id ∈ {0, 1, 2, 4}.
+    // op_id = 0 has multiplicity Sum3 = 0, so only {1, 2, 4} reach the bus.
+    // The memory argument by itself does NOT enforce at-most-one: MU_BITWISE
+    // is a witness column and BITWISE has precomputed rows at z = 3, 5..15
+    // with RESULT = 0; without IS_BIT + DECODE a malicious prover could
+    // place MU_BITWISE > 0 there and balance the bus with RES[i] = 0.
     for i in 0..8 {
         interactions.push(BusInteraction::sender(
             BusId::Bitwise,

--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -1038,61 +1038,36 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
     // ));
 
     // -------------------------------------------------------------------------
-    // AND_BYTE interactions (×8 for each byte)
+    // BITWISE interactions (×8 for each byte)
     // -------------------------------------------------------------------------
+    // Unified bitwise lookup. Token: (op_id, X, Y, RESULT) with
+    //   op_id = AND + 2*OR + 4*XOR        (disjoint-bit encoding)
+    //   RESULT = RES[i]                   (matches x&y / x|y / x^y)
+    //   multiplicity = AND + OR + XOR     (at most one, enforced by IS_BIT)
+    // Receiver on BITWISE table uses Z as the op_id discriminator: the
+    // sender's op_id ∈ {1, 2, 4} lands on rows z = 1 (AND), 2 (OR), 4 (XOR).
+    // Invalid op_ids (3, 5, 6, 7) from multi-flag settings never match a
+    // preprocessed row with non-zero MU_BITWISE, so the memory argument
+    // enforces at-most-one without a dedicated algebraic constraint.
     for i in 0..8 {
         interactions.push(BusInteraction::sender(
-            BusId::AndByte,
-            Multiplicity::Column(cols::AND),
+            BusId::Bitwise,
+            Multiplicity::Sum3(cols::AND, cols::OR, cols::XOR),
             vec![
-                BusValue::Packed {
-                    start_column: cols::ARG1[i],
-                    packing: Packing::Direct,
-                },
-                BusValue::Packed {
-                    start_column: cols::ARG2[i],
-                    packing: Packing::Direct,
-                },
-                BusValue::Packed {
-                    start_column: cols::RES[i],
-                    packing: Packing::Direct,
-                },
-            ],
-        ));
-    }
-
-    // -------------------------------------------------------------------------
-    // OR_BYTE interactions (×8)
-    // -------------------------------------------------------------------------
-    for i in 0..8 {
-        interactions.push(BusInteraction::sender(
-            BusId::OrByte,
-            Multiplicity::Column(cols::OR),
-            vec![
-                BusValue::Packed {
-                    start_column: cols::ARG1[i],
-                    packing: Packing::Direct,
-                },
-                BusValue::Packed {
-                    start_column: cols::ARG2[i],
-                    packing: Packing::Direct,
-                },
-                BusValue::Packed {
-                    start_column: cols::RES[i],
-                    packing: Packing::Direct,
-                },
-            ],
-        ));
-    }
-
-    // -------------------------------------------------------------------------
-    // XOR_BYTE interactions (×8)
-    // -------------------------------------------------------------------------
-    for i in 0..8 {
-        interactions.push(BusInteraction::sender(
-            BusId::XorByte,
-            Multiplicity::Column(cols::XOR),
-            vec![
+                BusValue::linear(vec![
+                    LinearTerm::Column {
+                        coefficient: 1,
+                        column: cols::AND,
+                    },
+                    LinearTerm::Column {
+                        coefficient: 2,
+                        column: cols::OR,
+                    },
+                    LinearTerm::Column {
+                        coefficient: 4,
+                        column: cols::XOR,
+                    },
+                ]),
                 BusValue::Packed {
                     start_column: cols::ARG1[i],
                     packing: Packing::Direct,

--- a/prover/src/tables/shift.rs
+++ b/prover/src/tables/shift.rs
@@ -396,11 +396,13 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
         ],
     ));
 
-    // SHIFT-C1: AND_BYTE[shift, 15] → bit_shift | left (= μ - direction)
+    // SHIFT-C1: BITWISE[op_id=1, shift, 15] → bit_shift | left (= μ - direction)
+    // Unified bitwise bus; constant op_id = 1 selects the AND row (z = 1).
     interactions.push(BusInteraction::sender(
-        BusId::AndByte,
+        BusId::Bitwise,
         Multiplicity::Diff(cols::MU, cols::DIRECTION),
         vec![
+            BusValue::constant(1),
             BusValue::Packed {
                 start_column: cols::SHIFT_AMOUNT,
                 packing: Packing::Direct,
@@ -413,15 +415,16 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
         ],
     ));
 
-    // SHIFT-C2: AND_BYTE[256 - zbs * 16 - shift, 15] → bit_shift | right (= direction)
+    // SHIFT-C2: BITWISE[op_id=1, 256 - zbs * 16 - shift, 15] → bit_shift | right (= direction)
     // 256 - shift would overflow a byte when shift = 0. Subtracting zbs * 16 keeps it in
     // [0,255].
     // When zbs = 1, shift is a multiple of 16 (i.e. shift ∈ [0, 240]), so
     // 256 - 16 - shift ∈ [0,255].
     interactions.push(BusInteraction::sender(
-        BusId::AndByte,
+        BusId::Bitwise,
         Multiplicity::Column(cols::DIRECTION),
         vec![
+            BusValue::constant(1),
             BusValue::linear(vec![
                 LinearTerm::Constant(256),
                 LinearTerm::Column {
@@ -519,13 +522,15 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
         ],
     ));
 
-    // SHIFT-C11: AND_BYTE[encoded_limb; shift, mask] | μ
+    // SHIFT-C11: BITWISE[op_id=1, shift, mask] → encoded_limb | μ
     // encoded = (1 - ls[0]) + 15*ls[1] + 31*ls[2] + 47*ls[3]
     // mask = 48 - 32 * word_instr
+    // Unified bitwise bus; constant op_id = 1 selects the AND row (z = 1).
     interactions.push(BusInteraction::sender(
-        BusId::AndByte,
+        BusId::Bitwise,
         Multiplicity::Column(cols::MU),
         vec![
+            BusValue::constant(1),
             // first input: shift
             BusValue::Packed {
                 start_column: cols::SHIFT_AMOUNT,

--- a/prover/src/tables/types.rs
+++ b/prover/src/tables/types.rs
@@ -54,12 +54,12 @@ pub enum BusId {
     // =========================================================================
     // Bitwise operations (BITWISE table provides)
     // =========================================================================
-    /// Bitwise AND of two bytes: AND_BYTE[X, Y] -> X & Y
-    AndByte,
-    /// Bitwise OR of two bytes: OR_BYTE[X, Y] -> X | Y
-    OrByte,
-    /// Bitwise XOR of two bytes: XOR_BYTE[X, Y] -> X ^ Y
-    XorByte,
+    /// Unified bitwise byte lookup: BITWISE[op_id, X, Y] -> op_id(X, Y)
+    ///
+    /// Token: (op_id, X, Y, RESULT) with op_id = AND + 2*OR + 4*XOR
+    /// (disjoint-bit encoding). IS_BIT on the three flag columns combined
+    /// with the memory-argument integrity enforces at-most-one.
+    Bitwise,
     /// Most significant bit of a byte: MSB8[X] -> (X >> 7) & 1
     Msb8,
     /// Most significant bit of a halfword: MSB16[X] -> (X >> 15) & 1
@@ -119,9 +119,7 @@ impl BusId {
             BusId::IsByte => "IsByte",
             BusId::IsHalfword => "IsHalfword",
             BusId::IsB20 => "IsB20",
-            BusId::AndByte => "AndByte",
-            BusId::OrByte => "OrByte",
-            BusId::XorByte => "XorByte",
+            BusId::Bitwise => "Bitwise",
             BusId::Msb8 => "Msb8",
             BusId::Msb16 => "Msb16",
             BusId::Zero => "Zero",
@@ -150,25 +148,23 @@ impl TryFrom<u64> for BusId {
             0 => Ok(BusId::IsByte),
             1 => Ok(BusId::IsHalfword),
             2 => Ok(BusId::IsB20),
-            3 => Ok(BusId::AndByte),
-            4 => Ok(BusId::OrByte),
-            5 => Ok(BusId::XorByte),
-            6 => Ok(BusId::Msb8),
-            7 => Ok(BusId::Msb16),
-            8 => Ok(BusId::Zero),
-            9 => Ok(BusId::Hwsl),
-            10 => Ok(BusId::Lt),
-            11 => Ok(BusId::Mul),
-            12 => Ok(BusId::Dvrm),
-            13 => Ok(BusId::Shift),
-            14 => Ok(BusId::Memw),
-            15 => Ok(BusId::Load),
-            16 => Ok(BusId::Memory),
-            17 => Ok(BusId::Branch),
-            18 => Ok(BusId::Decode),
-            19 => Ok(BusId::Ecall),
-            20 => Ok(BusId::CommitNextByte),
-            21 => Ok(BusId::Commit),
+            3 => Ok(BusId::Bitwise),
+            4 => Ok(BusId::Msb8),
+            5 => Ok(BusId::Msb16),
+            6 => Ok(BusId::Zero),
+            7 => Ok(BusId::Hwsl),
+            8 => Ok(BusId::Lt),
+            9 => Ok(BusId::Mul),
+            10 => Ok(BusId::Dvrm),
+            11 => Ok(BusId::Shift),
+            12 => Ok(BusId::Memw),
+            13 => Ok(BusId::Load),
+            14 => Ok(BusId::Memory),
+            15 => Ok(BusId::Branch),
+            16 => Ok(BusId::Decode),
+            17 => Ok(BusId::Ecall),
+            18 => Ok(BusId::CommitNextByte),
+            19 => Ok(BusId::Commit),
             other => Err(other),
         }
     }

--- a/prover/src/test_utils.rs
+++ b/prover/src/test_utils.rs
@@ -373,24 +373,25 @@ pub fn collect_bitwise_ops_from_load(
 pub fn generate_minimal_bitwise_trace(ops: &[BitwiseOperation]) -> TraceTable<F, E> {
     use std::collections::HashMap;
 
-    // Collect unique (lo_byte, hi_byte, shift) tuples and count multiplicities per lookup type
-    let mut row_data: HashMap<(u8, u8, u8), [u64; 10]> = HashMap::new();
+    // Multiplicities indexed as [MU_BITWISE, MU_MSB8, MU_MSB16, MU_ZERO,
+    //                           MU_IS_BYTE, MU_IS_HALF, MU_IS_B20, MU_HWSL]
+    // AND/OR/XOR ops route to z = 1 / 2 / 4 (disjoint-bit op_id) and share MU_BITWISE.
+    let mut row_data: HashMap<(u8, u8, u8), [u64; 8]> = HashMap::new();
 
     for op in ops {
-        let key = (op.x, op.y, op.z);
-        let mu_idx = match op.lookup_type {
-            BitwiseOperationType::AndByte => 0,
-            BitwiseOperationType::OrByte => 1,
-            BitwiseOperationType::XorByte => 2,
-            BitwiseOperationType::Msb8 => 3,
-            BitwiseOperationType::Msb16 => 4,
-            BitwiseOperationType::Zero => 5,
-            BitwiseOperationType::IsByte => 6,
-            BitwiseOperationType::IsHalf => 7,
-            BitwiseOperationType::IsB20 => 8,
-            BitwiseOperationType::Hwsl => 9,
+        let (key, mu_idx) = match op.lookup_type {
+            BitwiseOperationType::AndByte => ((op.x, op.y, 1u8), 0),
+            BitwiseOperationType::OrByte => ((op.x, op.y, 2u8), 0),
+            BitwiseOperationType::XorByte => ((op.x, op.y, 4u8), 0),
+            BitwiseOperationType::Msb8 => ((op.x, op.y, op.z), 1),
+            BitwiseOperationType::Msb16 => ((op.x, op.y, op.z), 2),
+            BitwiseOperationType::Zero => ((op.x, op.y, op.z), 3),
+            BitwiseOperationType::IsByte => ((op.x, op.y, op.z), 4),
+            BitwiseOperationType::IsHalf => ((op.x, op.y, op.z), 5),
+            BitwiseOperationType::IsB20 => ((op.x, op.y, op.z), 6),
+            BitwiseOperationType::Hwsl => ((op.x, op.y, op.z), 7),
         };
-        row_data.entry(key).or_insert([0; 10])[mu_idx] += 1;
+        row_data.entry(key).or_insert([0; 8])[mu_idx] += 1;
     }
 
     // Need at least 4 rows for FRI, pad to power of 2
@@ -401,53 +402,55 @@ pub fn generate_minimal_bitwise_trace(ops: &[BitwiseOperation]) -> TraceTable<F,
 
     for (row_idx, (x, y, z)) in unique_rows.iter().enumerate() {
         let base = row_idx * bitwise_cols::NUM_COLUMNS;
-        let x = *x as u32;
-        let y = *y as u32;
-        let z = *z as u32;
+        let x_u = *x as u32;
+        let y_u = *y as u32;
+        let z_u = *z as u32;
 
         // Input columns
-        data[base + bitwise_cols::X] = FE::from(x as u64);
-        data[base + bitwise_cols::Y] = FE::from(y as u64);
-        data[base + bitwise_cols::Z] = FE::from(z as u64);
+        data[base + bitwise_cols::X] = FE::from(x_u as u64);
+        data[base + bitwise_cols::Y] = FE::from(y_u as u64);
+        data[base + bitwise_cols::Z] = FE::from(z_u as u64);
 
-        // Bitwise operation results
-        data[base + bitwise_cols::AND] = FE::from((x & y) as u64);
-        data[base + bitwise_cols::OR] = FE::from((x | y) as u64);
-        data[base + bitwise_cols::XOR] = FE::from((x ^ y) as u64);
+        // Unified bitwise result driven by Z (sender's op_id).
+        let result = match z_u {
+            1 => x_u & y_u,
+            2 => x_u | y_u,
+            4 => x_u ^ y_u,
+            _ => 0,
+        };
+        data[base + bitwise_cols::RESULT] = FE::from(result as u64);
 
         // MSB extractions
-        let msb8 = (x >> 7) & 1;
-        let halfword = x + y * 256;
+        let msb8 = (x_u >> 7) & 1;
+        let halfword = x_u + y_u * 256;
         let msb16 = (halfword >> 15) & 1;
         data[base + bitwise_cols::MSB8] = FE::from(msb8 as u64);
         data[base + bitwise_cols::MSB16] = FE::from(msb16 as u64);
 
         // Zero check
-        let is_zero = if x == 0 && y == 0 { 1u64 } else { 0u64 };
+        let is_zero = if x_u == 0 && y_u == 0 { 1u64 } else { 0u64 };
         data[base + bitwise_cols::ZERO] = FE::from(is_zero);
 
         // Shift operations
-        let sll = if z == 0 {
+        let sll = if z_u == 0 {
             halfword
         } else {
-            (halfword << z) & 0xFFFF
+            (halfword << z_u) & 0xFFFF
         };
-        let sllc = if z == 0 { 0 } else { halfword >> (16 - z) };
+        let sllc = if z_u == 0 { 0 } else { halfword >> (16 - z_u) };
         data[base + bitwise_cols::SLL] = FE::from(sll as u64);
         data[base + bitwise_cols::SLLC] = FE::from(sllc as u64);
 
         // Multiplicity columns
-        let mus = &row_data[&(x as u8, y as u8, z as u8)];
-        data[base + bitwise_cols::MU_AND] = FE::from(mus[0]);
-        data[base + bitwise_cols::MU_OR] = FE::from(mus[1]);
-        data[base + bitwise_cols::MU_XOR] = FE::from(mus[2]);
-        data[base + bitwise_cols::MU_MSB8] = FE::from(mus[3]);
-        data[base + bitwise_cols::MU_MSB16] = FE::from(mus[4]);
-        data[base + bitwise_cols::MU_ZERO] = FE::from(mus[5]);
-        data[base + bitwise_cols::MU_IS_BYTE] = FE::from(mus[6]);
-        data[base + bitwise_cols::MU_IS_HALF] = FE::from(mus[7]);
-        data[base + bitwise_cols::MU_IS_B20] = FE::from(mus[8]);
-        data[base + bitwise_cols::MU_HWSL] = FE::from(mus[9]);
+        let mus = &row_data[&(*x, *y, *z)];
+        data[base + bitwise_cols::MU_BITWISE] = FE::from(mus[0]);
+        data[base + bitwise_cols::MU_MSB8] = FE::from(mus[1]);
+        data[base + bitwise_cols::MU_MSB16] = FE::from(mus[2]);
+        data[base + bitwise_cols::MU_ZERO] = FE::from(mus[3]);
+        data[base + bitwise_cols::MU_IS_BYTE] = FE::from(mus[4]);
+        data[base + bitwise_cols::MU_IS_HALF] = FE::from(mus[5]);
+        data[base + bitwise_cols::MU_IS_B20] = FE::from(mus[6]);
+        data[base + bitwise_cols::MU_HWSL] = FE::from(mus[7]);
     }
 
     TraceTable::new_main(data, bitwise_cols::NUM_COLUMNS, 1)

--- a/prover/src/tests/bitwise_bus_tests.rs
+++ b/prover/src/tests/bitwise_bus_tests.rs
@@ -215,10 +215,7 @@ fn create_custom_receiver_trace(rows: &[(u8, u8, u8, u8, u32)]) -> TraceTable<F,
     TraceTable::new_main(data, receiver_cols::NUM_COLUMNS, 1)
 }
 
-fn run_proof(
-    mut sender_trace: TraceTable<F, E>,
-    mut receiver_trace: TraceTable<F, E>,
-) -> bool {
+fn run_proof(mut sender_trace: TraceTable<F, E>, mut receiver_trace: TraceTable<F, E>) -> bool {
     let proof_options = ProofOptions::default_test_options();
     let sender_air = new_sender_air(&proof_options);
     let receiver_air = new_receiver_air(&proof_options);

--- a/prover/src/tests/bitwise_bus_tests.rs
+++ b/prover/src/tests/bitwise_bus_tests.rs
@@ -1,8 +1,13 @@
-//! Soundness and completeness tests for BITWISE table bus interactions.
+//! Soundness and completeness tests for the unified BITWISE bus.
 //!
-//! These tests verify that:
-//! - Completeness: Valid lookups to BITWISE are accepted
-//! - Soundness: Invalid lookups to BITWISE are rejected
+//! These tests model the real `BusId::Bitwise` protocol: a 4-element token
+//! `(op_id, X, Y, RESULT)` where `op_id = AND + 2*OR + 4*XOR` (disjoint-bit
+//! encoding). Z values 1, 2, 4 carry the AND, OR, XOR results; other Z
+//! values have RESULT = 0 and are absorbed only by accident on a malicious
+//! trace that bypasses IS_BIT + DECODE in the real CPU.
+//!
+//! The receiver here mirrors a slice of the BITWISE table: a single
+//! interaction on `BusId::Bitwise` with token `(Z, X, Y, RESULT)`.
 
 use std::collections::HashMap;
 
@@ -26,26 +31,28 @@ type F = GoldilocksField;
 type E = GoldilocksExtension;
 
 // =============================================================================
-// Column indices (simplified for testing)
+// Column indices (mirror the real 4-element token)
 // =============================================================================
 
-/// Sender table columns
+/// Sender table columns. Token sent: (OP_ID, X, Y, RESULT) with multiplicity MU.
 mod sender_cols {
-    pub const X: usize = 0;
-    pub const Y: usize = 1;
-    pub const AND_RESULT: usize = 2;
-    /// Flag indicating this row performs an AND operation (0 or 1)
-    pub const AND: usize = 3;
-    pub const NUM_COLUMNS: usize = 4;
+    pub const OP_ID: usize = 0;
+    pub const X: usize = 1;
+    pub const Y: usize = 2;
+    pub const RESULT: usize = 3;
+    /// Sender multiplicity (1 in honest traces; 0 on padding rows).
+    pub const MU: usize = 4;
+    pub const NUM_COLUMNS: usize = 5;
 }
 
-/// Receiver (BITWISE-like) table columns
+/// Receiver (BITWISE-like) table columns. Token received: (Z, X, Y, RESULT).
 mod receiver_cols {
-    pub const X: usize = 0;
-    pub const Y: usize = 1;
-    pub const AND: usize = 2;
-    pub const MU_AND: usize = 3;
-    pub const NUM_COLUMNS: usize = 4;
+    pub const Z: usize = 0;
+    pub const X: usize = 1;
+    pub const Y: usize = 2;
+    pub const RESULT: usize = 3;
+    pub const MU_BITWISE: usize = 4;
+    pub const NUM_COLUMNS: usize = 5;
 }
 
 // =============================================================================
@@ -60,8 +67,12 @@ fn new_sender_air(
     let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
         interactions: vec![BusInteraction::sender(
             BusId::Bitwise,
-            Multiplicity::Column(sender_cols::AND),
+            Multiplicity::Column(sender_cols::MU),
             vec![
+                BusValue::Packed {
+                    start_column: sender_cols::OP_ID,
+                    packing: Packing::Direct,
+                },
                 BusValue::Packed {
                     start_column: sender_cols::X,
                     packing: Packing::Direct,
@@ -71,7 +82,7 @@ fn new_sender_air(
                     packing: Packing::Direct,
                 },
                 BusValue::Packed {
-                    start_column: sender_cols::AND_RESULT,
+                    start_column: sender_cols::RESULT,
                     packing: Packing::Direct,
                 },
             ],
@@ -95,8 +106,12 @@ fn new_receiver_air(
     let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
         interactions: vec![BusInteraction::receiver(
             BusId::Bitwise,
-            Multiplicity::Column(receiver_cols::MU_AND),
+            Multiplicity::Column(receiver_cols::MU_BITWISE),
             vec![
+                BusValue::Packed {
+                    start_column: receiver_cols::Z,
+                    packing: Packing::Direct,
+                },
                 BusValue::Packed {
                     start_column: receiver_cols::X,
                     packing: Packing::Direct,
@@ -106,7 +121,7 @@ fn new_receiver_air(
                     packing: Packing::Direct,
                 },
                 BusValue::Packed {
-                    start_column: receiver_cols::AND,
+                    start_column: receiver_cols::RESULT,
                     packing: Packing::Direct,
                 },
             ],
@@ -123,66 +138,87 @@ fn new_receiver_air(
 }
 
 // =============================================================================
-// Helper functions
+// Helpers
 // =============================================================================
 
-fn create_sender_trace(lookups: &[(u8, u8, u8)]) -> TraceTable<F, E> {
+/// Honest result for a (op_id, x, y) triple.
+///
+/// Mirrors the precomputed RESULT in the BITWISE table:
+/// op_id = 1 → x & y, op_id = 2 → x | y, op_id = 4 → x ^ y, otherwise 0.
+fn honest_result(op_id: u8, x: u8, y: u8) -> u8 {
+    match op_id {
+        1 => x & y,
+        2 => x | y,
+        4 => x ^ y,
+        _ => 0,
+    }
+}
+
+/// Build a sender trace from `(op_id, x, y, result)` lookups, multiplicity 1.
+fn create_sender_trace(lookups: &[(u8, u8, u8, u8)]) -> TraceTable<F, E> {
     let num_rows = lookups.len().next_power_of_two().max(4);
     let mut data = vec![FE::zero(); num_rows * sender_cols::NUM_COLUMNS];
 
-    for (i, &(x, y, result)) in lookups.iter().enumerate() {
+    for (i, &(op_id, x, y, result)) in lookups.iter().enumerate() {
         let base = i * sender_cols::NUM_COLUMNS;
+        data[base + sender_cols::OP_ID] = FE::from(op_id as u64);
         data[base + sender_cols::X] = FE::from(x as u64);
         data[base + sender_cols::Y] = FE::from(y as u64);
-        data[base + sender_cols::AND_RESULT] = FE::from(result as u64);
-        data[base + sender_cols::AND] = FE::one(); // Flag: this row performs AND
+        data[base + sender_cols::RESULT] = FE::from(result as u64);
+        data[base + sender_cols::MU] = FE::one();
     }
 
     TraceTable::new_main(data, sender_cols::NUM_COLUMNS, 1)
 }
 
-/// Creates a receiver (BITWISE-like) trace with precomputed values.
+/// Build a receiver trace that auto-precomputes the honest RESULT for every
+/// `(op_id, x, y)` triple sent and accumulates the matching multiplicities.
 ///
-/// This function mimics the real BITWISE table behavior:
-/// 1. Precomputes the AND result for each unique (X, Y) combination
-/// 2. Updates multiplicities based on how many times each tuple is received from sender
-///
-/// # Arguments
-/// * `sender_lookups` - Tuples (X, Y, claimed_result) sent by the sender table
-fn create_receiver_trace(sender_lookups: &[(u8, u8, u8)]) -> TraceTable<F, E> {
-    // Count multiplicities for each unique (X, Y) pair from sender lookups
-    let mut multiplicities: HashMap<(u8, u8), u32> = HashMap::new();
-    for &(x, y, _) in sender_lookups {
-        *multiplicities.entry((x, y)).or_insert(0) += 1;
+/// This mirrors the real BITWISE behaviour: the precomputed table fixes
+/// RESULT for every (Z, X, Y), and only `MU_BITWISE` is witnessed.
+fn create_honest_receiver_trace(lookups: &[(u8, u8, u8, u8)]) -> TraceTable<F, E> {
+    let mut multiplicities: HashMap<(u8, u8, u8), u32> = HashMap::new();
+    for &(op_id, x, y, _) in lookups {
+        *multiplicities.entry((op_id, x, y)).or_insert(0) += 1;
     }
 
-    // Build precomputed table with AND results and multiplicities
-    let unique_rows: Vec<((u8, u8), u32)> = multiplicities.into_iter().collect();
-    let num_rows = unique_rows.len().next_power_of_two().max(4);
+    let unique: Vec<((u8, u8, u8), u32)> = multiplicities.into_iter().collect();
+    let num_rows = unique.len().next_power_of_two().max(4);
     let mut data = vec![FE::zero(); num_rows * receiver_cols::NUM_COLUMNS];
 
-    for (i, &((x, y), multiplicity)) in unique_rows.iter().enumerate() {
+    for (i, &((op_id, x, y), mu)) in unique.iter().enumerate() {
         let base = i * receiver_cols::NUM_COLUMNS;
-        // Precomputed values
+        data[base + receiver_cols::Z] = FE::from(op_id as u64);
         data[base + receiver_cols::X] = FE::from(x as u64);
         data[base + receiver_cols::Y] = FE::from(y as u64);
-        data[base + receiver_cols::AND] = FE::from((x & y) as u64); // Precomputed AND
-        // Multiplicity updated from sender lookups
-        data[base + receiver_cols::MU_AND] = FE::from(multiplicity as u64);
+        data[base + receiver_cols::RESULT] = FE::from(honest_result(op_id, x, y) as u64);
+        data[base + receiver_cols::MU_BITWISE] = FE::from(mu as u64);
     }
 
     TraceTable::new_main(data, receiver_cols::NUM_COLUMNS, 1)
 }
 
-/// Proves and verifies a sender-receiver interaction.
-///
-/// The receiver trace is automatically built from sender lookups, mimicking
-/// how the BITWISE table works: precomputed values with multiplicities
-/// updated based on received lookups.
-fn prove_and_verify(sender_lookups: &[(u8, u8, u8)]) -> bool {
-    let mut sender_trace = create_sender_trace(sender_lookups);
-    let mut receiver_trace = create_receiver_trace(sender_lookups);
+/// Build a fully manual receiver trace from `(z, x, y, result, mu)` rows.
+fn create_custom_receiver_trace(rows: &[(u8, u8, u8, u8, u32)]) -> TraceTable<F, E> {
+    let num_rows = rows.len().next_power_of_two().max(4);
+    let mut data = vec![FE::zero(); num_rows * receiver_cols::NUM_COLUMNS];
 
+    for (i, &(z, x, y, result, mu)) in rows.iter().enumerate() {
+        let base = i * receiver_cols::NUM_COLUMNS;
+        data[base + receiver_cols::Z] = FE::from(z as u64);
+        data[base + receiver_cols::X] = FE::from(x as u64);
+        data[base + receiver_cols::Y] = FE::from(y as u64);
+        data[base + receiver_cols::RESULT] = FE::from(result as u64);
+        data[base + receiver_cols::MU_BITWISE] = FE::from(mu as u64);
+    }
+
+    TraceTable::new_main(data, receiver_cols::NUM_COLUMNS, 1)
+}
+
+fn run_proof(
+    mut sender_trace: TraceTable<F, E>,
+    mut receiver_trace: TraceTable<F, E>,
+) -> bool {
     let proof_options = ProofOptions::default_test_options();
     let sender_air = new_sender_air(&proof_options);
     let receiver_air = new_receiver_air(&proof_options);
@@ -210,176 +246,195 @@ fn prove_and_verify(sender_lookups: &[(u8, u8, u8)]) -> bool {
     )
 }
 
+/// Sender lookups + auto-precomputed receiver. The bus balances iff every
+/// `(op_id, x, y, result)` matches the honest result for that op.
+fn prove_and_verify(lookups: &[(u8, u8, u8, u8)]) -> bool {
+    run_proof(
+        create_sender_trace(lookups),
+        create_honest_receiver_trace(lookups),
+    )
+}
+
+/// Sender lookups + manual receiver rows. Used to inject malicious receiver
+/// states (wrong RESULT, wrong multiplicity, missing rows, etc).
+fn prove_and_verify_custom(
+    sender_lookups: &[(u8, u8, u8, u8)],
+    receiver_rows: &[(u8, u8, u8, u8, u32)],
+) -> bool {
+    run_proof(
+        create_sender_trace(sender_lookups),
+        create_custom_receiver_trace(receiver_rows),
+    )
+}
+
 // =============================================================================
-// Completeness Tests - Valid lookups should be ACCEPTED
+// Completeness — valid lookups should be accepted for AND, OR, XOR
 // =============================================================================
 
 #[test]
-fn test_completeness_and_byte_simple() {
-    // Sender: AND_BYTE[5, 3] = 1 (correct: 5 & 3 = 1)
-    // Receiver: precomputed table has row (5, 3) with AND = 1, multiplicity = 1
-    let sender = vec![(5u8, 3u8, 1u8)];
-
-    assert!(prove_and_verify(&sender));
+fn test_completeness_and_simple() {
+    // op_id = 1 (AND): 5 & 3 = 1
+    assert!(prove_and_verify(&[(1, 5, 3, 1)]));
 }
 
 #[test]
-fn test_completeness_and_byte_zero_result() {
-    // 0xAA & 0x55 = 0 (alternating bits)
-    let sender = vec![(0xAAu8, 0x55u8, 0x00u8)];
-
-    assert!(prove_and_verify(&sender));
+fn test_completeness_and_zero_result() {
+    // 0xAA & 0x55 = 0
+    assert!(prove_and_verify(&[(1, 0xAA, 0x55, 0x00)]));
 }
 
 #[test]
-fn test_completeness_and_byte_max() {
-    // 0xFF & 0xFF = 0xFF
-    let sender = vec![(0xFFu8, 0xFFu8, 0xFFu8)];
-
-    assert!(prove_and_verify(&sender));
+fn test_completeness_and_max() {
+    assert!(prove_and_verify(&[(1, 0xFF, 0xFF, 0xFF)]));
 }
 
 #[test]
-fn test_completeness_multiple_lookups() {
-    // Multiple different lookups - receiver precomputes each and sets multiplicity = 1
-    let sender = vec![
-        (0xFFu8, 0xFFu8, 0xFFu8), // FF & FF = FF
-        (0xAAu8, 0x55u8, 0x00u8), // AA & 55 = 00
-        (0x0Fu8, 0xF0u8, 0x00u8), // 0F & F0 = 00
-        (0x12u8, 0x34u8, 0x10u8), // 12 & 34 = 10
+fn test_completeness_or_simple() {
+    // op_id = 2 (OR): 5 | 3 = 7
+    assert!(prove_and_verify(&[(2, 5, 3, 7)]));
+}
+
+#[test]
+fn test_completeness_or_alternating_bits() {
+    // 0xAA | 0x55 = 0xFF
+    assert!(prove_and_verify(&[(2, 0xAA, 0x55, 0xFF)]));
+}
+
+#[test]
+fn test_completeness_xor_simple() {
+    // op_id = 4 (XOR): 5 ^ 3 = 6
+    assert!(prove_and_verify(&[(4, 5, 3, 6)]));
+}
+
+#[test]
+fn test_completeness_xor_alternating_bits() {
+    // 0xAA ^ 0x55 = 0xFF
+    assert!(prove_and_verify(&[(4, 0xAA, 0x55, 0xFF)]));
+}
+
+#[test]
+fn test_completeness_mixed_ops() {
+    // Mix the three ops in a single trace.
+    let lookups = vec![
+        (1u8, 0x12u8, 0x34u8, 0x12u8 & 0x34u8),
+        (2u8, 0x12u8, 0x34u8, 0x12u8 | 0x34u8),
+        (4u8, 0x12u8, 0x34u8, 0x12u8 ^ 0x34u8),
+        (1u8, 0xFFu8, 0xFFu8, 0xFFu8),
     ];
-
-    assert!(prove_and_verify(&sender));
+    assert!(prove_and_verify(&lookups));
 }
 
 #[test]
 fn test_completeness_duplicate_lookups() {
-    // Same lookup multiple times - receiver precomputes once with multiplicity = 3
-    let sender = vec![
-        (5u8, 3u8, 1u8), // First lookup
-        (5u8, 3u8, 1u8), // Duplicate
-        (5u8, 3u8, 1u8), // Duplicate
-    ];
+    // Same (op_id, x, y) repeated three times → multiplicity 3 on a single row.
+    let lookups = vec![(1u8, 5u8, 3u8, 1u8); 3];
+    assert!(prove_and_verify(&lookups));
+}
 
-    assert!(prove_and_verify(&sender));
+#[test]
+fn test_completeness_branch_style_constant_op_id() {
+    // Mirrors branch.rs and shift.rs, which always emit op_id = 1 (AND) as a
+    // literal constant. Honest result for `unmasked & 0xFE`.
+    let lookups = vec![
+        (1u8, 0x12u8, 0xFEu8, 0x12u8 & 0xFEu8),
+        (1u8, 0xABu8, 0xFEu8, 0xABu8 & 0xFEu8),
+    ];
+    assert!(prove_and_verify(&lookups));
 }
 
 // =============================================================================
-// Soundness Tests - Invalid lookups should be REJECTED
+// Soundness — invalid lookups should be rejected
 // =============================================================================
 
-/// Creates a custom receiver trace for soundness tests.
-/// Allows specifying exact (X, Y, AND, multiplicity) tuples.
-fn create_custom_receiver_trace(rows: &[(u8, u8, u8, u32)]) -> TraceTable<F, E> {
-    let num_rows = rows.len().next_power_of_two().max(4);
-    let mut data = vec![FE::zero(); num_rows * receiver_cols::NUM_COLUMNS];
-
-    for (i, &(x, y, and_result, multiplicity)) in rows.iter().enumerate() {
-        let base = i * receiver_cols::NUM_COLUMNS;
-        data[base + receiver_cols::X] = FE::from(x as u64);
-        data[base + receiver_cols::Y] = FE::from(y as u64);
-        data[base + receiver_cols::AND] = FE::from(and_result as u64);
-        data[base + receiver_cols::MU_AND] = FE::from(multiplicity as u64);
-    }
-
-    TraceTable::new_main(data, receiver_cols::NUM_COLUMNS, 1)
-}
-
-/// Proves and verifies with a custom receiver trace (for soundness tests).
-fn prove_and_verify_custom(
-    sender_lookups: &[(u8, u8, u8)],
-    receiver_rows: &[(u8, u8, u8, u32)],
-) -> bool {
-    let mut sender_trace = create_sender_trace(sender_lookups);
-    let mut receiver_trace = create_custom_receiver_trace(receiver_rows);
-
-    let proof_options = ProofOptions::default_test_options();
-    let sender_air = new_sender_air(&proof_options);
-    let receiver_air = new_receiver_air(&proof_options);
-
-    let air_trace_pairs: Vec<(
-        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
-        _,
-        _,
-    )> = vec![
-        (&sender_air, &mut sender_trace, &()),
-        (&receiver_air, &mut receiver_trace, &()),
-    ];
-
-    let multi_proof =
-        Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[])).unwrap();
-
-    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
-        vec![&sender_air, &receiver_air];
-
-    Verifier::multi_verify(
-        &airs,
-        &multi_proof,
-        &mut DefaultTranscript::<E>::new(&[]),
-        &FieldElement::zero(),
-    )
+#[test]
+fn test_soundness_wrong_and_result() {
+    // 5 & 3 = 1, sender claims 99.
+    assert!(!prove_and_verify(&[(1, 5, 3, 99)]));
 }
 
 #[test]
-fn test_soundness_wrong_result() {
-    // Sender claims AND_BYTE[5, 3] = 99 (WRONG! Should be 1)
-    // Receiver has precomputed correct value 1, so verification should fail
-    let sender = vec![(5u8, 3u8, 99u8)];
-
-    assert!(!prove_and_verify(&sender));
+fn test_soundness_wrong_or_result() {
+    // 5 | 3 = 7, sender claims 0.
+    assert!(!prove_and_verify(&[(2, 5, 3, 0)]));
 }
 
 #[test]
-fn test_soundness_off_by_one() {
-    // Sender claims AND_BYTE[0xFF, 0xFF] = 0xFE (WRONG! Should be 0xFF)
-    let sender = vec![(0xFFu8, 0xFFu8, 0xFEu8)];
-
-    assert!(!prove_and_verify(&sender));
+fn test_soundness_wrong_xor_result() {
+    // 5 ^ 3 = 6, sender claims 5.
+    assert!(!prove_and_verify(&[(4, 5, 3, 5)]));
 }
 
 #[test]
-fn test_soundness_multiplicity_mismatch() {
-    // Sender sends 2 lookups for same value, but receiver has multiplicity 1
-    let sender = vec![
-        (5u8, 3u8, 1u8),
-        (5u8, 3u8, 1u8), // Duplicate!
-    ];
-    // Custom receiver with wrong multiplicity (1 instead of 2)
-    let receiver = vec![(5u8, 3u8, 1u8, 1u32)]; // multiplicity = 1, should be 2
-
+fn test_soundness_op_id_swapped() {
+    // Sender emits op_id = 2 (OR) but the receiver row is z = 1 (AND).
+    let sender = vec![(2u8, 5u8, 3u8, 7u8)]; // 5 | 3 = 7
+    let receiver = vec![(1u8, 5u8, 3u8, 5u8 & 3u8, 1u32)];
     assert!(!prove_and_verify_custom(&sender, &receiver));
 }
 
 #[test]
-fn test_soundness_missing_receiver_row() {
-    // Sender looks up (100, 200), but receiver only has (5, 3)
-    let sender = vec![(100u8, 200u8, 64u8)]; // 100 & 200 = 64
-    // Custom receiver with different row
-    let receiver = vec![(5u8, 3u8, 1u8, 1u32)]; // Different row!
-
+fn test_soundness_multiplicity_mismatch() {
+    // Sender sends two AND lookups, receiver claims multiplicity 1.
+    let sender = vec![(1u8, 5u8, 3u8, 1u8); 2];
+    let receiver = vec![(1u8, 5u8, 3u8, 1u8, 1u32)];
     assert!(!prove_and_verify_custom(&sender, &receiver));
 }
 
 #[test]
 fn test_soundness_swapped_inputs() {
-    // Sender: AND_BYTE[3, 5] = 1
-    // Receiver: has (5, 3) not (3, 5) - order matters!
-    let sender = vec![(3u8, 5u8, 1u8)]; // Note: X=3, Y=5
-    // Custom receiver with swapped inputs
-    let receiver = vec![(5u8, 3u8, 1u8, 1u32)]; // X=5, Y=3 - different input order
-
+    // Sender x=3, y=5; receiver row stores x=5, y=3 (different).
+    let sender = vec![(1u8, 3u8, 5u8, 1u8)];
+    let receiver = vec![(1u8, 5u8, 3u8, 1u8, 1u32)];
     assert!(!prove_and_verify_custom(&sender, &receiver));
 }
 
 #[test]
 fn test_soundness_extra_sender_lookup() {
-    // Sender sends 2 different lookups, but receiver only provides 1 row
-    let sender = vec![
-        (5u8, 3u8, 1u8),
-        (10u8, 6u8, 2u8), // Extra lookup not in receiver
-    ];
-    // Custom receiver missing the (10, 6) row
-    let receiver = vec![(5u8, 3u8, 1u8, 1u32)];
+    let sender = vec![(1u8, 5u8, 3u8, 1u8), (1u8, 10u8, 6u8, 2u8)];
+    let receiver = vec![(1u8, 5u8, 3u8, 1u8, 1u32)];
+    assert!(!prove_and_verify_custom(&sender, &receiver));
+}
 
+#[test]
+fn test_soundness_op_id_zero_with_nonzero_multiplicity() {
+    // op_id = 0 corresponds to "no op": no honest CPU sender ever emits a
+    // token with op_id = 0 and multiplicity > 0 (Sum3(AND, OR, XOR) = 0).
+    // A standalone receiver row at z = 0 with MU > 0 must not balance.
+    let sender: Vec<(u8, u8, u8, u8)> = vec![];
+    let receiver = vec![(0u8, 5u8, 3u8, 0u8, 1u32)];
+    assert!(!prove_and_verify_custom(&sender, &receiver));
+}
+
+// =============================================================================
+// Multi-flag attack — what the bus *cannot* prevent on its own
+// =============================================================================
+//
+// These tests document the soundness limit of the unified bus: in isolation
+// (without IS_BIT + DECODE on the sender's flag columns), a malicious prover
+// can balance the bus with op_id ∈ {3, 5, 6, 7} as long as RESULT = 0,
+// because BITWISE has precomputed rows at those Z values with RESULT = 0.
+// In production this is blocked by IS_BIT (force AND/OR/XOR ∈ {0,1}) and
+// the DECODE lookup (force at most one flag set). See cpu.rs and bitwise.rs
+// soundness comments.
+
+#[test]
+fn test_isolated_bus_accepts_op_id_3_with_zero_result() {
+    // op_id = 3 (would correspond to AND=OR=1 in the sender's flag columns,
+    // ruled out by IS_BIT + DECODE). RESULT = 0 matches the precomputed row
+    // at Z = 3, so the bus balances on its own — this is the gap that
+    // IS_BIT + DECODE close in production.
+    let sender = vec![(3u8, 5u8, 3u8, 0u8)];
+    let receiver = vec![(3u8, 5u8, 3u8, 0u8, 1u32)];
+    assert!(prove_and_verify_custom(&sender, &receiver));
+}
+
+#[test]
+fn test_isolated_bus_rejects_op_id_3_with_nonzero_result() {
+    // The Z = 3 precomputed row has RESULT = 0. A sender that emits a
+    // non-zero RESULT for op_id = 3 still cannot balance, because the
+    // fingerprint depends on RESULT — it would require a receiver row
+    // with that exact RESULT and matching multiplicity.
+    let sender = vec![(3u8, 5u8, 3u8, 1u8)];
+    let receiver = vec![(3u8, 5u8, 3u8, 0u8, 1u32)];
     assert!(!prove_and_verify_custom(&sender, &receiver));
 }

--- a/prover/src/tests/bitwise_bus_tests.rs
+++ b/prover/src/tests/bitwise_bus_tests.rs
@@ -59,7 +59,7 @@ fn new_sender_air(
 
     let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
         interactions: vec![BusInteraction::sender(
-            BusId::AndByte,
+            BusId::Bitwise,
             Multiplicity::Column(sender_cols::AND),
             vec![
                 BusValue::Packed {
@@ -94,7 +94,7 @@ fn new_receiver_air(
 
     let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
         interactions: vec![BusInteraction::receiver(
-            BusId::AndByte,
+            BusId::Bitwise,
             Multiplicity::Column(receiver_cols::MU_AND),
             vec![
                 BusValue::Packed {

--- a/prover/src/tests/bitwise_tests.rs
+++ b/prover/src/tests/bitwise_tests.rs
@@ -400,22 +400,29 @@ mod soundness_tests {
     type F = GoldilocksField;
     type E = GoldilocksExtension;
 
-    // Column indices for sender (CPU-like) table
+    // Column indices for sender (CPU-like) table.
+    // Token sent on BusId::Bitwise: (OP_ID, X, Y, AND_RESULT). OP_ID is fixed
+    // to 1 here (AND lane) — same shape branch.rs and shift.rs use against the
+    // unified bus, just with a witnessed AND_RESULT.
     mod sender_cols {
-        pub const X: usize = 0;
-        pub const Y: usize = 1;
-        pub const AND_RESULT: usize = 2;
-        pub const FLAG: usize = 3; // 1 = perform AND lookup
-        pub const NUM_COLUMNS: usize = 4;
+        pub const OP_ID: usize = 0;
+        pub const X: usize = 1;
+        pub const Y: usize = 2;
+        pub const AND_RESULT: usize = 3;
+        pub const FLAG: usize = 4; // 1 = perform AND lookup
+        pub const NUM_COLUMNS: usize = 5;
     }
 
-    // Column indices for receiver (BITWISE-like) table
+    // Column indices for receiver (BITWISE-like) table.
+    // Receives (Z, X, Y, AND). Z = 1 marks the AND lane (matches the real
+    // BITWISE table's discriminator).
     mod receiver_cols {
-        pub const X: usize = 0;
-        pub const Y: usize = 1;
-        pub const AND: usize = 2;
-        pub const MU_AND: usize = 3;
-        pub const NUM_COLUMNS: usize = 4;
+        pub const Z: usize = 0;
+        pub const X: usize = 1;
+        pub const Y: usize = 2;
+        pub const AND: usize = 3;
+        pub const MU_AND: usize = 4;
+        pub const NUM_COLUMNS: usize = 5;
     }
 
     fn create_sender_air(
@@ -429,6 +436,10 @@ mod soundness_tests {
                 BusId::Bitwise,
                 Multiplicity::Column(sender_cols::FLAG),
                 vec![
+                    BusValue::Packed {
+                        start_column: sender_cols::OP_ID,
+                        packing: Packing::Direct,
+                    },
                     BusValue::Packed {
                         start_column: sender_cols::X,
                         packing: Packing::Direct,
@@ -464,8 +475,8 @@ mod soundness_tests {
         proof_options: &ProofOptions,
         commitment: stark::config::Commitment,
     ) -> AirWithBuses<F, E, NullBoundaryConstraintBuilder, ()> {
-        // 3 precomputed columns: X, Y, AND (column 3 = MU_AND is multiplicity)
-        create_receiver_air_impl(proof_options, Some((commitment, 3)))
+        // 4 precomputed columns: Z, X, Y, AND (column 4 = MU_AND is multiplicity)
+        create_receiver_air_impl(proof_options, Some((commitment, 4)))
     }
 
     fn create_receiver_air_impl(
@@ -480,6 +491,10 @@ mod soundness_tests {
                 BusId::Bitwise,
                 Multiplicity::Column(receiver_cols::MU_AND),
                 vec![
+                    BusValue::Packed {
+                        start_column: receiver_cols::Z,
+                        packing: Packing::Direct,
+                    },
                     BusValue::Packed {
                         start_column: receiver_cols::X,
                         packing: Packing::Direct,
@@ -526,8 +541,8 @@ mod soundness_tests {
         // Create a dummy AIR just to get the domain parameters
         let dummy_air = create_receiver_air(proof_options);
 
-        // Use the prover's commitment computation (3 precomputed cols: X, Y, AND)
-        Prover::compute_precomputed_commitment_for_testing(trace, &dummy_air, 3)
+        // Use the prover's commitment computation (4 precomputed cols: Z, X, Y, AND)
+        Prover::compute_precomputed_commitment_for_testing(trace, &dummy_air, 4)
             .expect("Failed to compute commitment")
     }
 
@@ -535,7 +550,8 @@ mod soundness_tests {
         let num_rows = 4; // minimum power of 2
         let mut data = vec![FE::zero(); num_rows * sender_cols::NUM_COLUMNS];
 
-        // Row 0: perform AND lookup
+        // Row 0: perform AND lookup (op_id = 1)
+        data[sender_cols::OP_ID] = FE::one();
         data[sender_cols::X] = FE::from(x as u64);
         data[sender_cols::Y] = FE::from(y as u64);
         data[sender_cols::AND_RESULT] = FE::from(claimed_result as u64);
@@ -548,7 +564,8 @@ mod soundness_tests {
         let num_rows = 4;
         let mut data = vec![FE::zero(); num_rows * receiver_cols::NUM_COLUMNS];
 
-        // Row 0: MALICIOUS - wrong AND value!
+        // Row 0: MALICIOUS - wrong AND value at the AND lane (Z = 1).
+        data[receiver_cols::Z] = FE::one();
         data[receiver_cols::X] = FE::from(x as u64);
         data[receiver_cols::Y] = FE::from(y as u64);
         data[receiver_cols::AND] = FE::from(fake_and as u64); // WRONG!
@@ -561,8 +578,9 @@ mod soundness_tests {
         let num_rows = 4;
         let mut data = vec![FE::zero(); num_rows * receiver_cols::NUM_COLUMNS];
 
-        // Row 0: CORRECT AND value
+        // Row 0: CORRECT AND value at the AND lane (Z = 1).
         let correct_and = x & y;
+        data[receiver_cols::Z] = FE::one();
         data[receiver_cols::X] = FE::from(x as u64);
         data[receiver_cols::Y] = FE::from(y as u64);
         data[receiver_cols::AND] = FE::from(correct_and as u64);

--- a/prover/src/tests/bitwise_tests.rs
+++ b/prover/src/tests/bitwise_tests.rs
@@ -41,9 +41,22 @@ fn test_generate_bitwise_trace() {
     assert_eq!(row_data[cols::X], FE::from(5u64));
     assert_eq!(row_data[cols::Y], FE::from(3u64));
     assert_eq!(row_data[cols::Z], FE::from(0u64));
-    assert_eq!(row_data[cols::AND], FE::from(1u64)); // 5 & 3 = 1
-    assert_eq!(row_data[cols::OR], FE::from(7u64)); // 5 | 3 = 7
-    assert_eq!(row_data[cols::XOR], FE::from(6u64)); // 5 ^ 3 = 6
+    // z = 0 is outside the op_id set {1, 2, 4}: RESULT stays at 0.
+    assert_eq!(row_data[cols::RESULT], FE::from(0u64));
+
+    // AND/OR/XOR results live at z = 1 / 2 / 4 respectively.
+    assert_eq!(
+        trace.main_table.get_row(row_index(5, 3, 1))[cols::RESULT],
+        FE::from(1u64) // 5 & 3
+    );
+    assert_eq!(
+        trace.main_table.get_row(row_index(5, 3, 2))[cols::RESULT],
+        FE::from(7u64) // 5 | 3
+    );
+    assert_eq!(
+        trace.main_table.get_row(row_index(5, 3, 4))[cols::RESULT],
+        FE::from(6u64) // 5 ^ 3
+    );
 
     // Check MSB8 for x=128 (MSB set)
     let row = row_index(128, 0, 0);
@@ -94,8 +107,9 @@ fn test_zero_check() {
 #[test]
 fn test_bus_interactions_count() {
     let interactions = bus_interactions();
-    // Should have 10 interactions (one per lookup type; HWSLC merged into HWSL)
-    assert_eq!(interactions.len(), 10);
+    // 8 interactions: one unified Bitwise (AND/OR/XOR share Z-as-op_id),
+    // plus MSB8, MSB16, ZERO, IS_BYTE, IS_HALF, IS_B20, HWSL.
+    assert_eq!(interactions.len(), 8);
 }
 
 #[test]
@@ -108,9 +122,8 @@ fn test_first_row() {
     assert_eq!(row_data[cols::X], FE::from(0u64));
     assert_eq!(row_data[cols::Y], FE::from(0u64));
     assert_eq!(row_data[cols::Z], FE::from(0u64));
-    assert_eq!(row_data[cols::AND], FE::from(0u64)); // 0 & 0 = 0
-    assert_eq!(row_data[cols::OR], FE::from(0u64)); // 0 | 0 = 0
-    assert_eq!(row_data[cols::XOR], FE::from(0u64)); // 0 ^ 0 = 0
+    // z = 0 → RESULT = 0 by convention (outside op_id set {1, 2, 4}).
+    assert_eq!(row_data[cols::RESULT], FE::from(0u64));
     assert_eq!(row_data[cols::MSB8], FE::from(0u64)); // MSB of 0 = 0
     assert_eq!(row_data[cols::MSB16], FE::from(0u64)); // MSB of 0 = 0
     assert_eq!(row_data[cols::ZERO], FE::from(1u64)); // 0 and 0 are both zero
@@ -128,9 +141,8 @@ fn test_last_row() {
     assert_eq!(row_data[cols::X], FE::from(255u64));
     assert_eq!(row_data[cols::Y], FE::from(255u64));
     assert_eq!(row_data[cols::Z], FE::from(15u64));
-    assert_eq!(row_data[cols::AND], FE::from(255u64)); // 255 & 255 = 255
-    assert_eq!(row_data[cols::OR], FE::from(255u64)); // 255 | 255 = 255
-    assert_eq!(row_data[cols::XOR], FE::from(0u64)); // 255 ^ 255 = 0
+    // z = 15 is outside the op_id set {1, 2, 4}: RESULT = 0.
+    assert_eq!(row_data[cols::RESULT], FE::from(0u64));
     assert_eq!(row_data[cols::MSB8], FE::from(1u64)); // MSB of 255 = 1
     // halfword = 255 + 256*255 = 65535 = 0xFFFF, MSB is bit 15 = 1
     assert_eq!(row_data[cols::MSB16], FE::from(1u64));
@@ -190,22 +202,25 @@ fn test_shift_boundaries() {
 fn test_all_bitwise_operations() {
     let trace = generate_bitwise_trace();
 
-    // Test with x=0xAA, y=0x55 (alternating bits)
-    let row = row_index(0xAA, 0x55, 0);
-    let row_data = trace.main_table.get_row(row);
-
-    assert_eq!(row_data[cols::AND], FE::from(0u64)); // 0xAA & 0x55 = 0
-    assert_eq!(row_data[cols::OR], FE::from(0xFFu64)); // 0xAA | 0x55 = 0xFF
-    assert_eq!(row_data[cols::XOR], FE::from(0xFFu64)); // 0xAA ^ 0x55 = 0xFF
+    // Test with x=0xAA, y=0x55 (alternating bits); bitwise results live at z = 1, 2, 4.
+    let row_data = trace.main_table.get_row(row_index(0xAA, 0x55, 1));
+    assert_eq!(row_data[cols::RESULT], FE::from(0u64)); // 0xAA & 0x55 = 0
+    let row_data = trace.main_table.get_row(row_index(0xAA, 0x55, 2));
+    assert_eq!(row_data[cols::RESULT], FE::from(0xFFu64)); // 0xAA | 0x55 = 0xFF
+    let row_data = trace.main_table.get_row(row_index(0xAA, 0x55, 4));
+    assert_eq!(row_data[cols::RESULT], FE::from(0xFFu64)); // 0xAA ^ 0x55 = 0xFF
+    // MSB8 is not op-indexed by z; check on a z = 0 row.
+    let row_data = trace.main_table.get_row(row_index(0xAA, 0x55, 0));
     assert_eq!(row_data[cols::MSB8], FE::from(1u64)); // MSB of 0xAA = 1
 
     // Test with x=0x55, y=0xAA
-    let row = row_index(0x55, 0xAA, 0);
-    let row_data = trace.main_table.get_row(row);
-
-    assert_eq!(row_data[cols::AND], FE::from(0u64)); // 0x55 & 0xAA = 0
-    assert_eq!(row_data[cols::OR], FE::from(0xFFu64)); // 0x55 | 0xAA = 0xFF
-    assert_eq!(row_data[cols::XOR], FE::from(0xFFu64)); // 0x55 ^ 0xAA = 0xFF
+    let row_data = trace.main_table.get_row(row_index(0x55, 0xAA, 1));
+    assert_eq!(row_data[cols::RESULT], FE::from(0u64)); // 0x55 & 0xAA = 0
+    let row_data = trace.main_table.get_row(row_index(0x55, 0xAA, 2));
+    assert_eq!(row_data[cols::RESULT], FE::from(0xFFu64)); // 0x55 | 0xAA = 0xFF
+    let row_data = trace.main_table.get_row(row_index(0x55, 0xAA, 4));
+    assert_eq!(row_data[cols::RESULT], FE::from(0xFFu64)); // 0x55 ^ 0xAA = 0xFF
+    let row_data = trace.main_table.get_row(row_index(0x55, 0xAA, 0));
     assert_eq!(row_data[cols::MSB8], FE::from(0u64)); // MSB of 0x55 = 0
 }
 
@@ -249,7 +264,7 @@ fn test_generate_bitwise_row_matches_trace() {
         let const_row = generate_bitwise_row(idx);
         let trace_row = trace.main_table.get_row(idx);
 
-        // Verify all 11 precomputed columns match
+        // Verify all 9 precomputed columns match: [X, Y, Z, RESULT, MSB8, MSB16, ZERO, SLL, SLLC]
         assert_eq!(const_row.len(), NUM_PRECOMPUTED_COLS);
 
         assert_eq!(
@@ -269,41 +284,31 @@ fn test_generate_bitwise_row_matches_trace() {
         );
         assert_eq!(
             const_row[3],
-            trace_row[cols::AND].canonical_u64(),
-            "AND mismatch at index {idx}"
+            trace_row[cols::RESULT].canonical_u64(),
+            "RESULT mismatch at index {idx}"
         );
         assert_eq!(
             const_row[4],
-            trace_row[cols::OR].canonical_u64(),
-            "OR mismatch at index {idx}"
-        );
-        assert_eq!(
-            const_row[5],
-            trace_row[cols::XOR].canonical_u64(),
-            "XOR mismatch at index {idx}"
-        );
-        assert_eq!(
-            const_row[6],
             trace_row[cols::MSB8].canonical_u64(),
             "MSB8 mismatch at index {idx}"
         );
         assert_eq!(
-            const_row[7],
+            const_row[5],
             trace_row[cols::MSB16].canonical_u64(),
             "MSB16 mismatch at index {idx}"
         );
         assert_eq!(
-            const_row[8],
+            const_row[6],
             trace_row[cols::ZERO].canonical_u64(),
             "ZERO mismatch at index {idx}"
         );
         assert_eq!(
-            const_row[9],
+            const_row[7],
             trace_row[cols::SLL].canonical_u64(),
             "SLL mismatch at index {idx}"
         );
         assert_eq!(
-            const_row[10],
+            const_row[8],
             trace_row[cols::SLLC].canonical_u64(),
             "SLLC mismatch at index {idx}"
         );
@@ -421,7 +426,7 @@ mod soundness_tests {
         let transition_constraints: Vec<Box<dyn TransitionConstraintEvaluator<F, E>>> = vec![];
         let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
             interactions: vec![BusInteraction::sender(
-                BusId::AndByte,
+                BusId::Bitwise,
                 Multiplicity::Column(sender_cols::FLAG),
                 vec![
                     BusValue::Packed {
@@ -472,7 +477,7 @@ mod soundness_tests {
         let transition_constraints: Vec<Box<dyn TransitionConstraintEvaluator<F, E>>> = vec![];
         let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
             interactions: vec![BusInteraction::receiver(
-                BusId::AndByte,
+                BusId::Bitwise,
                 Multiplicity::Column(receiver_cols::MU_AND),
                 vec![
                     BusValue::Packed {

--- a/prover/src/tests/cpu_tests.rs
+++ b/prover/src/tests/cpu_tests.rs
@@ -310,9 +310,7 @@ fn test_bus_interactions_count() {
     let interactions = bus_interactions();
 
     // Expected interactions:
-    // - 8 AND_BYTE
-    // - 8 OR_BYTE
-    // - 8 XOR_BYTE
+    // - 8 BITWISE (unified AND/OR/XOR, one per byte, op_id = AND + 2*OR + 4*XOR)
     // - 2 MSB16 (rv1_sign_bit, arg2_sign_bit)
     // - 1 MSB8 (res_sign_bit)
     // - 1 ZERO (is_equal for BEQ)
@@ -332,9 +330,8 @@ fn test_bus_interactions_count() {
     // - 1 IS_BYTE for (RS1, RS2) paired
     // - 1 IS_BYTE for (RD, 0)
     // - 12 IS_BYTE (ARG1/ARG2/RES byte pairs: 4 pairs × 3 arrays)
-    // Inline PC replaces CM54: -1 CM54, +4 inline PC → net +3 vs pre-PR main.
-    // Total: 8 + 8 + 8 + 2 + 1 + 1 + 1 + 1 + 5 + 4 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 12 = 58
-    assert_eq!(interactions.len(), 58);
+    // Total: 8 + 2 + 1 + 1 + 1 + 1 + 1 + 1 + 5 + 4 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 12 = 42
+    assert_eq!(interactions.len(), 42);
 }
 
 #[test]

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -23,7 +23,7 @@ use stark::traits::AIR;
 use stark::verifier::{IsStarkVerifier, Verifier};
 
 use crate::tables::trace_builder::Traces;
-use crate::tables::types::{GoldilocksExtension, GoldilocksField};
+use crate::tables::types::{BusId, GoldilocksExtension, GoldilocksField};
 
 use executor::elf::Elf;
 
@@ -1006,7 +1006,7 @@ fn test_debug_memory_bus_tokens() {
 
     let z: i128 = 1000;
     let alpha: i128 = 2;
-    let bus_id: i128 = 16; // BusId::Memory
+    let bus_id: i128 = u64::from(BusId::Memory) as i128;
 
     // Compute fingerprint for a token
     let fingerprint =

--- a/prover/src/tests/trace_builder_tests.rs
+++ b/prover/src/tests/trace_builder_tests.rs
@@ -268,10 +268,10 @@ fn test_bitwise_lookups_collected() {
 
     let traces = Traces::from_logs(&logs, instructions, &Default::default()).unwrap();
 
-    // Check AND multiplicity was updated for (0x12, 0x34, 0)
-    let row_idx = bitwise::row_index(0x12, 0x34, 0);
+    // AND ops route to the unified MU_BITWISE at row (x, y, 1).
+    let row_idx = bitwise::row_index(0x12, 0x34, 1);
     let row = traces.bitwise.main_table.get_row(row_idx);
-    assert_eq!(row[bitwise::cols::MU_AND], FE::one());
+    assert_eq!(row[bitwise::cols::MU_BITWISE], FE::one());
 }
 
 #[test]


### PR DESCRIPTION
Collapses three bus IDs (AndByte, OrByte, XorByte) into a single BusId::Bitwise. CPU sends 8 interactions for bitwise byte ops instead of 24, and the BITWISE preprocessed table has one receiver instead of three.

Design. The sender's token is
    (op_id, X, Y, RESULT)
with
    op_id        = AND + 2*OR + 4*XOR    (disjoint-bit encoding)
    multiplicity = AND + OR + XOR        (at most one)

On the receiver side, the existing 4-bit Z column doubles as the op_id discriminator: rows with Z = 1 / 2 / 4 carry the AND / OR / XOR result in a unified RESULT column.

Soundness of at-most-one. IS_BIT on each flag (unchanged) gives op_id in {0, 1, 2, 4}. If a malicious prover sets two flags to 1, op_id lands in {3, 5, 6, 7}: no preprocessed row with non-zero MU_BITWISE exists at those z values, so the memory argument rejects the token. No dedicated mutex constraint needed.

Preprocessed table changes (2^20 rows, unchanged count):
- Columns 21 -> 17 (AND, OR, XOR data cols + MU_AND, MU_OR, MU_XOR removed; RESULT + MU_BITWISE added)
- update_multiplicities routes AND -> (x, y, 1), OR -> (x, y, 2), XOR -> (x, y, 4) against MU_BITWISE; other op types unchanged

Callers updated: CPU (8 senders), branch.rs (one AND lookup), shift.rs (three AND lookups), tests and test_utils.

266 non-ELF prover tests pass; 123/123 stark tests pass (including all 71 bus soundness tests). ELF-based tests require fresh program binaries and pass in CI.