### PR TITLE
perf(stark): borrow trace rows in place for prover transition eval

### DIFF
--- a/crypto/stark/src/constraint_ir/interp.rs
+++ b/crypto/stark/src/constraint_ir/interp.rs
@@ -175,7 +175,7 @@ pub fn eval_program<F, E>(
     E: IsField,
 {
     let TransitionEvaluationContext::Prover {
-        frame,
+        rows,
         rap_challenges,
         logup_alpha_powers,
         logup_table_offset,
@@ -188,12 +188,11 @@ pub fn eval_program<F, E>(
     let values = run(
         prog,
         |main, offset, row, col| {
-            let step: &TableView<F, E> = frame.get_evaluation_step(offset as usize);
             debug_assert_eq!(row, 0, "tables read row 0 of each frame step");
             if main {
-                Value::Base(step.get_main_evaluation_element(0, col as usize).clone())
+                Value::Base(rows.main(offset as usize, col as usize).clone())
             } else {
-                Value::Ext(step.get_aux_evaluation_element(0, col as usize).clone())
+                Value::Ext(rows.aux(offset as usize, col as usize).clone())
             }
         },
         |idx| rap_challenges[idx as usize].clone(),

--- a/crypto/stark/src/constraint_ir/tests.rs
+++ b/crypto/stark/src/constraint_ir/tests.rs
@@ -200,7 +200,13 @@ fn frame_offset_reads_next_step() {
     let alpha: Vec<ExtE> = vec![];
     let offset = ExtE::zero();
     let shifts = PackingShifts::<Fp>::new();
-    let ctx = TransitionEvaluationContext::new_prover(&frame, &rap, &alpha, &offset, &shifts);
+    let ctx = TransitionEvaluationContext::new_prover(
+        frame.as_row_frame(),
+        &rap,
+        &alpha,
+        &offset,
+        &shifts,
+    );
 
     let mut base_evals = vec![FpE::zero()];
     let mut ext_evals: Vec<ExtE> = vec![];
@@ -234,7 +240,13 @@ fn mixed_base_ext_auto_embeds() {
     let alpha: Vec<ExtE> = vec![];
     let offset = ExtE::zero();
     let shifts = PackingShifts::<Fp>::new();
-    let ctx = TransitionEvaluationContext::new_prover(&frame, &rap, &alpha, &offset, &shifts);
+    let ctx = TransitionEvaluationContext::new_prover(
+        frame.as_row_frame(),
+        &rap,
+        &alpha,
+        &offset,
+        &shifts,
+    );
 
     let mut base_evals: Vec<FpE> = vec![];
     let mut ext_evals = vec![ExtE::zero(), ExtE::zero()];
@@ -267,7 +279,13 @@ fn explicit_embed_and_ext_neg() {
     let alpha: Vec<ExtE> = vec![];
     let offset = ExtE::zero();
     let shifts = PackingShifts::<Fp>::new();
-    let ctx = TransitionEvaluationContext::new_prover(&frame, &rap, &alpha, &offset, &shifts);
+    let ctx = TransitionEvaluationContext::new_prover(
+        frame.as_row_frame(),
+        &rap,
+        &alpha,
+        &offset,
+        &shifts,
+    );
 
     let mut base_evals: Vec<FpE> = vec![];
     let mut ext_evals = vec![ExtE::zero()];
@@ -317,7 +335,13 @@ fn all_leaf_kinds_logup_shaped() {
     let step = TableView::<Fp, Ext>::new(vec![main_row], vec![aux_row]);
     let frame = Frame::<Fp, Ext>::new(vec![step]);
     let shifts = PackingShifts::<Fp>::new();
-    let ctx = TransitionEvaluationContext::new_prover(&frame, &rap, &alpha, &offset, &shifts);
+    let ctx = TransitionEvaluationContext::new_prover(
+        frame.as_row_frame(),
+        &rap,
+        &alpha,
+        &offset,
+        &shifts,
+    );
 
     let mut base_evals: Vec<FpE> = vec![];
     let mut ext_evals = vec![ExtE::zero()];
@@ -354,7 +378,13 @@ fn prover_entry_point_splits_base_and_ext() {
     let alpha = vec![ext3(3, 3, 3)];
     let offset = ExtE::zero();
     let shifts = PackingShifts::<Fp>::new();
-    let ctx = TransitionEvaluationContext::new_prover(&frame, &rap, &alpha, &offset, &shifts);
+    let ctx = TransitionEvaluationContext::new_prover(
+        frame.as_row_frame(),
+        &rap,
+        &alpha,
+        &offset,
+        &shifts,
+    );
 
     let mut base_evals = vec![FpE::zero()];
     let mut ext_evals = vec![ExtE::zero(), ExtE::zero()];
@@ -485,8 +515,13 @@ fn non_goldilocks_reflexive_tower_builds_and_interprets() {
     let alpha: Vec<GE> = vec![];
     let offset = g(0);
     let shifts = PackingShifts::<G>::new();
-    let ctx =
-        TransitionEvaluationContext::<G, G>::new_prover(&frame, &rap, &alpha, &offset, &shifts);
+    let ctx = TransitionEvaluationContext::<G, G>::new_prover(
+        frame.as_row_frame(),
+        &rap,
+        &alpha,
+        &offset,
+        &shifts,
+    );
     let mut base_evals = vec![GE::zero()];
     let mut ext_evals = vec![GE::zero(), GE::zero()];
     eval_program(&prog, &ctx, &mut base_evals, &mut ext_evals);

--- a/crypto/stark/src/constraints/builder.rs
+++ b/crypto/stark/src/constraints/builder.rs
@@ -26,7 +26,7 @@ use math::field::element::FieldElement;
 use math::field::traits::{IsField, IsSubFieldOf};
 
 use crate::constraint_ir::{ConstraintProgram, Dim, IrBuilder};
-use crate::frame::Frame;
+use crate::frame::{Frame, RowFrame};
 use crate::traits::TransitionEvaluationContext;
 
 // =============================================================================
@@ -381,7 +381,7 @@ where
     F: IsSubFieldOf<E>,
     E: IsField,
 {
-    frame: &'a Frame<F, E>,
+    rows: RowFrame<'a, F, E>,
     challenges: &'a [FieldElement<E>],
     alphas: &'a [FieldElement<E>],
     logup_table_offset: &'a FieldElement<E>,
@@ -406,7 +406,7 @@ where
         ext_out: &'a mut [FieldElement<E>],
     ) -> Self {
         let TransitionEvaluationContext::Prover {
-            frame,
+            rows,
             rap_challenges,
             logup_alpha_powers,
             logup_table_offset,
@@ -417,7 +417,7 @@ where
         };
         let num_constraints = base_out.len().max(ext_out.len());
         Self {
-            frame,
+            rows: *rows,
             challenges: rap_challenges,
             alphas: logup_alpha_powers,
             logup_table_offset,
@@ -443,16 +443,10 @@ where
     type ExprE = FieldElement<E>;
 
     fn main(&self, offset: usize, col: usize) -> FieldElement<F> {
-        self.frame
-            .get_evaluation_step(offset)
-            .get_main_evaluation_element(0, col)
-            .clone()
+        self.rows.main(offset, col).clone()
     }
     fn aux(&self, offset: usize, col: usize) -> FieldElement<E> {
-        self.frame
-            .get_evaluation_step(offset)
-            .get_aux_evaluation_element(0, col)
-            .clone()
+        self.rows.aux(offset, col).clone()
     }
     fn challenge(&self, idx: usize) -> FieldElement<E> {
         self.challenges[idx].clone()

--- a/crypto/stark/src/constraints/builder_tests.rs
+++ b/crypto/stark/src/constraints/builder_tests.rs
@@ -188,7 +188,7 @@ fn prover_folder_matches_direct_arithmetic() {
         let challenges = vec![t.challenge0];
         let alphas = vec![t.alpha0];
         let ctx = TransitionEvaluationContext::new_prover(
-            &frame,
+            frame.as_row_frame(),
             &challenges,
             &alphas,
             &t.offset,
@@ -226,7 +226,7 @@ fn prover_folder_matches_interpreted_capture() {
         let challenges = vec![t.challenge0];
         let alphas = vec![t.alpha0];
         let ctx = TransitionEvaluationContext::new_prover(
-            &frame,
+            frame.as_row_frame(),
             &challenges,
             &alphas,
             &t.offset,
@@ -360,8 +360,13 @@ fn prover_folder_missing_emit_asserts() {
     let challenges: Vec<ExtE> = vec![];
     let alphas: Vec<ExtE> = vec![];
     let offset = ExtE::zero();
-    let ctx =
-        TransitionEvaluationContext::new_prover(&frame, &challenges, &alphas, &offset, &shifts);
+    let ctx = TransitionEvaluationContext::new_prover(
+        frame.as_row_frame(),
+        &challenges,
+        &alphas,
+        &offset,
+        &shifts,
+    );
 
     let mut base_out = vec![FpE::zero(); 2];
     let mut ext_out = vec![ExtE::zero(); 2];
@@ -381,8 +386,13 @@ fn prover_folder_double_emit_asserts() {
     let challenges: Vec<ExtE> = vec![];
     let alphas: Vec<ExtE> = vec![];
     let offset = ExtE::zero();
-    let ctx =
-        TransitionEvaluationContext::new_prover(&frame, &challenges, &alphas, &offset, &shifts);
+    let ctx = TransitionEvaluationContext::new_prover(
+        frame.as_row_frame(),
+        &challenges,
+        &alphas,
+        &offset,
+        &shifts,
+    );
 
     let mut base_out = vec![FpE::zero(); 2];
     let mut ext_out = vec![ExtE::zero(); 2];
@@ -594,8 +604,13 @@ fn next_row_aux_and_multi_alpha_folder_matches_capture() {
             .map(|s| TableView::new(vec![rows[s].clone()], vec![auxs[s].clone()]))
             .collect();
         let frame = Frame::<Fp, Ext>::new(steps);
-        let ctx =
-            TransitionEvaluationContext::new_prover(&frame, &challenges, &alphas, &offset, &shifts);
+        let ctx = TransitionEvaluationContext::new_prover(
+            frame.as_row_frame(),
+            &challenges,
+            &alphas,
+            &offset,
+            &shifts,
+        );
 
         let mut folder_base = vec![FpE::zero(); num_base];
         let mut folder_ext = vec![ExtE::zero(); meta.len()];

--- a/crypto/stark/src/constraints/evaluator.rs
+++ b/crypto/stark/src/constraints/evaluator.rs
@@ -1,6 +1,6 @@
 use super::boundary::BoundaryConstraints;
 use crate::domain::Domain;
-use crate::frame::Frame;
+use crate::frame::RowFrame;
 use crate::lookup::{BusPublicInputs, LOGUP_CHALLENGE_ALPHA, PackingShifts, compute_alpha_powers};
 use crate::trace::LDETraceTable;
 use crate::traits::{AIR, TransitionEvaluationContext, ZerofierEvaluations};
@@ -61,29 +61,21 @@ where
         // Precompute packing shift constants once for all LDE domain points.
         let packing_shifts = PackingShifts::<Field>::new();
 
-        // Per-thread buffers via map_init: each Rayon worker allocates once,
-        // then reuses for all iterations assigned to that thread.
-        // The Frame is pre-allocated and filled in-place to avoid Vec allocations
-        // on every LDE point (a significant fraction of total CPU time).
-        let blowup_factor = lde_trace.blowup_factor;
-        let lde_step_size = lde_trace.lde_step_size;
-        let rows_per_step = lde_step_size / blowup_factor;
-        let num_main_cols = lde_trace.num_main_cols();
-        let num_aux_cols = lde_trace.num_aux_cols();
-        let num_offsets = offsets.len();
-
+        // Per-thread output buffers via map_init: each Rayon worker allocates
+        // once, then reuses for all iterations assigned to that thread. The
+        // trace rows themselves are BORROWED in place per LDE point (the LDE
+        // buffers are row-major) — no per-row gather copy.
         // Per-row evaluation, shared by the parallel and sequential paths below:
-        // fill the frame, evaluate transition constraints, accumulate with zerofiers.
+        // borrow the rows, evaluate transition constraints, accumulate with zerofiers.
         let eval_row = |i: usize,
                         boundary: FieldElement<FieldExtension>,
                         transition_buf: &mut [FieldElement<FieldExtension>],
-                        base_buf: &mut [FieldElement<Field>],
-                        frame: &mut Frame<Field, FieldExtension>|
+                        base_buf: &mut [FieldElement<Field>]|
          -> FieldElement<FieldExtension> {
-            frame.fill_from_lde(lde_trace, i, offsets);
+            let rows = RowFrame::from_lde(lde_trace, i, offsets);
 
             let ctx = TransitionEvaluationContext::new_prover(
-                frame,
+                rows,
                 rap_challenges,
                 &logup_alpha_powers,
                 logup_table_offset,
@@ -145,16 +137,10 @@ where
                         (
                             vec![FieldElement::<FieldExtension>::zero(); num_transition],
                             vec![FieldElement::<Field>::zero(); num_base],
-                            Frame::preallocate(
-                                num_offsets,
-                                rows_per_step,
-                                num_main_cols,
-                                num_aux_cols,
-                            ),
                         )
                     },
-                    |(transition_buf, base_buf, frame), (i, boundary)| {
-                        eval_row(i, boundary, transition_buf, base_buf, frame)
+                    |(transition_buf, base_buf), (i, boundary)| {
+                        eval_row(i, boundary, transition_buf, base_buf)
                     },
                 )
                 .collect()
@@ -164,15 +150,11 @@ where
         {
             let mut transition_buf = vec![FieldElement::<FieldExtension>::zero(); num_transition];
             let mut base_buf = vec![FieldElement::<Field>::zero(); num_base];
-            let mut frame =
-                Frame::preallocate(num_offsets, rows_per_step, num_main_cols, num_aux_cols);
 
             boundary_evaluation
                 .into_iter()
                 .enumerate()
-                .map(|(i, boundary)| {
-                    eval_row(i, boundary, &mut transition_buf, &mut base_buf, &mut frame)
-                })
+                .map(|(i, boundary)| eval_row(i, boundary, &mut transition_buf, &mut base_buf))
                 .collect()
         }
     }

--- a/crypto/stark/src/debug.rs
+++ b/crypto/stark/src/debug.rs
@@ -104,7 +104,7 @@ pub fn validate_trace<
     for step in 0..lde_trace.num_steps() {
         let frame = Frame::read_step_from_lde(&lde_trace, step, &air.context().transition_offsets);
         let transition_evaluation_context = TransitionEvaluationContext::new_prover(
-            &frame,
+            frame.as_row_frame(),
             rap_challenges,
             &logup_alpha_powers,
             &logup_table_offset,

--- a/crypto/stark/src/frame.rs
+++ b/crypto/stark/src/frame.rs
@@ -3,6 +3,80 @@ use itertools::Itertools;
 use math::field::element::FieldElement;
 use math::field::traits::{IsField, IsSubFieldOf};
 
+/// Maximum number of transition offsets a [`RowFrame`] can hold. Every
+/// production table uses two (`[0, 1]`); the widest example AIR uses three.
+pub const MAX_TRANSITION_OFFSETS: usize = 4;
+
+/// Borrowed per-row view of the trace for prover-side transition
+/// evaluation: one contiguous `(main, aux)` row-slice pair per transition
+/// offset, taken IN PLACE from the row-major storage. Replaces the per-row
+/// gather-copy into an owned [`Frame`] on the evaluator hot path — the LDE
+/// buffers are row-major, so a step is just two borrowed slices.
+///
+/// Requires single-row steps (step_size 1) — the only shape since
+/// virtual columns were removed.
+pub struct RowFrame<'a, F: IsSubFieldOf<E>, E: IsField> {
+    mains: [&'a [FieldElement<F>]; MAX_TRANSITION_OFFSETS],
+    auxs: [&'a [FieldElement<E>]; MAX_TRANSITION_OFFSETS],
+    num_offsets: usize,
+}
+
+// Manual impls: the derives would demand `F: Copy`/`E: Copy`, but every field
+// is a shared reference (or usize), which is Copy for any field type.
+impl<F: IsSubFieldOf<E>, E: IsField> Clone for RowFrame<'_, F, E> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<F: IsSubFieldOf<E>, E: IsField> Copy for RowFrame<'_, F, E> {}
+
+impl<'a, F: IsSubFieldOf<E>, E: IsField> RowFrame<'a, F, E> {
+    /// Borrow the rows for LDE point `row` at each transition offset,
+    /// wrapping cyclically at the domain end (same row arithmetic as
+    /// [`Frame::fill_from_lde`] with single-row steps).
+    pub fn from_lde(lde_trace: &'a LDETraceTable<F, E>, row: usize, offsets: &[usize]) -> Self {
+        debug_assert_eq!(
+            lde_trace.lde_step_size, lde_trace.blowup_factor,
+            "RowFrame requires single-row steps (step_size 1)"
+        );
+        assert!(
+            offsets.len() <= MAX_TRANSITION_OFFSETS,
+            "RowFrame supports at most {MAX_TRANSITION_OFFSETS} transition offsets"
+        );
+        let num_rows = lde_trace.num_rows();
+        let mut mains: [&'a [FieldElement<F>]; MAX_TRANSITION_OFFSETS] =
+            [&[]; MAX_TRANSITION_OFFSETS];
+        let mut auxs: [&'a [FieldElement<E>]; MAX_TRANSITION_OFFSETS] =
+            [&[]; MAX_TRANSITION_OFFSETS];
+        for (k, &offset) in offsets.iter().enumerate() {
+            let idx = (row + offset * lde_trace.lde_step_size) % num_rows;
+            mains[k] = lde_trace.main_row(idx);
+            auxs[k] = lde_trace.aux_row(idx);
+        }
+        Self {
+            mains,
+            auxs,
+            num_offsets: offsets.len(),
+        }
+    }
+
+    /// The main-trace element at (offset position, column).
+    #[inline(always)]
+    pub fn main(&self, offset: usize, col: usize) -> &FieldElement<F> {
+        &self.mains[offset][col]
+    }
+
+    /// The aux-trace element at (offset position, column).
+    #[inline(always)]
+    pub fn aux(&self, offset: usize, col: usize) -> &FieldElement<E> {
+        &self.auxs[offset][col]
+    }
+
+    pub fn num_offsets(&self) -> usize {
+        self.num_offsets
+    }
+}
+
 /// A frame represents a collection of trace steps.
 /// The collected steps are all the necessary steps for
 /// all transition constraints over a trace to be evaluated.
@@ -21,6 +95,31 @@ impl<F: IsSubFieldOf<E>, E: IsField> Frame<F, E> {
 
     pub fn get_evaluation_step(&self, step: usize) -> &TableView<F, E> {
         &self.steps[step]
+    }
+
+    /// Borrow this frame's single-row steps as a [`RowFrame`] — the bridge
+    /// for callers that own a `Frame` (debug validation, tests); the
+    /// evaluator hot loop uses [`RowFrame::from_lde`] directly.
+    pub fn as_row_frame(&self) -> RowFrame<'_, F, E> {
+        assert!(
+            self.steps.len() <= MAX_TRANSITION_OFFSETS,
+            "RowFrame supports at most {MAX_TRANSITION_OFFSETS} transition offsets"
+        );
+        let mut mains: [&[FieldElement<F>]; MAX_TRANSITION_OFFSETS] = [&[]; MAX_TRANSITION_OFFSETS];
+        let mut auxs: [&[FieldElement<E>]; MAX_TRANSITION_OFFSETS] = [&[]; MAX_TRANSITION_OFFSETS];
+        for (k, step) in self.steps.iter().enumerate() {
+            debug_assert!(
+                step.data.len() <= 1 && step.aux_data.len() <= 1,
+                "RowFrame requires single-row steps (step_size 1)"
+            );
+            mains[k] = step.data.first().map(|r| r.as_slice()).unwrap_or(&[]);
+            auxs[k] = step.aux_data.first().map(|r| r.as_slice()).unwrap_or(&[]);
+        }
+        RowFrame {
+            mains,
+            auxs,
+            num_offsets: self.steps.len(),
+        }
     }
 
     /// Build a Frame by gathering row data from a column-major LDETraceTable.
@@ -73,70 +172,5 @@ impl<F: IsSubFieldOf<E>, E: IsField> Frame<F, E> {
     ) -> Self {
         let row = lde_trace.step_to_row(step);
         Self::read_from_lde(lde_trace, row, offsets)
-    }
-
-    /// Pre-allocate a Frame with the right dimensions for reuse in hot loops.
-    ///
-    /// The frame will have `offsets.len()` steps, each containing
-    /// `step_size / blowup_factor` rows (typically 1) of main and aux columns.
-    pub fn preallocate(
-        num_offsets: usize,
-        rows_per_step: usize,
-        num_main_cols: usize,
-        num_aux_cols: usize,
-    ) -> Self {
-        let steps = (0..num_offsets)
-            .map(|_| {
-                let main_data: Vec<Vec<FieldElement<F>>> = (0..rows_per_step)
-                    .map(|_| vec![FieldElement::zero(); num_main_cols])
-                    .collect();
-                let aux_data: Vec<Vec<FieldElement<E>>> = (0..rows_per_step)
-                    .map(|_| vec![FieldElement::zero(); num_aux_cols])
-                    .collect();
-                TableView::new(main_data, aux_data)
-            })
-            .collect();
-        Frame { steps }
-    }
-
-    /// Fill a pre-allocated frame from LDE data, without allocating.
-    ///
-    /// The frame must have been created with `preallocate` with matching dimensions.
-    pub fn fill_from_lde(
-        &mut self,
-        lde_trace: &LDETraceTable<F, E>,
-        row: usize,
-        offsets: &[usize],
-    ) {
-        let blowup_factor = lde_trace.blowup_factor;
-        let num_rows = lde_trace.num_rows();
-        let step_size = lde_trace.lde_step_size;
-        let num_main_cols = lde_trace.num_main_cols();
-        let num_aux_cols = lde_trace.num_aux_cols();
-
-        for (step_idx, &offset) in offsets.iter().enumerate() {
-            let initial_step_row = row + offset * step_size;
-            let end_step_row = initial_step_row + step_size;
-            let step = &mut self.steps[step_idx];
-
-            let mut sub_row_idx = 0;
-            let mut step_row = initial_step_row;
-            while step_row < end_step_row {
-                let step_row_idx = step_row % num_rows;
-
-                // Overwrite main row elements
-                for col in 0..num_main_cols {
-                    step.data[sub_row_idx][col] = lde_trace.get_main(step_row_idx, col).clone();
-                }
-
-                // Overwrite aux row elements
-                for col in 0..num_aux_cols {
-                    step.aux_data[sub_row_idx][col] = lde_trace.get_aux(step_row_idx, col).clone();
-                }
-
-                sub_row_idx += 1;
-                step_row += blowup_factor;
-            }
-        }
     }
 }

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -2338,7 +2338,7 @@ mod logup_single_source_tests {
             let table_offset = rand_fp3(&mut rng);
 
             let prover_ctx = TransitionEvaluationContext::new_prover(
-                &frame,
+                frame.as_row_frame(),
                 &rap_challenges,
                 &alpha_powers,
                 &table_offset,

--- a/crypto/stark/src/trace.rs
+++ b/crypto/stark/src/trace.rs
@@ -453,6 +453,18 @@ where
         &self.aux_data[row * self.num_aux_cols + col]
     }
 
+    /// Borrow a full main-trace row as a contiguous slice (row-major buffer).
+    #[inline]
+    pub fn main_row(&self, row: usize) -> &[FieldElement<F>] {
+        &self.main_data[row * self.num_main_cols..(row + 1) * self.num_main_cols]
+    }
+
+    /// Borrow a full aux-trace row as a contiguous slice (row-major buffer).
+    #[inline]
+    pub fn aux_row(&self, row: usize) -> &[FieldElement<E>] {
+        &self.aux_data[row * self.num_aux_cols..(row + 1) * self.num_aux_cols]
+    }
+
     /// Gather a full main-trace row into an owned Vec.
     /// Used by `open_trace_polys` (called ~30 times per table, allocation is negligible).
     pub fn gather_main_row(&self, row_idx: usize) -> Vec<FieldElement<F>> {

--- a/crypto/stark/src/traits.rs
+++ b/crypto/stark/src/traits.rs
@@ -15,7 +15,7 @@ use crate::{
 
 use super::{
     config::Commitment, constraints::boundary::BoundaryConstraints, context::AirContext,
-    frame::Frame, proof::options::ProofOptions, trace::TraceTable,
+    frame::Frame, frame::RowFrame, proof::options::ProofOptions, trace::TraceTable,
 };
 
 /// Deduplicated zerofier evaluations: unique zerofier vectors indexed by constraint.
@@ -71,7 +71,9 @@ where
     E: IsField,
 {
     Prover {
-        frame: &'a Frame<F, E>,
+        /// Borrowed row view straight into the row-major trace storage —
+        /// the prover hot path never copies rows into an owned frame.
+        rows: RowFrame<'a, F, E>,
         rap_challenges: &'a [FieldElement<E>],
         logup_alpha_powers: &'a [FieldElement<E>],
         logup_table_offset: &'a FieldElement<E>,
@@ -92,14 +94,14 @@ where
     E: IsField,
 {
     pub fn new_prover(
-        frame: &'a Frame<F, E>,
+        rows: RowFrame<'a, F, E>,
         rap_challenges: &'a [FieldElement<E>],
         logup_alpha_powers: &'a [FieldElement<E>],
         logup_table_offset: &'a FieldElement<E>,
         packing_shifts: &'a PackingShifts<F>,
     ) -> Self {
         Self::Prover {
-            frame,
+            rows,
             rap_challenges,
             logup_alpha_powers,
             logup_table_offset,

--- a/prover/src/tests/constraint_emit_tests.rs
+++ b/prover/src/tests/constraint_emit_tests.rs
@@ -115,8 +115,13 @@ fn check_emit<T: EmitBody>(label: &str, body: &T, meta: &[ConstraintMeta]) {
 
         // --- ProverEvalFolder (base) ---
         let frame = Frame::<Gl, Gl3>::new(vec![TableView::new(vec![row.clone()], vec![vec![]])]);
-        let ctx =
-            TransitionEvaluationContext::new_prover(&frame, &no_ch, &no_ch, &offset_e, &shifts);
+        let ctx = TransitionEvaluationContext::new_prover(
+            frame.as_row_frame(),
+            &no_ch,
+            &no_ch,
+            &offset_e,
+            &shifts,
+        );
         let mut base_out = vec![FE::zero(); n];
         let mut ext_out = vec![Fp3::zero(); n];
         let mut folder = ProverEvalFolder::new(&ctx, &mut base_out, &mut ext_out);

--- a/prover/src/tests/constraint_set_tests_a.rs
+++ b/prover/src/tests/constraint_set_tests_a.rs
@@ -100,8 +100,13 @@ where
 
         // --- ProverEvalFolder (base) ---
         let frame = Frame::<Gl, Gl3>::new(vec![TableView::new(vec![row.clone()], vec![vec![]])]);
-        let ctx =
-            TransitionEvaluationContext::new_prover(&frame, &no_ch, &no_ch, &offset_e, &shifts);
+        let ctx = TransitionEvaluationContext::new_prover(
+            frame.as_row_frame(),
+            &no_ch,
+            &no_ch,
+            &offset_e,
+            &shifts,
+        );
         let mut base_out = vec![FE::zero(); n];
         let mut ext_out = vec![Fp3::zero(); n];
         let mut folder = ProverEvalFolder::new(&ctx, &mut base_out, &mut ext_out);

--- a/prover/src/tests/constraint_set_tests_b.rs
+++ b/prover/src/tests/constraint_set_tests_b.rs
@@ -93,8 +93,13 @@ fn check_table<CS: ConstraintSet<Gl, Gl3>>(label: &str, set: &CS, num_cols: usiz
 
         // --- ProverEvalFolder (base) ---
         let frame = Frame::<Gl, Gl3>::new(vec![TableView::new(vec![row.clone()], vec![vec![]])]);
-        let ctx =
-            TransitionEvaluationContext::new_prover(&frame, &no_ch, &no_ch, &offset_e, &shifts);
+        let ctx = TransitionEvaluationContext::new_prover(
+            frame.as_row_frame(),
+            &no_ch,
+            &no_ch,
+            &offset_e,
+            &shifts,
+        );
         let mut base_out = vec![FE::zero(); n];
         let mut ext_out = vec![Fp3::zero(); n];
         let mut folder = ProverEvalFolder::new(&ctx, &mut base_out, &mut ext_out);

--- a/prover/src/tests/cpu32_tests.rs
+++ b/prover/src/tests/cpu32_tests.rs
@@ -25,7 +25,13 @@ fn eval_cpu32(row: &[FE]) -> Vec<FE> {
     let shifts = PackingShifts::<GoldilocksField>::new();
     let no_e: Vec<FieldElement<GoldilocksExtension>> = vec![];
     let offset_e = FieldElement::<GoldilocksExtension>::zero();
-    let ctx = TransitionEvaluationContext::new_prover(&frame, &no_e, &no_e, &offset_e, &shifts);
+    let ctx = TransitionEvaluationContext::new_prover(
+        frame.as_row_frame(),
+        &no_e,
+        &no_e,
+        &offset_e,
+        &shifts,
+    );
     let mut base = vec![FE::zero(); n];
     let mut ext = vec![FieldElement::<GoldilocksExtension>::zero(); n];
     let mut folder = ProverEvalFolder::new(&ctx, &mut base, &mut ext);

--- a/prover/src/tests/ec_scalar_tests.rs
+++ b/prover/src/tests/ec_scalar_tests.rs
@@ -27,7 +27,13 @@ fn eval_row(trace: &TraceTable<GoldilocksField, GoldilocksExtension>, row: usize
     let shifts = PackingShifts::<GoldilocksField>::new();
     let no_e: Vec<FieldElement<GoldilocksExtension>> = vec![];
     let offset_e = FieldElement::<GoldilocksExtension>::zero();
-    let ctx = TransitionEvaluationContext::new_prover(&frame, &no_e, &no_e, &offset_e, &shifts);
+    let ctx = TransitionEvaluationContext::new_prover(
+        frame.as_row_frame(),
+        &no_e,
+        &no_e,
+        &offset_e,
+        &shifts,
+    );
     let mut base = vec![FE::zero(); n];
     let mut ext = vec![FieldElement::<GoldilocksExtension>::zero(); n];
     let mut folder = ProverEvalFolder::new(&ctx, &mut base, &mut ext);

--- a/prover/src/tests/ecdas_tests.rs
+++ b/prover/src/tests/ecdas_tests.rs
@@ -58,7 +58,13 @@ fn eval_row(trace: &TraceTable<GoldilocksField, GoldilocksExtension>, row: usize
     let shifts = PackingShifts::<GoldilocksField>::new();
     let no_e: Vec<FieldElement<GoldilocksExtension>> = vec![];
     let offset_e = FieldElement::<GoldilocksExtension>::zero();
-    let ctx = TransitionEvaluationContext::new_prover(&frame, &no_e, &no_e, &offset_e, &shifts);
+    let ctx = TransitionEvaluationContext::new_prover(
+        frame.as_row_frame(),
+        &no_e,
+        &no_e,
+        &offset_e,
+        &shifts,
+    );
     let mut base = vec![FE::zero(); n];
     let mut ext = vec![FieldElement::<GoldilocksExtension>::zero(); n];
     let mut folder = ProverEvalFolder::new(&ctx, &mut base, &mut ext);

--- a/prover/src/tests/ecsm_tests.rs
+++ b/prover/src/tests/ecsm_tests.rs
@@ -54,7 +54,13 @@ fn eval_row(trace: &TraceTable<GoldilocksField, GoldilocksExtension>, row: usize
     let shifts = PackingShifts::<GoldilocksField>::new();
     let no_e: Vec<FieldElement<GoldilocksExtension>> = vec![];
     let offset_e = FieldElement::<GoldilocksExtension>::zero();
-    let ctx = TransitionEvaluationContext::new_prover(&frame, &no_e, &no_e, &offset_e, &shifts);
+    let ctx = TransitionEvaluationContext::new_prover(
+        frame.as_row_frame(),
+        &no_e,
+        &no_e,
+        &offset_e,
+        &shifts,
+    );
     let mut base = vec![FE::zero(); n];
     let mut ext = vec![FieldElement::<GoldilocksExtension>::zero(); n];
     let mut folder = ProverEvalFolder::new(&ctx, &mut base, &mut ext);


### PR DESCRIPTION
Stacked on #764. Candidate from the perf investigation — bench in isolation before deciding.

## What

The LDE buffers have been **row-major** since the row-major LDE rework, but the evaluator still gather-copied every main + aux column of every transition offset into an owned `Frame` on **each LDE point** (~150–200 element clones per row per table) before the constraint body ran.

This replaces the Prover context's `frame` with `RowFrame`: one borrowed `(main, aux)` row-slice pair per transition offset, taken straight from the row-major storage with the same cyclic row arithmetic. The `ProverEvalFolder` and the IR interpreter read `rows[offset][col]` directly. The per-thread preallocated `Frame` + `fill_from_lde` are deleted (single-row steps are the only shape since virtual columns were removed — asserted). `Frame` stays for the verifier/OOD path and debug validation (bridged via `Frame::as_row_frame`).

**Reads the same values from the same memory — proofs are unchanged.** Gates: stark 165/165 (incl. folder-vs-capture differentials), emit differentials 13/13, release e2e prove→verify, `make lint`.

## How to bench

Isolated against the base branch (recommended — measures only this change):
```
scripts/bench_abba.sh origin/perf/row-frame-view origin/feat/single-source-constraints-switch 20
```
Or `/bench-abba` on this PR (measures vs main, i.e. this change + the whole switch branch).