### PR TITLE
perf(verifier): amortize per-table/per-query verifier work (Tier 0 + Tier 1)

### DIFF
--- a/crypto/stark/src/domain.rs
+++ b/crypto/stark/src/domain.rs
@@ -101,7 +101,6 @@ impl<F: IsFFTField> Domain<F> {
 /// which only needs to compute specific elements on-demand.
 /// This avoids allocating O(n) memory for domains that would be O(millions) of elements.
 pub struct VerifierDomain<F: IsFFTField> {
-    pub(crate) root_order: u32,
     pub(crate) trace_length: usize,
     pub(crate) lde_length: usize,
     pub(crate) trace_primitive_root: FieldElement<F>,
@@ -139,7 +138,6 @@ where
     let lde_primitive_root = Field::get_primitive_root_of_unity(lde_root_order as u64).unwrap();
 
     VerifierDomain {
-        root_order,
         trace_length,
         lde_length,
         trace_primitive_root,

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -428,6 +428,18 @@ pub trait IsStarkVerifier<
         FieldElement<FieldExtension>: AsBytes + Sync + Send,
     {
         crate::profile_markers::step_marker::<{ crate::profile_markers::STEP_VERIFY_FRI }>();
+
+        // The Q primary FRI evaluation points 𝜐 = offset·lde_root^iota, computed once
+        // (one `pow` each) and shared between the DEEP reconstruction — whose symmetric
+        // point is −𝜐, so it needs no second `pow` — and the FRI fold's 𝜐⁻¹ below.
+        // Previously the driver recomputed all 2Q (primary + symmetric) and the fold
+        // recomputed Q more.
+        let query_points: Vec<FieldElement<Field>> = challenges
+            .iotas
+            .iter()
+            .map(|iota| Self::query_challenge_to_evaluation_point(*iota, false, domain))
+            .collect();
+
         let (deep_poly_evaluations, deep_poly_evaluations_sym) =
             match Self::reconstruct_deep_composition_poly_evaluations_for_all_queries(
                 challenges,
@@ -436,6 +448,7 @@ pub trait IsStarkVerifier<
                 ood_full,
                 next_row_cols,
                 step_size,
+                &query_points,
             ) {
                 Some(pair) => pair,
                 None => return false,
@@ -482,12 +495,9 @@ pub trait IsStarkVerifier<
                 layout.terminal_len,
             );
 
-        // verify FRI
-        let mut evaluation_point_inverse = challenges
-            .iotas
-            .iter()
-            .map(|iota| Self::query_challenge_to_evaluation_point(*iota, false, domain))
-            .collect::<Vec<FieldElement<Field>>>();
+        // verify FRI: the fold needs 𝜐⁻¹ per query — reuse the primary points computed
+        // above (moved in) instead of recomputing them.
+        let mut evaluation_point_inverse = query_points;
         // Any zero evaluation point means a malformed query index, reject.
         if FieldElement::inplace_batch_inverse(&mut evaluation_point_inverse).is_err() {
             return false;
@@ -852,6 +862,9 @@ pub trait IsStarkVerifier<
         ood_full: &Table<FieldExtension>,
         next_row_cols: &[usize],
         step_size: usize,
+        // The Q primary FRI evaluation points 𝜐, computed once by the caller and shared
+        // with the FRI fold. Each query's symmetric point is −𝜐 (no extra `pow`).
+        query_points: &[FieldElement<Field>],
     ) -> Option<DeepPolynomialEvaluations<FieldExtension>> {
         let num_queries = challenges.iotas.len();
 
@@ -866,8 +879,10 @@ pub trait IsStarkVerifier<
             return None;
         }
 
-        let primitive_root = &Field::get_primitive_root_of_unity(domain.root_order as u64)
-            .expect("verifier domain root_order is a valid power of two");
+        // The trace-size primitive root is precomputed once when the verifier domain
+        // is built; reuse it instead of recomputing (which needed `root_order` and a
+        // `get_primitive_root_of_unity` — repeated squarings — every proof).
+        let primitive_root = &domain.trace_primitive_root;
 
         let query_invariant_terms = Self::compute_query_invariant_deep_terms(
             challenges,
@@ -897,14 +912,16 @@ pub trait IsStarkVerifier<
         // denominator; points ordered [q0 primary, q0 sym, q1 primary, q1 sym, …].
         let stride = ood_height + 1;
         let mut denominators = Vec::with_capacity(2 * num_queries * stride);
-        for iota in challenges.iotas.iter() {
-            for is_sym in [false, true] {
-                let evaluation_point =
-                    Self::query_challenge_to_evaluation_point(*iota, is_sym, domain);
+        // The symmetric point of each primary FRI point 𝜐 is −𝜐 (its bit-reversed LDE
+        // index is `primary + N/2` and `lde_root^(N/2) = −1`), so negate instead of a
+        // second `pow`.
+        for primary in query_points {
+            let sym = -primary;
+            for evaluation_point in [primary, &sym] {
                 for z_row_point in &z_row_points {
-                    denominators.push(&evaluation_point - z_row_point);
+                    denominators.push(evaluation_point - z_row_point);
                 }
-                denominators.push(&evaluation_point - z_pow_parts);
+                denominators.push(evaluation_point - z_pow_parts);
             }
         }
         // One inversion for the whole proof's DEEP denominators. Fails closed if any


### PR DESCRIPTION
Stacked on #829. Removes redundancies from the per-table verify path. Each runs `T` times for the ~100–140 un-batched sub-proofs of an ethrex proof, and `verifier.rs` doubles as the recursion guest, so cycles count as well as wall-clock.

### Tier 0 (micro)
- **FRI-layer leaf hashing** — hash the two folded evaluations directly from element slices (`hash_data_from_slices` + `verify_merkle_path_from_leaf_hash`, mirroring `verify_opening_pair`) instead of allocating a `vec![a, b]` per layer per query.
- **FRI fold twiddles** — produce the per-layer inverse points `𝜐^(-2ⁱ)` lazily and zip them into the fold, dropping the pre-collected `evaluation_point_vec`.
- **Redundant primitive root** — the DEEP driver recomputed `g` via `get_primitive_root_of_unity(root_order)` (~log₂N squarings/table) although the verifier domain already stores it as `trace_primitive_root`. Use that; drop the now-dead `VerifierDomain::root_order` field.
- **DEEP eval points** — compute the `Q` primary FRI points once in step 3 and reuse them for both the DEEP denominators and the FRI eval-point inverses. The symmetric point is the primary's negation (`sym_index = primary + N/2`, `lde_root^(N/2) = −1`), so no second `pow` per point.

### Tier 1 (structural)
- **Zerofier denominator** — fold the transition zerofier's shared `1/(zᴺ − 1)` into the boundary-constraint batch inverse as one trailing element (~3 muls) instead of a separate extension inversion (~70 base muls) per table.
- **OOD grid** — reconstruct the full current+next-row OOD grid once per table in `verify_rounds_2_to_4` (with the soundness-I3 shape validation, now in `reconstruct_ood_grid`) and thread it into both step 2 and step 3 instead of each rebuilding it.

### Tier 2 (per-query DEEP arithmetic)
- **DEEP trace-term denominator factoring** — the per-query trace-term sum `Σ_col Σ_row (t_col(x) − ood[row][col])·inv_den[row]·γ` multiplied the shared row denominator `1/(x − z·gʳᵒʷ)` in per `(col,row)` element. Factor it out of the column sum (`Σ_row inv_den[row]·Σ_col (…)·γ`): one extension multiply per row instead of per cell, ~halving the trace-term extension muls over 2·Q queries × T tables. Byte-identical (field add/mul are associative + commutative); the g·z pruning skip is preserved and the `trace_term_coeffs` shape guard is strengthened to exact per-dimension equality so the row-major indexing is panic-safe.

### Soundness
No checks removed. The I3 OOD-shape validation still runs (moved into `reconstruct_ood_grid`, returns `None` → reject). The folded `1/(zᴺ − 1)` still fails closed: a zero denominator (z on a boundary step or on the trace domain) fails the batch inverse and rejects. The `sym = −primary` identity is the same one the openings already rely on. The DEEP factoring reorders a finite-field sum/product, so it is exact.

### Testing
- All 198 `stark` tests pass — the `test_prove_verify_*` suite generates real proofs and runs them through the full `multi_verify_views → verify_rounds_2_to_4 → step_2/3/4` path, exercising every changed line; any DEEP drift would desync the codeword from the FRI folding.
- `cargo clippy -p stark` clean; no new warnings.
- Prover-crate ELF/recursion roundtrip tests are unrun locally (need the RISC-V toolchain to compile guest artifacts — the 139 local failures are all missing-ELF, zero verification-arithmetic). GPU and cross-verify validation to run on the server.

### Considered but deferred
- Cross-table domain/layout sharing in `multi_verify_views` — unsafe when tables have different trace lengths (table splitting), and structural; belongs with the batched-FRI lane.
- Merkle-path Keccak (~85% of native wall-clock) — only shrinks by batching commitments/FRI across tables, out of scope here.
- Double-build of `boundary_constraints` per table (counted in replay, rebuilt in step 2) — a small per-table alloc, not arithmetic; avoiding it needs a new AIR-trait count method or `Challenges` plumbing not justified by the saving.