### PR TITLE
refactor(prover): centralize u64 limb decomposition into a limbs helper

### DIFF
--- a/prover/src/tables/branch.rs
+++ b/prover/src/tables/branch.rs
@@ -33,6 +33,7 @@ use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing}
 use stark::table::TableView;
 use stark::trace::TraceTable;
 
+use super::limbs::set_limbs_32;
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField, SHIFT_16, alu_op};
 
 // =========================================================================
@@ -173,18 +174,6 @@ pub fn generate_branch_trace(
     for (row_idx, (op, multiplicity)) in unique_ops.iter().enumerate() {
         let base = row_idx * cols::NUM_COLUMNS;
 
-        // Extract pc as DWordWL: [Word, Word]
-        let pc_0 = (op.pc & 0xFFFF_FFFF) as u32;
-        let pc_1 = (op.pc >> 32) as u32;
-
-        // Extract offset as DWordWL: [Word, Word]
-        let offset_0 = (op.offset & 0xFFFF_FFFF) as u32;
-        let offset_1 = (op.offset >> 32) as u32;
-
-        // Extract register as DWordWL: [Word, Word]
-        let register_0 = (op.register & 0xFFFF_FFFF) as u32;
-        let register_1 = (op.register >> 32) as u32;
-
         // Compute next_pc
         let next_pc_unmasked = op.compute_next_pc_unmasked();
         let next_pc = op.compute_next_pc();
@@ -203,12 +192,9 @@ pub fn generate_branch_trace(
         let next_pc_high_2 = ((next_pc >> 48) & 0xFFFF) as u16;
 
         // Store columns
-        data[base + cols::PC_0] = FE::from(pc_0 as u64);
-        data[base + cols::PC_1] = FE::from(pc_1 as u64);
-        data[base + cols::OFFSET_0] = FE::from(offset_0 as u64);
-        data[base + cols::OFFSET_1] = FE::from(offset_1 as u64);
-        data[base + cols::REGISTER_0] = FE::from(register_0 as u64);
-        data[base + cols::REGISTER_1] = FE::from(register_1 as u64);
+        set_limbs_32(&mut data, base + cols::PC_0, op.pc);
+        set_limbs_32(&mut data, base + cols::OFFSET_0, op.offset);
+        set_limbs_32(&mut data, base + cols::REGISTER_0, op.register);
         data[base + cols::JALR] = FE::from(if op.jalr { 1u64 } else { 0u64 });
         data[base + cols::NEXT_PC_HIGH_0] = FE::from(next_pc_high_0 as u64);
         data[base + cols::NEXT_PC_HIGH_1] = FE::from(next_pc_high_1 as u64);

--- a/prover/src/tables/commit.rs
+++ b/prover/src/tables/commit.rs
@@ -53,6 +53,7 @@ use stark::trace::TraceTable;
 use crate::constraints::templates::{AddConstraint, AddOperand};
 
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
+use super::limbs::{set_limbs_16, set_limbs_32};
 
 // =========================================================================
 // Column indices for COMMIT table
@@ -170,26 +171,20 @@ pub fn generate_commit_trace(
         let base = row_idx * cols::NUM_COLUMNS;
 
         // Timestamp (DWordWL)
-        data[base + cols::TIMESTAMP_0] = FE::from(op.timestamp & 0xFFFF_FFFF);
-        data[base + cols::TIMESTAMP_1] = FE::from(op.timestamp >> 32);
+        set_limbs_32(&mut data, base + cols::TIMESTAMP_0, op.timestamp);
 
         // Index (BaseField)
         data[base + cols::INDEX] = FE::from(op.index);
 
         // Address (DWordWL)
-        data[base + cols::ADDRESS_0] = FE::from(op.address & 0xFFFF_FFFF);
-        data[base + cols::ADDRESS_1] = FE::from(op.address >> 32);
+        set_limbs_32(&mut data, base + cols::ADDRESS_0, op.address);
 
         // address_incr = address + 1 (DWordHL: 4 halfwords)
         let address_incr = op.address.wrapping_add(1);
-        data[base + cols::ADDRESS_INCR_0] = FE::from(address_incr & 0xFFFF);
-        data[base + cols::ADDRESS_INCR_1] = FE::from((address_incr >> 16) & 0xFFFF);
-        data[base + cols::ADDRESS_INCR_2] = FE::from((address_incr >> 32) & 0xFFFF);
-        data[base + cols::ADDRESS_INCR_3] = FE::from((address_incr >> 48) & 0xFFFF);
+        set_limbs_16(&mut data, base + cols::ADDRESS_INCR_0, address_incr);
 
         // Count (DWordWL)
-        data[base + cols::COUNT_0] = FE::from(op.count & 0xFFFF_FFFF);
-        data[base + cols::COUNT_1] = FE::from(op.count >> 32);
+        set_limbs_32(&mut data, base + cols::COUNT_0, op.count);
 
         // count_decr: if count == 0, use 0xFFFF_FFFF_FFFF_FFFF; else count - 1
         let count_decr = if op.count == 0 {
@@ -197,10 +192,7 @@ pub fn generate_commit_trace(
         } else {
             op.count - 1
         };
-        data[base + cols::COUNT_DECR_0] = FE::from(count_decr & 0xFFFF);
-        data[base + cols::COUNT_DECR_1] = FE::from((count_decr >> 16) & 0xFFFF);
-        data[base + cols::COUNT_DECR_2] = FE::from((count_decr >> 32) & 0xFFFF);
-        data[base + cols::COUNT_DECR_3] = FE::from((count_decr >> 48) & 0xFFFF);
+        set_limbs_16(&mut data, base + cols::COUNT_DECR_0, count_decr);
 
         // Control bits
         data[base + cols::FIRST] = FE::from(op.first as u64);

--- a/prover/src/tables/commit.rs
+++ b/prover/src/tables/commit.rs
@@ -52,8 +52,8 @@ use stark::trace::TraceTable;
 
 use crate::constraints::templates::{AddConstraint, AddOperand};
 
-use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
 use super::limbs::{set_limbs_16, set_limbs_32};
+use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
 
 // =========================================================================
 // Column indices for COMMIT table

--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -25,6 +25,7 @@
 //! `mem_flags` column is used directly as `JALR` wherever it is gated by `BRANCH`.
 
 use super::types::{BusId, DecodeEntry, FE, GoldilocksExtension, GoldilocksField, alu_op};
+use super::limbs::set_limbs_32;
 use crate::Error;
 use executor::vm::{
     instruction::{decoding::Instruction, execution::SyscallNumbers},
@@ -451,8 +452,7 @@ pub fn generate_cpu_trace(
         let effective = |flag: bool| (!word && flag) as u64;
 
         data[base + cols::TIMESTAMP] = FE::from(op.timestamp);
-        data[base + cols::PC_0] = FE::from(op.decode.pc & 0xFFFF_FFFF);
-        data[base + cols::PC_1] = FE::from(op.decode.pc >> 32);
+        set_limbs_32(&mut data, base + cols::PC_0, op.decode.pc);
 
         // rs1/rs2/rd and read/write flags are only present on non-word rows.
         let (rs1, rs2, rd) = if word {
@@ -480,8 +480,7 @@ pub fn generate_cpu_trace(
             (op.decode.imm, op.rvd, op.rv1, op.rv2, op.arg2, op.res)
         };
 
-        data[base + cols::IMM_0] = FE::from(imm & 0xFFFF_FFFF);
-        data[base + cols::IMM_1] = FE::from(imm >> 32);
+        set_limbs_32(&mut data, base + cols::IMM_0, imm);
 
         data[base + cols::HALF_INSTRUCTION_LENGTH] = FE::from(f.half_instruction_length as u64);
         data[base + cols::WORD_INSTR] = FE::from(word as u64);
@@ -495,19 +494,14 @@ pub fn generate_cpu_trace(
         data[base + cols::BRANCH] = FE::from(effective(f.branch));
         data[base + cols::ECALL] = FE::from(effective(f.ecall));
 
-        data[base + cols::NEXT_PC_0] = FE::from(op.next_pc & 0xFFFF_FFFF);
-        data[base + cols::NEXT_PC_1] = FE::from(op.next_pc >> 32);
+        set_limbs_32(&mut data, base + cols::NEXT_PC_0, op.next_pc);
 
-        data[base + cols::RVD_0] = FE::from(rvd & 0xFFFF_FFFF);
-        data[base + cols::RVD_1] = FE::from(rvd >> 32);
+        set_limbs_32(&mut data, base + cols::RVD_0, rvd);
 
         // rv1/rv2/arg2 as DWordWL (2 × 32-bit words).
-        data[base + cols::RV1_0] = FE::from(rv1 & 0xFFFF_FFFF);
-        data[base + cols::RV1_1] = FE::from(rv1 >> 32);
-        data[base + cols::RV2_0] = FE::from(rv2 & 0xFFFF_FFFF);
-        data[base + cols::RV2_1] = FE::from(rv2 >> 32);
-        data[base + cols::ARG2_0] = FE::from(arg2 & 0xFFFF_FFFF);
-        data[base + cols::ARG2_1] = FE::from(arg2 >> 32);
+        set_limbs_32(&mut data, base + cols::RV1_0, rv1);
+        set_limbs_32(&mut data, base + cols::RV2_0, rv2);
+        set_limbs_32(&mut data, base + cols::ARG2_0, arg2);
 
         // res as DWordHL (4 × 16-bit halves).
         for i in 0..4 {

--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -24,8 +24,8 @@
 //! JALR bit (the memory-width bits are 0), so `mem_flags ∈ {0,1} = JALR` and the
 //! `mem_flags` column is used directly as `JALR` wherever it is gated by `BRANCH`.
 
-use super::types::{BusId, DecodeEntry, FE, GoldilocksExtension, GoldilocksField, alu_op};
 use super::limbs::set_limbs_32;
+use super::types::{BusId, DecodeEntry, FE, GoldilocksExtension, GoldilocksField, alu_op};
 use crate::Error;
 use executor::vm::{
     instruction::{decoding::Instruction, execution::SyscallNumbers},

--- a/prover/src/tables/cpu32.rs
+++ b/prover/src/tables/cpu32.rs
@@ -24,6 +24,7 @@ use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing}
 use stark::table::TableView;
 use stark::trace::TraceTable;
 
+use super::limbs::{set_limbs_16, set_limbs_32};
 use super::types::{
     BusId, FE, GoldilocksExtension, GoldilocksField, SHIFT_16, alu_op, packed_decode_shrunk,
 };
@@ -204,10 +205,8 @@ pub fn generate_cpu32_trace(
         let aux = op.compute_aux();
 
         // Inputs
-        data[base + cols::TIMESTAMP_0] = FE::from(op.timestamp & 0xFFFF_FFFF);
-        data[base + cols::TIMESTAMP_1] = FE::from(op.timestamp >> 32);
-        data[base + cols::PC_0] = FE::from(op.pc & 0xFFFF_FFFF);
-        data[base + cols::PC_1] = FE::from(op.pc >> 32);
+        set_limbs_32(&mut data, base + cols::TIMESTAMP_0, op.timestamp);
+        set_limbs_32(&mut data, base + cols::PC_0, op.pc);
 
         // rv1 as DWordWHH: [Half, Half, Word]
         data[base + cols::RS1] = FE::from(op.rs1 as u64);
@@ -216,8 +215,7 @@ pub fn generate_cpu32_trace(
         data[base + cols::RV1_1] = FE::from((op.rv1 >> 16) & 0xFFFF);
         data[base + cols::RV1_2] = FE::from(op.rv1 >> 32);
         data[base + cols::RV1_SIGN] = FE::from(aux.rv1_sign as u64);
-        data[base + cols::ARG1_0] = FE::from(aux.arg1 & 0xFFFF_FFFF);
-        data[base + cols::ARG1_1] = FE::from(aux.arg1 >> 32);
+        set_limbs_32(&mut data, base + cols::ARG1_0, aux.arg1);
 
         // rv2 as DWordWHH
         data[base + cols::RS2] = FE::from(op.rs2 as u64);
@@ -226,23 +224,17 @@ pub fn generate_cpu32_trace(
         data[base + cols::RV2_1] = FE::from((op.rv2 >> 16) & 0xFFFF);
         data[base + cols::RV2_2] = FE::from(op.rv2 >> 32);
         data[base + cols::RV2_SIGN] = FE::from(aux.rv2_sign as u64);
-        data[base + cols::IMM_0] = FE::from(op.imm & 0xFFFF_FFFF);
-        data[base + cols::IMM_1] = FE::from(op.imm >> 32);
-        data[base + cols::ARG2_0] = FE::from(aux.arg2 & 0xFFFF_FFFF);
-        data[base + cols::ARG2_1] = FE::from(aux.arg2 >> 32);
+        set_limbs_32(&mut data, base + cols::IMM_0, op.imm);
+        set_limbs_32(&mut data, base + cols::ARG2_0, aux.arg2);
 
         // res as DWordHL: 4 halves
-        data[base + cols::RES_0] = FE::from(op.res & 0xFFFF);
-        data[base + cols::RES_1] = FE::from((op.res >> 16) & 0xFFFF);
-        data[base + cols::RES_2] = FE::from((op.res >> 32) & 0xFFFF);
-        data[base + cols::RES_3] = FE::from((op.res >> 48) & 0xFFFF);
+        set_limbs_16(&mut data, base + cols::RES_0, op.res);
         data[base + cols::RES_SIGN] = FE::from(aux.res_sign as u64);
 
         // rd write
         data[base + cols::RD] = FE::from(op.rd as u64);
         data[base + cols::WRITE_REGISTER] = FE::from(op.write_register as u64);
-        data[base + cols::RVD_0] = FE::from(aux.rvd & 0xFFFF_FFFF);
-        data[base + cols::RVD_1] = FE::from(aux.rvd >> 32);
+        set_limbs_32(&mut data, base + cols::RVD_0, aux.rvd);
 
         // ALU control
         data[base + cols::ALU] = FE::from(op.alu as u64);

--- a/prover/src/tables/decode.rs
+++ b/prover/src/tables/decode.rs
@@ -42,6 +42,7 @@ use stark::proof::options::ProofOptions;
 use stark::prover::evaluate_polynomial_on_lde_domain;
 use stark::trace::{TraceTable, columns2rows};
 
+use super::limbs::set_limbs_32;
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
 
 // Re-export DecodeEntry from types for backwards compatibility
@@ -135,15 +136,13 @@ pub fn generate_decode_trace(
         let base = row_idx * cols::NUM_COLUMNS;
 
         // PC as DWordWL
-        data[base + cols::PC_0] = FE::from(entry.pc & 0xFFFF_FFFF);
-        data[base + cols::PC_1] = FE::from(entry.pc >> 32);
+        set_limbs_32(&mut data, base + cols::PC_0, entry.pc);
 
         // packed_decode
         data[base + cols::PACKED_DECODE] = FE::from(entry.packed_decode());
 
         // imm as DWordWL
-        data[base + cols::IMM_0] = FE::from(entry.imm & 0xFFFF_FFFF);
-        data[base + cols::IMM_1] = FE::from(entry.imm >> 32);
+        set_limbs_32(&mut data, base + cols::IMM_0, entry.imm);
 
         // MU = 0 (already zero from vec initialization)
     }
@@ -151,11 +150,9 @@ pub fn generate_decode_trace(
     // Write CPU padding entry (pc=1, all flags=0)
     {
         let base = cpu_padding_row * cols::NUM_COLUMNS;
-        data[base + cols::PC_0] = FE::from(cpu_padding_entry.pc & 0xFFFF_FFFF);
-        data[base + cols::PC_1] = FE::from(cpu_padding_entry.pc >> 32);
+        set_limbs_32(&mut data, base + cols::PC_0, cpu_padding_entry.pc);
         data[base + cols::PACKED_DECODE] = FE::from(cpu_padding_entry.packed_decode());
-        data[base + cols::IMM_0] = FE::from(cpu_padding_entry.imm & 0xFFFF_FFFF);
-        data[base + cols::IMM_1] = FE::from(cpu_padding_entry.imm >> 32);
+        set_limbs_32(&mut data, base + cols::IMM_0, cpu_padding_entry.imm);
     }
 
     // Fill padding rows with the DECODE padding pattern: odd pc=1, all flags 0
@@ -164,11 +161,9 @@ pub fn generate_decode_trace(
     for row_idx in num_entries..num_rows {
         let base = row_idx * cols::NUM_COLUMNS;
 
-        data[base + cols::PC_0] = FE::from(padding_entry.pc & 0xFFFF_FFFF);
-        data[base + cols::PC_1] = FE::from(padding_entry.pc >> 32);
+        set_limbs_32(&mut data, base + cols::PC_0, padding_entry.pc);
         data[base + cols::PACKED_DECODE] = FE::from(padding_entry.packed_decode());
-        data[base + cols::IMM_0] = FE::from(padding_entry.imm & 0xFFFF_FFFF);
-        data[base + cols::IMM_1] = FE::from(padding_entry.imm >> 32);
+        set_limbs_32(&mut data, base + cols::IMM_0, padding_entry.imm);
         // MU = 0 for padding rows (already zero from vec initialization)
     }
 
@@ -407,32 +402,26 @@ fn build_decode_table(
     // Fill actual entries
     for (row_idx, entry) in entries.iter().enumerate() {
         let base = row_idx * cols::NUM_COLUMNS;
-        data[base + cols::PC_0] = FE::from(entry.pc & 0xFFFF_FFFF);
-        data[base + cols::PC_1] = FE::from(entry.pc >> 32);
+        set_limbs_32(&mut data, base + cols::PC_0, entry.pc);
         data[base + cols::PACKED_DECODE] = FE::from(entry.packed_decode());
-        data[base + cols::IMM_0] = FE::from(entry.imm & 0xFFFF_FFFF);
-        data[base + cols::IMM_1] = FE::from(entry.imm >> 32);
+        set_limbs_32(&mut data, base + cols::IMM_0, entry.imm);
     }
 
     // Write CPU padding entry
     {
         let base = cpu_padding_row * cols::NUM_COLUMNS;
-        data[base + cols::PC_0] = FE::from(cpu_padding_entry.pc & 0xFFFF_FFFF);
-        data[base + cols::PC_1] = FE::from(cpu_padding_entry.pc >> 32);
+        set_limbs_32(&mut data, base + cols::PC_0, cpu_padding_entry.pc);
         data[base + cols::PACKED_DECODE] = FE::from(cpu_padding_entry.packed_decode());
-        data[base + cols::IMM_0] = FE::from(cpu_padding_entry.imm & 0xFFFF_FFFF);
-        data[base + cols::IMM_1] = FE::from(cpu_padding_entry.imm >> 32);
+        set_limbs_32(&mut data, base + cols::IMM_0, cpu_padding_entry.imm);
     }
 
     // Fill padding rows with DECODE padding pattern
     let padding_entry = DecodeEntry::padding_entry();
     for row_idx in num_entries..num_rows {
         let base = row_idx * cols::NUM_COLUMNS;
-        data[base + cols::PC_0] = FE::from(padding_entry.pc & 0xFFFF_FFFF);
-        data[base + cols::PC_1] = FE::from(padding_entry.pc >> 32);
+        set_limbs_32(&mut data, base + cols::PC_0, padding_entry.pc);
         data[base + cols::PACKED_DECODE] = FE::from(padding_entry.packed_decode());
-        data[base + cols::IMM_0] = FE::from(padding_entry.imm & 0xFFFF_FFFF);
-        data[base + cols::IMM_1] = FE::from(padding_entry.imm >> 32);
+        set_limbs_32(&mut data, base + cols::IMM_0, padding_entry.imm);
     }
 
     TraceTable::new_main(data, cols::NUM_COLUMNS, 1)

--- a/prover/src/tables/dvrm.rs
+++ b/prover/src/tables/dvrm.rs
@@ -38,11 +38,11 @@ use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing}
 use stark::table::TableView;
 use stark::trace::TraceTable;
 
+use super::limbs::{set_limbs_16, set_limbs_32};
 use super::types::{
     BusId, FE, GoldilocksExtension, GoldilocksField, NEG_INV_2_16, NEG_INV_2_32, NEG_INV_2_48,
     NEG_INV_2_64, SHIFT_16, alu_op,
 };
-use super::limbs::{set_limbs_16, set_limbs_32};
 
 // =========================================================================
 // Column indices for DVRM table

--- a/prover/src/tables/dvrm.rs
+++ b/prover/src/tables/dvrm.rs
@@ -42,6 +42,7 @@ use super::types::{
     BusId, FE, GoldilocksExtension, GoldilocksField, NEG_INV_2_16, NEG_INV_2_32, NEG_INV_2_48,
     NEG_INV_2_64, SHIFT_16, alu_op,
 };
+use super::limbs::{set_limbs_16, set_limbs_32};
 
 // =========================================================================
 // Column indices for DVRM table
@@ -312,47 +313,23 @@ pub fn generate_dvrm_trace(
         let abs_r = op.abs_r();
         let abs_d = op.abs_d();
 
-        // Fill n as DWordHL (4 halfwords)
-        data[base + cols::N_0] = FE::from(op.n & 0xFFFF);
-        data[base + cols::N_1] = FE::from((op.n >> 16) & 0xFFFF);
-        data[base + cols::N_2] = FE::from((op.n >> 32) & 0xFFFF);
-        data[base + cols::N_3] = FE::from((op.n >> 48) & 0xFFFF);
-
-        // Fill d as DWordHL (4 halfwords)
-        data[base + cols::D_0] = FE::from(op.d & 0xFFFF);
-        data[base + cols::D_1] = FE::from((op.d >> 16) & 0xFFFF);
-        data[base + cols::D_2] = FE::from((op.d >> 32) & 0xFFFF);
-        data[base + cols::D_3] = FE::from((op.d >> 48) & 0xFFFF);
+        // Fill n/d/q/r as DWordHL (4 halfwords each)
+        set_limbs_16(&mut data, base + cols::N_0, op.n);
+        set_limbs_16(&mut data, base + cols::D_0, op.d);
 
         data[base + cols::SIGNED] = FE::from(op.signed as u64);
 
-        // Fill q as DWordHL (4 halfwords)
-        data[base + cols::Q_0] = FE::from(q & 0xFFFF);
-        data[base + cols::Q_1] = FE::from((q >> 16) & 0xFFFF);
-        data[base + cols::Q_2] = FE::from((q >> 32) & 0xFFFF);
-        data[base + cols::Q_3] = FE::from((q >> 48) & 0xFFFF);
-
-        // Fill r as DWordHL (4 halfwords)
-        data[base + cols::R_0] = FE::from(r & 0xFFFF);
-        data[base + cols::R_1] = FE::from((r >> 16) & 0xFFFF);
-        data[base + cols::R_2] = FE::from((r >> 32) & 0xFFFF);
-        data[base + cols::R_3] = FE::from((r >> 48) & 0xFFFF);
+        set_limbs_16(&mut data, base + cols::Q_0, q);
+        set_limbs_16(&mut data, base + cols::R_0, r);
 
         // Fill auxiliary columns
         data[base + cols::DIV_BY_ZERO] = FE::from(op.is_div_by_zero() as u64);
         data[base + cols::OVERFLOW] = FE::from(op.is_overflow() as u64);
 
-        data[base + cols::ABS_R_0] = FE::from(abs_r & 0xFFFF_FFFF);
-        data[base + cols::ABS_R_1] = FE::from(abs_r >> 32);
+        set_limbs_32(&mut data, base + cols::ABS_R_0, abs_r);
+        set_limbs_32(&mut data, base + cols::ABS_D_0, abs_d);
 
-        data[base + cols::ABS_D_0] = FE::from(abs_d & 0xFFFF_FFFF);
-        data[base + cols::ABS_D_1] = FE::from(abs_d >> 32);
-
-        // Fill n_sub_r as DWordHL (4 halfwords)
-        data[base + cols::N_SUB_R_0] = FE::from(n_sub_r & 0xFFFF);
-        data[base + cols::N_SUB_R_1] = FE::from((n_sub_r >> 16) & 0xFFFF);
-        data[base + cols::N_SUB_R_2] = FE::from((n_sub_r >> 32) & 0xFFFF);
-        data[base + cols::N_SUB_R_3] = FE::from((n_sub_r >> 48) & 0xFFFF);
+        set_limbs_16(&mut data, base + cols::N_SUB_R_0, n_sub_r);
 
         data[base + cols::SIGN_N_SUB_R] = FE::from(op.sign_n_sub_r() as u64);
         data[base + cols::SIGN_N] = FE::from(op.sign_n() as u64);

--- a/prover/src/tables/ec_scalar.rs
+++ b/prover/src/tables/ec_scalar.rs
@@ -23,6 +23,7 @@ use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing}
 use stark::table::TableView;
 use stark::trace::TraceTable;
 
+use super::limbs::set_limbs_32;
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
 use crate::constraints::templates::new_is_bit_constraints;
 
@@ -91,10 +92,8 @@ pub fn generate_ec_scalar_trace(
 
     for (row_idx, op) in ops.iter().enumerate() {
         let base = row_idx * cols::NUM_COLUMNS;
-        data[base + cols::TIMESTAMP_0] = FE::from(op.timestamp & 0xFFFF_FFFF);
-        data[base + cols::TIMESTAMP_1] = FE::from(op.timestamp >> 32);
-        data[base + cols::PTR_0] = FE::from(op.ptr & 0xFFFF_FFFF);
-        data[base + cols::PTR_1] = FE::from(op.ptr >> 32);
+        set_limbs_32(&mut data, base + cols::TIMESTAMP_0, op.timestamp);
+        set_limbs_32(&mut data, base + cols::PTR_0, op.ptr);
         data[base + cols::OFFSET] = FE::from(op.offset as u64);
         for i in 0..8 {
             data[base + cols::limb_bit(i)] = FE::from(((op.limb >> i) & 1) as u64);

--- a/prover/src/tables/ecdas.rs
+++ b/prover/src/tables/ecdas.rs
@@ -17,6 +17,7 @@ use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing}
 use stark::table::TableView;
 use stark::trace::TraceTable;
 
+use super::limbs::set_limbs_32;
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
 use crate::constraints::templates::IsBitConstraint;
 use crate::tables::ecsm::ecdas_tuple;
@@ -110,8 +111,7 @@ pub fn generate_ecdas_trace(
         let base = row_idx * cols::NUM_COLUMNS;
         let s = &op.step;
 
-        data[base + cols::TIMESTAMP_0] = FE::from(op.timestamp & 0xFFFF_FFFF);
-        data[base + cols::TIMESTAMP_1] = FE::from(op.timestamp >> 32);
+        set_limbs_32(&mut data, base + cols::TIMESTAMP_0, op.timestamp);
         write_bytes(&mut data, base, cols::XG, &s.x_g);
         write_bytes(&mut data, base, cols::YG, &s.y_g);
         write_bytes(&mut data, base, cols::XA, &s.x_a);

--- a/prover/src/tables/eq.rs
+++ b/prover/src/tables/eq.rs
@@ -28,6 +28,7 @@ use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing}
 use stark::table::TableView;
 use stark::trace::TraceTable;
 
+use super::limbs::{set_limbs_16, set_limbs_32};
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField, alu_op};
 use crate::constraints::templates::{AddConstraint, AddOperand, new_is_bit_constraints};
 
@@ -135,20 +136,15 @@ pub fn generate_eq_trace(
         let base = row_idx * cols::NUM_COLUMNS;
 
         // a, b as DWordWL (2 words each)
-        data[base + cols::A_0] = FE::from(op.a & 0xFFFF_FFFF);
-        data[base + cols::A_1] = FE::from(op.a >> 32);
-        data[base + cols::B_0] = FE::from(op.b & 0xFFFF_FFFF);
-        data[base + cols::B_1] = FE::from(op.b >> 32);
+        set_limbs_32(&mut data, base + cols::A_0, op.a);
+        set_limbs_32(&mut data, base + cols::B_0, op.b);
 
         data[base + cols::INVERT] = FE::from(op.invert as u64);
         data[base + cols::RES] = FE::from(op.compute_res() as u64);
 
         // diff = a - b (wrapping) as DWordHL (4 halves)
         let diff = op.a.wrapping_sub(op.b);
-        data[base + cols::DIFF_0] = FE::from(diff & 0xFFFF);
-        data[base + cols::DIFF_1] = FE::from((diff >> 16) & 0xFFFF);
-        data[base + cols::DIFF_2] = FE::from((diff >> 32) & 0xFFFF);
-        data[base + cols::DIFF_3] = FE::from((diff >> 48) & 0xFFFF);
+        set_limbs_16(&mut data, base + cols::DIFF_0, diff);
 
         data[base + cols::EQ] = FE::from(op.compute_eq() as u64);
         data[base + cols::MU] = FE::from(*multiplicity);

--- a/prover/src/tables/keccak.rs
+++ b/prover/src/tables/keccak.rs
@@ -23,6 +23,7 @@ use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing}
 use stark::table::TableView;
 use stark::trace::TraceTable;
 
+use super::limbs::set_limbs_32;
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField, alu_op};
 use crate::constraints::templates::{AddConstraint, AddOperand, INV_SHIFT_32};
 
@@ -109,8 +110,7 @@ pub fn generate_keccak_trace(
         let base = row_idx * cols::NUM_COLUMNS;
 
         // Timestamp
-        data[base + cols::TIMESTAMP_0] = FE::from(op.timestamp & 0xFFFF_FFFF);
-        data[base + cols::TIMESTAMP_1] = FE::from(op.timestamp >> 32);
+        set_limbs_32(&mut data, base + cols::TIMESTAMP_0, op.timestamp);
 
         // Address as 8 bytes
         for b in 0..8 {

--- a/prover/src/tables/keccak_rnd.rs
+++ b/prover/src/tables/keccak_rnd.rs
@@ -33,6 +33,7 @@ use stark::constraints::transition::{TransitionConstraint, TransitionConstraintE
 use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing};
 use stark::trace::TraceTable;
 
+use super::limbs::set_limbs_32;
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField, alu_op};
 
 // =========================================================================
@@ -254,8 +255,7 @@ pub fn generate_keccak_rnd_trace(
             let base = row_idx * cols::NUM_COLUMNS;
 
             // Timestamp & round
-            data[base + cols::TIMESTAMP_0] = FE::from(op.timestamp & 0xFFFF_FFFF);
-            data[base + cols::TIMESTAMP_1] = FE::from(op.timestamp >> 32);
+            set_limbs_32(&mut data, base + cols::TIMESTAMP_0, op.timestamp);
             data[base + cols::ROUND] = FE::from(round as u64);
 
             // start = current state as bytes

--- a/prover/src/tables/limbs.rs
+++ b/prover/src/tables/limbs.rs
@@ -1,0 +1,59 @@
+//! Little-endian limb decomposition of 64-bit values for trace columns.
+//!
+//! VM tables repeatedly split a `u64` operand into 16-bit or 32-bit limbs — to
+//! range-check each piece and feed it to the bus. These helpers centralize the
+//! shift/mask arithmetic (and the field-element column writes) so the exact same
+//! decomposition isn't open-coded in every table.
+//!
+//! Limb order is always little-endian: limb 0 is the least-significant chunk.
+
+use super::types::FE;
+
+/// Mask selecting one 16-bit limb.
+const LIMB16_MASK: u64 = 0xFFFF;
+/// Mask selecting one 32-bit limb.
+const LIMB32_MASK: u64 = 0xFFFF_FFFF;
+
+/// The four little-endian 16-bit limbs of `x`:
+/// `[x[0..16], x[16..32], x[32..48], x[48..64]]`.
+#[inline]
+pub const fn limbs_16(x: u64) -> [u64; 4] {
+    [
+        x & LIMB16_MASK,
+        (x >> 16) & LIMB16_MASK,
+        (x >> 32) & LIMB16_MASK,
+        (x >> 48) & LIMB16_MASK,
+    ]
+}
+
+/// The two little-endian 32-bit limbs of `x`: `[lo, hi]`.
+#[inline]
+pub const fn limbs_32(x: u64) -> [u64; 2] {
+    [x & LIMB32_MASK, x >> 32]
+}
+
+/// The `i`-th little-endian 16-bit limb of `x` (`i` in `0..4`).
+#[inline]
+pub const fn limb_16(x: u64, i: u32) -> u64 {
+    (x >> (16 * i)) & LIMB16_MASK
+}
+
+/// Write the four 16-bit limbs of `x` as field elements into the four
+/// consecutive columns `data[col..col + 4]` (little-endian limb order).
+#[inline]
+pub fn set_limbs_16(data: &mut [FE], col: usize, x: u64) {
+    let limbs = limbs_16(x);
+    data[col] = FE::from(limbs[0]);
+    data[col + 1] = FE::from(limbs[1]);
+    data[col + 2] = FE::from(limbs[2]);
+    data[col + 3] = FE::from(limbs[3]);
+}
+
+/// Write the two 32-bit limbs of `x` as field elements into the two consecutive
+/// columns `data[col..col + 2]` (`[lo, hi]`).
+#[inline]
+pub fn set_limbs_32(data: &mut [FE], col: usize, x: u64) {
+    let limbs = limbs_32(x);
+    data[col] = FE::from(limbs[0]);
+    data[col + 1] = FE::from(limbs[1]);
+}

--- a/prover/src/tables/load.rs
+++ b/prover/src/tables/load.rs
@@ -31,6 +31,7 @@ use stark::table::TableView;
 use stark::trace::TraceTable;
 
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
+use super::limbs::set_limbs_32;
 
 // =========================================================================
 // Column indices for LOAD table
@@ -190,12 +191,10 @@ pub fn generate_load_trace(
 
         // Input columns
         // base_address as DWordWL (2 words)
-        data[base + cols::BASE_ADDRESS_0] = FE::from(op.base_address & 0xFFFF_FFFF);
-        data[base + cols::BASE_ADDRESS_1] = FE::from(op.base_address >> 32);
+        set_limbs_32(&mut data, base + cols::BASE_ADDRESS_0, op.base_address);
 
         // timestamp as DWordWL (2 words)
-        data[base + cols::TIMESTAMP_0] = FE::from(op.timestamp & 0xFFFF_FFFF);
-        data[base + cols::TIMESTAMP_1] = FE::from(op.timestamp >> 32);
+        set_limbs_32(&mut data, base + cols::TIMESTAMP_0, op.timestamp);
 
         // read flags
         let (r2, r4, r8) = op.read_flags();

--- a/prover/src/tables/load.rs
+++ b/prover/src/tables/load.rs
@@ -30,8 +30,8 @@ use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing}
 use stark::table::TableView;
 use stark::trace::TraceTable;
 
-use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
 use super::limbs::set_limbs_32;
+use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
 
 // =========================================================================
 // Column indices for LOAD table

--- a/prover/src/tables/lt.rs
+++ b/prover/src/tables/lt.rs
@@ -33,6 +33,7 @@ use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing}
 use stark::table::TableView;
 use stark::trace::TraceTable;
 
+use super::limbs::set_limbs_16;
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField, SHIFT_16, alu_op};
 
 // =========================================================================
@@ -204,14 +205,7 @@ pub fn generate_lt_trace(
         let lhs_sub_rhs = op.lhs.wrapping_sub(op.rhs);
 
         // Store lhs_sub_rhs as DWordHL: [Half, Half, Half, Half]
-        let sub_0 = (lhs_sub_rhs & 0xFFFF) as u16;
-        let sub_1 = ((lhs_sub_rhs >> 16) & 0xFFFF) as u16;
-        let sub_2 = ((lhs_sub_rhs >> 32) & 0xFFFF) as u16;
-        let sub_3 = ((lhs_sub_rhs >> 48) & 0xFFFF) as u16;
-        data[base + cols::LHS_SUB_RHS_0] = FE::from(sub_0 as u64);
-        data[base + cols::LHS_SUB_RHS_1] = FE::from(sub_1 as u64);
-        data[base + cols::LHS_SUB_RHS_2] = FE::from(sub_2 as u64);
-        data[base + cols::LHS_SUB_RHS_3] = FE::from(sub_3 as u64);
+        set_limbs_16(&mut data, base + cols::LHS_SUB_RHS_0, lhs_sub_rhs);
 
         // Compute MSBs (bit 63 of each value)
         let lhs_msb = (op.lhs >> 63) & 1;

--- a/prover/src/tables/memw.rs
+++ b/prover/src/tables/memw.rs
@@ -37,6 +37,7 @@ use stark::table::TableView;
 use stark::trace::TraceTable;
 
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField, alu_op};
+use super::limbs::set_limbs_32;
 use crate::constraints::templates::IsBitConstraint;
 
 /// Maximum number of rows per MEMW table chunk.
@@ -194,8 +195,7 @@ pub fn generate_memw_trace(
         }
 
         // timestamp as DWordWL (2 words)
-        data[base + cols::TIMESTAMP_0] = FE::from(op.timestamp & 0xFFFF_FFFF);
-        data[base + cols::TIMESTAMP_1] = FE::from(op.timestamp >> 32);
+        set_limbs_32(&mut data, base + cols::TIMESTAMP_0, op.timestamp);
 
         // write flags
         let (w2, w4, w8) = op.write_flags();

--- a/prover/src/tables/memw.rs
+++ b/prover/src/tables/memw.rs
@@ -36,8 +36,8 @@ use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing}
 use stark::table::TableView;
 use stark::trace::TraceTable;
 
-use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField, alu_op};
 use super::limbs::set_limbs_32;
+use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField, alu_op};
 use crate::constraints::templates::IsBitConstraint;
 
 /// Maximum number of rows per MEMW table chunk.

--- a/prover/src/tables/memw_aligned.rs
+++ b/prover/src/tables/memw_aligned.rs
@@ -43,6 +43,7 @@ use stark::trace::TraceTable;
 
 use super::memw::MemwOperation;
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField, alu_op};
+use super::limbs::set_limbs_32;
 use crate::constraints::templates::IsBitConstraint;
 
 /// Maximum number of rows per MEMW_A table chunk.
@@ -118,8 +119,7 @@ pub fn generate_memw_aligned_trace(
             data[base + cols::VALUE[i]] = FE::from(op.value[i]);
         }
 
-        data[base + cols::TIMESTAMP_0] = FE::from(op.timestamp & 0xFFFF_FFFF);
-        data[base + cols::TIMESTAMP_1] = FE::from(op.timestamp >> 32);
+        set_limbs_32(&mut data, base + cols::TIMESTAMP_0, op.timestamp);
 
         let (w2, w4, w8) = op.write_flags();
         data[base + cols::WRITE2] = FE::from(w2 as u64);
@@ -131,8 +131,7 @@ pub fn generate_memw_aligned_trace(
         }
 
         // Single old_timestamp (from old_timestamp[0], verified equal for all bytes)
-        data[base + cols::OLD_TIMESTAMP_0] = FE::from(op.old_timestamp[0] & 0xFFFF_FFFF);
-        data[base + cols::OLD_TIMESTAMP_1] = FE::from(op.old_timestamp[0] >> 32);
+        set_limbs_32(&mut data, base + cols::OLD_TIMESTAMP_0, op.old_timestamp[0]);
 
         data[base + cols::MU_READ] = FE::from(op.is_read as u64);
         data[base + cols::MU_WRITE] = FE::from(!op.is_read as u64);

--- a/prover/src/tables/memw_aligned.rs
+++ b/prover/src/tables/memw_aligned.rs
@@ -41,9 +41,9 @@ use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing}
 use stark::table::TableView;
 use stark::trace::TraceTable;
 
+use super::limbs::set_limbs_32;
 use super::memw::MemwOperation;
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField, alu_op};
-use super::limbs::set_limbs_32;
 use crate::constraints::templates::IsBitConstraint;
 
 /// Maximum number of rows per MEMW_A table chunk.

--- a/prover/src/tables/memw_register.rs
+++ b/prover/src/tables/memw_register.rs
@@ -45,6 +45,7 @@ use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing}
 use stark::table::TableView;
 use stark::trace::TraceTable;
 
+use super::limbs::set_limbs_32;
 use super::memw::MemwOperation;
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
 
@@ -119,8 +120,7 @@ pub fn generate_memw_register_trace(
         data[base + cols::ADDRESS] = FE::from(op.base_address / 2);
 
         // Timestamp split into lo/hi 32-bit words
-        data[base + cols::TIMESTAMP_0] = FE::from(op.timestamp & 0xFFFF_FFFF);
-        data[base + cols::TIMESTAMP_1] = FE::from(op.timestamp >> 32);
+        set_limbs_32(&mut data, base + cols::TIMESTAMP_0, op.timestamp);
 
         // Value: registers are DWordWL = 2 words
         data[base + cols::VAL_0] = FE::from(op.value[0]);

--- a/prover/src/tables/mod.rs
+++ b/prover/src/tables/mod.rs
@@ -37,6 +37,7 @@ pub mod halt;
 pub mod keccak;
 pub mod keccak_rc;
 pub mod keccak_rnd;
+pub mod limbs;
 pub mod load;
 pub mod lt;
 pub mod memw;

--- a/prover/src/tables/mul.rs
+++ b/prover/src/tables/mul.rs
@@ -44,6 +44,7 @@ use super::types::{
     NEG_INV_2_16, NEG_INV_2_32, NEG_INV_2_48, NEG_INV_2_64, NEG_INV_2_80, NEG_INV_2_96,
     NEG_INV_2_112, NEG_INV_2_128, SHIFT_16, alu_op,
 };
+use super::limbs::{limbs_16, set_limbs_16};
 
 /// Total row multiplicity (`ALU` bus, lo + hi), used by the internal
 /// range-check sends so they fire once per row-instance.
@@ -222,31 +223,15 @@ impl MulOperation {
     /// lhs_ext[4..8] = 0xFFFF if negative, 0 otherwise
     pub fn lhs_extended(&self) -> [u64; 8] {
         let fill = if self.lhs_is_negative() { SIGN_FILL } else { 0 };
-        [
-            self.lhs & 0xFFFF,
-            (self.lhs >> 16) & 0xFFFF,
-            (self.lhs >> 32) & 0xFFFF,
-            (self.lhs >> 48) & 0xFFFF,
-            fill,
-            fill,
-            fill,
-            fill,
-        ]
+        let [l0, l1, l2, l3] = limbs_16(self.lhs);
+        [l0, l1, l2, l3, fill, fill, fill, fill]
     }
 
     /// Get sign-extended rhs as 8 halfwords.
     pub fn rhs_extended(&self) -> [u64; 8] {
         let fill = if self.rhs_is_negative() { SIGN_FILL } else { 0 };
-        [
-            self.rhs & 0xFFFF,
-            (self.rhs >> 16) & 0xFFFF,
-            (self.rhs >> 32) & 0xFFFF,
-            (self.rhs >> 48) & 0xFFFF,
-            fill,
-            fill,
-            fill,
-            fill,
-        ]
+        let [r0, r1, r2, r3] = limbs_16(self.rhs);
+        [r0, r1, r2, r3, fill, fill, fill, fill]
     }
 
     /// Compute the raw_product values (convolution intermediates).
@@ -317,31 +302,15 @@ pub fn generate_mul_trace(
         // Compute product
         let (lo, hi) = op.compute_product();
 
-        // Fill lhs as DWordHL (4 halfwords)
-        data[base + cols::LHS_0] = FE::from(op.lhs & 0xFFFF);
-        data[base + cols::LHS_1] = FE::from((op.lhs >> 16) & 0xFFFF);
-        data[base + cols::LHS_2] = FE::from((op.lhs >> 32) & 0xFFFF);
-        data[base + cols::LHS_3] = FE::from((op.lhs >> 48) & 0xFFFF);
+        // Fill lhs/rhs/lo/hi as DWordHL (4 halfwords each)
+        set_limbs_16(&mut data, base + cols::LHS_0, op.lhs);
         data[base + cols::LHS_SIGNED] = FE::from(op.lhs_signed as u64);
 
-        // Fill rhs as DWordHL (4 halfwords)
-        data[base + cols::RHS_0] = FE::from(op.rhs & 0xFFFF);
-        data[base + cols::RHS_1] = FE::from((op.rhs >> 16) & 0xFFFF);
-        data[base + cols::RHS_2] = FE::from((op.rhs >> 32) & 0xFFFF);
-        data[base + cols::RHS_3] = FE::from((op.rhs >> 48) & 0xFFFF);
+        set_limbs_16(&mut data, base + cols::RHS_0, op.rhs);
         data[base + cols::RHS_SIGNED] = FE::from(op.rhs_signed as u64);
 
-        // Fill lo as DWordHL (4 halfwords)
-        data[base + cols::LO_0] = FE::from(lo & 0xFFFF);
-        data[base + cols::LO_1] = FE::from((lo >> 16) & 0xFFFF);
-        data[base + cols::LO_2] = FE::from((lo >> 32) & 0xFFFF);
-        data[base + cols::LO_3] = FE::from((lo >> 48) & 0xFFFF);
-
-        // Fill hi as DWordHL (4 halfwords)
-        data[base + cols::HI_0] = FE::from(hi & 0xFFFF);
-        data[base + cols::HI_1] = FE::from((hi >> 16) & 0xFFFF);
-        data[base + cols::HI_2] = FE::from((hi >> 32) & 0xFFFF);
-        data[base + cols::HI_3] = FE::from((hi >> 48) & 0xFFFF);
+        set_limbs_16(&mut data, base + cols::LO_0, lo);
+        set_limbs_16(&mut data, base + cols::HI_0, hi);
 
         // Fill auxiliary columns
         data[base + cols::LHS_IS_NEGATIVE] = FE::from(op.lhs_is_negative() as u64);

--- a/prover/src/tables/mul.rs
+++ b/prover/src/tables/mul.rs
@@ -39,12 +39,12 @@ use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing}
 use stark::table::TableView;
 use stark::trace::TraceTable;
 
+use super::limbs::{limbs_16, set_limbs_16};
 use super::types::{
     BusId, FE, GoldilocksExtension, GoldilocksField, INV_2_32, INV_2_64, INV_2_96, INV_2_128,
     NEG_INV_2_16, NEG_INV_2_32, NEG_INV_2_48, NEG_INV_2_64, NEG_INV_2_80, NEG_INV_2_96,
     NEG_INV_2_112, NEG_INV_2_128, SHIFT_16, alu_op,
 };
-use super::limbs::{limbs_16, set_limbs_16};
 
 /// Total row multiplicity (`ALU` bus, lo + hi), used by the internal
 /// range-check sends so they fire once per row-instance.

--- a/prover/src/tables/page.rs
+++ b/prover/src/tables/page.rs
@@ -40,8 +40,8 @@ use stark::proof::options::ProofOptions;
 use stark::prover::evaluate_polynomial_on_lde_domain;
 use stark::trace::{TraceTable, columns2rows};
 
-use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
 use super::limbs::set_limbs_32;
+use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
 
 // =========================================================================
 // Constants

--- a/prover/src/tables/page.rs
+++ b/prover/src/tables/page.rs
@@ -41,6 +41,7 @@ use stark::prover::evaluate_polynomial_on_lde_domain;
 use stark::trace::{TraceTable, columns2rows};
 
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
+use super::limbs::set_limbs_32;
 
 // =========================================================================
 // Constants
@@ -203,8 +204,7 @@ pub fn generate_page_trace(
         };
 
         data[base + cols::FINI] = FE::from(fini_value as u64);
-        data[base + cols::TIMESTAMP_LO] = FE::from(timestamp & 0xFFFF_FFFF);
-        data[base + cols::TIMESTAMP_HI] = FE::from(timestamp >> 32);
+        set_limbs_32(&mut data, base + cols::TIMESTAMP_LO, timestamp);
     }
 
     TraceTable::new_main(data, cols::NUM_COLUMNS, 1)

--- a/prover/src/tables/register.rs
+++ b/prover/src/tables/register.rs
@@ -28,9 +28,9 @@ use stark::proof::options::ProofOptions;
 use stark::prover::evaluate_polynomial_on_lde_domain;
 use stark::trace::{TraceTable, columns2rows};
 
+use super::limbs::set_limbs_32;
 use super::page::STACK_TOP;
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
-use super::limbs::set_limbs_32;
 
 // =========================================================================
 // Constants

--- a/prover/src/tables/register.rs
+++ b/prover/src/tables/register.rs
@@ -30,6 +30,7 @@ use stark::trace::{TraceTable, columns2rows};
 
 use super::page::STACK_TOP;
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
+use super::limbs::set_limbs_32;
 
 // =========================================================================
 // Constants
@@ -170,8 +171,7 @@ pub fn generate_register_trace(
         };
 
         data[base + cols::FINI] = FE::from(fini_value as u64);
-        data[base + cols::TIMESTAMP_LO] = FE::from(timestamp & 0xFFFF_FFFF);
-        data[base + cols::TIMESTAMP_HI] = FE::from(timestamp >> 32);
+        set_limbs_32(&mut data, base + cols::TIMESTAMP_LO, timestamp);
     }
 
     // Padding rows (if num_rows > NUM_REGISTER_ADDRESSES): set TIMESTAMP_LO=1 so

--- a/prover/src/tables/shift.rs
+++ b/prover/src/tables/shift.rs
@@ -24,6 +24,7 @@ use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing}
 use stark::table::TableView;
 use stark::trace::TraceTable;
 
+use super::limbs::limbs_16;
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField, SHIFT_16, alu_op};
 
 // =========================================================================
@@ -133,12 +134,7 @@ impl ShiftOperation {
         word_instr: bool,
     ) -> Self {
         Self {
-            in_halves: [
-                (value & 0xFFFF) as u16,
-                ((value >> 16) & 0xFFFF) as u16,
-                ((value >> 32) & 0xFFFF) as u16,
-                ((value >> 48) & 0xFFFF) as u16,
-            ],
+            in_halves: limbs_16(value).map(|l| l as u16),
             shift: (shift_amount & 0xFF) as u8,
             shift_amount,
             direction,

--- a/prover/src/tables/store.rs
+++ b/prover/src/tables/store.rs
@@ -26,6 +26,7 @@ use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing}
 use stark::table::TableView;
 use stark::trace::TraceTable;
 
+use super::limbs::set_limbs_32;
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
 use crate::constraints::templates::new_is_bit_constraints;
 
@@ -103,10 +104,8 @@ pub fn generate_store_trace(
     for (row_idx, op) in operations.iter().enumerate() {
         let base = row_idx * cols::NUM_COLUMNS;
 
-        data[base + cols::BASE_ADDRESS_0] = FE::from(op.base_address & 0xFFFF_FFFF);
-        data[base + cols::BASE_ADDRESS_1] = FE::from(op.base_address >> 32);
-        data[base + cols::TIMESTAMP_0] = FE::from(op.timestamp & 0xFFFF_FFFF);
-        data[base + cols::TIMESTAMP_1] = FE::from(op.timestamp >> 32);
+        set_limbs_32(&mut data, base + cols::BASE_ADDRESS_0, op.base_address);
+        set_limbs_32(&mut data, base + cols::TIMESTAMP_0, op.timestamp);
         data[base + cols::WRITE2] = FE::from(op.write2 as u64);
         data[base + cols::WRITE4] = FE::from(op.write4 as u64);
         data[base + cols::WRITE8] = FE::from(op.write8 as u64);

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -53,6 +53,7 @@ use super::halt;
 use super::keccak::{self, KeccakOperation};
 use super::keccak_rc;
 use super::keccak_rnd::{self, KeccakRoundOperation};
+use super::limbs::{limbs_16, limbs_32};
 use super::load::{self, LoadOperation};
 use super::lt::{self, LtOperation};
 use super::memw::{self, MemwOperation};
@@ -63,7 +64,6 @@ use super::page::{self, FinalByteState, FinalStateMap, PageConfig};
 use super::register::{self, FinalRegisterStateMap, FinalRegisterWordState};
 use super::shift::{self, ShiftOperation};
 use super::store;
-use super::limbs::{limbs_16, limbs_32};
 use super::types::{GoldilocksExtension, GoldilocksField};
 use crate::Error;
 

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -63,6 +63,7 @@ use super::page::{self, FinalByteState, FinalStateMap, PageConfig};
 use super::register::{self, FinalRegisterStateMap, FinalRegisterWordState};
 use super::shift::{self, ShiftOperation};
 use super::store;
+use super::limbs::{limbs_16, limbs_32};
 use super::types::{GoldilocksExtension, GoldilocksField};
 use crate::Error;
 
@@ -305,7 +306,8 @@ fn cpu_op_to_bytes_and_signed(op: &CpuOperation) -> (usize, bool) {
 ///
 /// For register operations, values are packed as [lo32, hi32, 0, 0, 0, 0, 0, 0].
 fn pack_register_value(value: u64) -> [u64; 8] {
-    [value & 0xFFFF_FFFF, value >> 32, 0, 0, 0, 0, 0, 0]
+    let [lo, hi] = limbs_32(value);
+    [lo, hi, 0, 0, 0, 0, 0, 0]
 }
 
 // =============================================================================
@@ -1598,18 +1600,8 @@ fn collect_bitwise_from_dvrm(dvrm_ops: &[(DvrmOperation, bool)]) -> Vec<BitwiseO
 
         // C8: ZERO[overflow; overflow_sum]
         // overflow_sum = n[0]+n[1]+n[2]+n[3] - 32769*sign_n + 262141 - d[0]-d[1]-d[2]-d[3]
-        let n_halves: [u32; 4] = [
-            (op.n & 0xFFFF) as u32,
-            ((op.n >> 16) & 0xFFFF) as u32,
-            ((op.n >> 32) & 0xFFFF) as u32,
-            ((op.n >> 48) & 0xFFFF) as u32,
-        ];
-        let d_halves: [u32; 4] = [
-            (op.d & 0xFFFF) as u32,
-            ((op.d >> 16) & 0xFFFF) as u32,
-            ((op.d >> 32) & 0xFFFF) as u32,
-            ((op.d >> 48) & 0xFFFF) as u32,
-        ];
+        let n_halves: [u32; 4] = limbs_16(op.n).map(|l| l as u32);
+        let d_halves: [u32; 4] = limbs_16(op.d).map(|l| l as u32);
         let sign_n: u32 = if op.sign_n() { 1 } else { 0 };
         let overflow_sum = n_halves[0] + n_halves[1] + n_halves[2] + n_halves[3] + 262141
             - 32769 * sign_n
@@ -1667,12 +1659,7 @@ fn collect_bitwise_from_dvrm(dvrm_ops: &[(DvrmOperation, bool)]) -> Vec<BitwiseO
             // C3: NEG for r (when sign_r = 1)
             if op.sign_r() {
                 let r = op.compute_remainder();
-                let r_halves: [u32; 4] = [
-                    (r & 0xFFFF) as u32,
-                    ((r >> 16) & 0xFFFF) as u32,
-                    ((r >> 32) & 0xFFFF) as u32,
-                    ((r >> 48) & 0xFFFF) as u32,
-                ];
+                let r_halves: [u32; 4] = limbs_16(r).map(|l| l as u32);
                 // C3a: ZERO[1-carry_r[0]; r[0]+r[1]]
                 bitwise_ops.push(BitwiseOperation::zero(r_halves[0] + r_halves[1]));
                 // C3b: ZERO[1-carry_r[1]; r[0]+r[1]+r[2]+r[3]]
@@ -1683,12 +1670,7 @@ fn collect_bitwise_from_dvrm(dvrm_ops: &[(DvrmOperation, bool)]) -> Vec<BitwiseO
 
             // C5: NEG for d (when sign_d = 1)
             if op.sign_d() {
-                let d_halves: [u32; 4] = [
-                    (op.d & 0xFFFF) as u32,
-                    ((op.d >> 16) & 0xFFFF) as u32,
-                    ((op.d >> 32) & 0xFFFF) as u32,
-                    ((op.d >> 48) & 0xFFFF) as u32,
-                ];
+                let d_halves: [u32; 4] = limbs_16(op.d).map(|l| l as u32);
                 // C5a: ZERO[1-carry_d[0]; d[0]+d[1]]
                 bitwise_ops.push(BitwiseOperation::zero(d_halves[0] + d_halves[1]));
                 // C5b: ZERO[1-carry_d[1]; d[0]+d[1]+d[2]+d[3]]
@@ -1984,10 +1966,7 @@ fn collect_bitwise_from_commit(commit_ops: &[CommitOperation]) -> Vec<BitwiseOpe
         // Zero bus for end detection (mult = mu)
         // Input: (65535 - cd_0) + (65535 - cd_1) + (65535 - cd_2) + (65535 - cd_3)
         // When count_decr = 0xFFFF_FFFF_FFFF_FFFF (count=0), sum = 0 → end=1
-        let cd_0 = (count_decr & 0xFFFF) as u32;
-        let cd_1 = ((count_decr >> 16) & 0xFFFF) as u32;
-        let cd_2 = ((count_decr >> 32) & 0xFFFF) as u32;
-        let cd_3 = ((count_decr >> 48) & 0xFFFF) as u32;
+        let [cd_0, cd_1, cd_2, cd_3] = limbs_16(count_decr).map(|l| l as u32);
         let zero_input = (65535 - cd_0) + (65535 - cd_1) + (65535 - cd_2) + (65535 - cd_3);
         lookups.push(BitwiseOperation::zero(zero_input));
     }

--- a/prover/src/tests/limbs_tests.rs
+++ b/prover/src/tests/limbs_tests.rs
@@ -1,0 +1,63 @@
+//! Tests for the little-endian limb-decomposition helpers.
+
+use crate::tables::limbs::*;
+use crate::tables::types::FE;
+
+const X: u64 = 0xDEAD_BEEF_1234_5678;
+const SHIFT_BOUNDARY: u64 = 0xFFFF_0000_FFFF_0000;
+
+#[test]
+fn limbs_16_is_little_endian_and_reconstructs() {
+    assert_eq!(limbs_16(X), [0x5678, 0x1234, 0xBEEF, 0xDEAD]);
+    let [a, b, c, d] = limbs_16(X);
+    assert_eq!(a | (b << 16) | (c << 32) | (d << 48), X);
+}
+
+#[test]
+fn limbs_32_is_little_endian_and_reconstructs() {
+    assert_eq!(limbs_32(X), [0x1234_5678, 0xDEAD_BEEF]);
+    let [lo, hi] = limbs_32(X);
+    assert_eq!(lo | (hi << 32), X);
+}
+
+#[test]
+fn limb_16_matches_limbs_16() {
+    for i in 0..4 {
+        assert_eq!(limb_16(X, i), limbs_16(X)[i as usize]);
+    }
+}
+
+#[test]
+fn limbs_match_open_coded_form() {
+    // Guards against drift from the idioms these helpers replace.
+    for x in [0u64, 1, u64::MAX, X, 0xFFFF, 0x1_0000, SHIFT_BOUNDARY] {
+        assert_eq!(
+            limbs_16(x),
+            [
+                x & 0xFFFF,
+                (x >> 16) & 0xFFFF,
+                (x >> 32) & 0xFFFF,
+                (x >> 48) & 0xFFFF
+            ]
+        );
+        assert_eq!(limbs_32(x), [x & 0xFFFF_FFFF, x >> 32]);
+    }
+}
+
+#[test]
+fn set_limbs_write_consecutive_columns() {
+    let mut data = vec![FE::from(0u64); 6];
+    set_limbs_16(&mut data, 0, X);
+    set_limbs_32(&mut data, 4, X);
+    assert_eq!(
+        data,
+        vec![
+            FE::from(0x5678u64),
+            FE::from(0x1234u64),
+            FE::from(0xBEEFu64),
+            FE::from(0xDEADu64),
+            FE::from(0x1234_5678u64),
+            FE::from(0xDEAD_BEEFu64),
+        ]
+    );
+}

--- a/prover/src/tests/mod.rs
+++ b/prover/src/tests/mod.rs
@@ -41,6 +41,8 @@ pub mod eq_tests;
 #[cfg(test)]
 pub mod keccak_rnd_tests;
 #[cfg(test)]
+pub mod limbs_tests;
+#[cfg(test)]
 pub mod load_tests;
 #[cfg(test)]
 pub mod lt_bus_tests;


### PR DESCRIPTION
## What

Centralizes the repeated `u64 → 16/32-bit little-endian limb` decomposition that was open-coded across the VM trace tables. Adds a small `prover/src/tables/limbs.rs` module and converts ~20 tables to use it.

## The helper (`prover/src/tables/limbs.rs`)

```rust
pub const fn limbs_16(x: u64) -> [u64; 4]   // [x[0..16], x[16..32], x[32..48], x[48..64]]
pub const fn limbs_32(x: u64) -> [u64; 2]   // [lo, hi]
pub const fn limb_16(x: u64, i: u32) -> u64 // (x >> 16*i) & 0xFFFF
pub fn set_limbs_16(data: &mut [FE], col: usize, x: u64) // FE limbs into data[col..col+4]
pub fn set_limbs_32(data: &mut [FE], col: usize, x: u64) // FE limbs into data[col..col+2]
```

Tests live in the dedicated `prover/src/tests/limbs_tests.rs` (no inline tests in the production module).

## Conversions

`set_limbs_16` / `set_limbs_32` replace the `data[base + cols::X_0] = FE::from(v & 0xFFFF); …` blocks; `limbs_16` / `limbs_32` replace the integer `[u32;4]`/`[u64;…]` decomposition arrays. Tables touched: mul, dvrm, decode, cpu, cpu32, commit, load, page, register, memw, memw_aligned, memw_register, lt, branch, eq, store, ec_scalar, ecdas, keccak, keccak_rnd, shift, plus the `trace_builder` bus-value arrays.

Every converted column group was verified consecutive in its `cols` module before conversion.

## Deliberately left as-is

Parametric column indices (`cols_i[..]`, `state_ptr(lane, k)`, `lo_col`/`hi_col` vars), byte (`& 0xFF`) / nibble (`& 0xF`) splits, non-standard groupings (e.g. `DWordWHH`, limbs starting at index 1), sign-fill constants, and the local `half` closure in `trace_builder` (already a local dedup).

## Correctness

Pure refactor — **byte-identical trace output**. `cargo test -p lambda-vm-prover --lib` is unchanged at **322 passed / 104 failed**; the 104 failures are pre-existing and environmental (tests that read `executor/program_artifacts/*.elf`, absent in the sandbox — they fail identically on `main`). `cargo clippy -p lambda-vm-prover` is clean. The 5 new `limbs_tests` cover the helper (LE order, reconstruction, a drift-guard against the open-coded form, and consecutive-column writes).
