### PR TITLE
fix(verifier): validate OOD trace width + portable CLI proof read

### DIFF
--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -21,16 +21,14 @@ const MIN_CONTINUATION_EPOCH_SIZE_LOG2: u32 = 18;
 
 /// Read a file into a buffer aligned for `rkyv::from_bytes`. A plain
 /// `Vec<u8>` from `std::fs::read` is align-1 by the type system even though
-/// the allocator happens to return well-aligned memory in practice — read
-/// straight into an `AlignedVec` instead of relying on that.
+/// the allocator happens to return well-aligned memory in practice — copy
+/// into an `AlignedVec` instead of relying on that. Uses the cross-platform
+/// `std::fs::read`; the previous `read_exact_at` was unix-only, and casting
+/// the u64 file length to `usize` truncated on 32-bit hosts.
 fn read_aligned_file(path: &Path) -> std::io::Result<rkyv::util::AlignedVec<16>> {
-    use std::os::unix::fs::FileExt;
-
-    let file = std::fs::File::open(path)?;
-    let len = file.metadata()?.len() as usize;
-    let mut aligned = rkyv::util::AlignedVec::<16>::with_capacity(len);
-    aligned.resize(len, 0);
-    file.read_exact_at(&mut aligned, 0)?;
+    let bytes = std::fs::read(path)?;
+    let mut aligned = rkyv::util::AlignedVec::<16>::with_capacity(bytes.len());
+    aligned.extend_from_slice(&bytes);
     Ok(aligned)
 }
 

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -900,15 +900,20 @@ pub trait IsStarkVerifier<
             }
             // The archive is read in place without validation; reject an OOD
             // table whose advertised dimensions disagree with its data length,
-            // has no rows, or whose height isn't a whole number of AIR steps
-            // (which `into_frame` below only `debug_assert!`s, not checks) —
-            // all before any row access indexes into it.
+            // has no rows, whose height isn't a whole number of AIR steps
+            // (which `into_frame` below only `debug_assert!`s, not checks), or
+            // whose width disagrees with the AIR's main+aux column count — a
+            // too-narrow row would make the boundary/transition column indexing
+            // in `step_2` read past the row slice and panic. All checks run
+            // before any row access indexes into the table.
             let trace_ood_evaluations = proof.trace_ood_evaluations();
             if !trace_ood_evaluations.dimensions_consistent()
                 || trace_ood_evaluations.height() == 0
                 || !trace_ood_evaluations
                     .height()
                     .is_multiple_of(air.step_size())
+                || trace_ood_evaluations.width()
+                    != air.trace_layout().0 + air.num_auxiliary_rap_columns()
             {
                 return false;
             }
@@ -1148,9 +1153,15 @@ pub trait IsStarkVerifier<
         // Column-major append (matches `Table::columns()` order) reading the
         // rows in place, without materializing transposed columns.
         let ood = proof.trace_ood_evaluations();
-        for col_idx in 0..ood.width() {
-            for row_idx in 0..ood.height() {
-                transcript.append_field_element(&ood.get_row(row_idx)[col_idx]);
+        // Shape validated up front (dimensions_consistent + width/height), so
+        // index the row-major backing directly instead of recomputing a row
+        // slice per element as `get_row` would.
+        let ood_width = ood.width();
+        let ood_height = ood.height();
+        let ood_data = ood.row_major_data();
+        for col_idx in 0..ood_width {
+            for row_idx in 0..ood_height {
+                transcript.append_field_element(&ood_data[row_idx * ood_width + col_idx]);
             }
         }
         // <<<< Receive value: Hᵢ(z^N)


### PR DESCRIPTION
Addresses findings from the xhigh multi-agent review of #769 (the rkyv zero-copy verify path). Targets #769 directly so it can land before/with that PR.

## Fixes

**1. Verifier panics on a prover-controlled OOD trace width (correctness — merge-blocker).**
The up-front OOD shape guard in `verify()` (`crypto/stark/src/verifier.rs`) validated `dimensions_consistent()` + `height`, but **never the width**. A malformed/hostile archived proof advertising `width < main_trace_width + num_aux` — while keeping `width*height == data.len` so `dimensions_consistent()` still passes — makes `step_2`'s boundary/transition column indexing (`ood_row[main_trace_width + c.col]`) read **past** the OOD row slice and **panic** instead of returning `false`. This is newly reachable because the zero-copy path feeds definitively untrusted input: the CLI `verify` file and the recursion guest's private-input blob via `multi_verify_archived`. Fix adds `width == trace_layout().0 + num_auxiliary_rap_columns()` to the same guard, before any row access — so it also covers the round-3 append loop and makes `step_2`'s later `checked_sub` provably succeed.

**2. `bin/cli` is unix-only + 32-bit-truncating (correctness/portability).**
`read_aligned_file` used unix-only `std::os::unix::fs::FileExt::read_exact_at` (broke non-unix compiles) and cast the u64 file length to `usize` (truncates a >4 GiB file on a 32-bit host). Now reads via cross-platform `std::fs::read` into the `AlignedVec`, which also drops the redundant `resize(len, 0)` zero-fill that `read_exact_at` immediately overwrote.

**3. OOD transcript append re-computed a row slice per element (cleanup).**
The round-3 column-major append called `get_row(row_idx)` (recomputing `slice_as_native` + width) for every element; hoisted `row_major_data()` once and index the flat backing directly (safe — shape is validated up front).

## Validation
- `cargo check -p stark -p cli` clean.
- `cargo clippy -p stark -p cli --all-targets -- -D warnings -A clippy::op_ref` clean.
- `cargo fmt --all --check` clean.
- Positive verifier tests pass, incl. the archived/serialized path (`test_verify_serialized_multi_table_proofs`), RAP/aux-column (`test_prove_rap_fib`), and multi-table (`test_multi_prove_fib_3_tables`) — the width guard does not reject valid proofs.

## Deferred to follow-ups (from the same review)
- **Negative test** asserting a too-narrow OOD width is cleanly rejected (not panicked). Needs a boundary/transition-constraint AIR to trigger the pre-fix panic deterministically; the current roundtrip test AIRs are constraint-less, so a width-tamper would fail via transcript divergence and not isolate the guard.
- **ethrex guest-ELF execution tests out of CI** (`tooling/ethrex-tests` is a detached, non-workspace crate). Note: it was detached specifically to prevent rkyv `aligned`/`unaligned` feature unification, so the fix is a dedicated CI job for the detached crate, **not** re-adding it to workspace members.
- `encode_guest_input` clones the full inner proof + ELF (memory spike); `ArchivedTable::into_frame` / `get_private_input` duplication; `bus_table_contribution()` called twice in `step_2`; `public_inputs()` Owned/Archived divergence.