### PR TITLE
fix(prover): print per-table instruments report on the continuation path

### DIFF
--- a/prover/src/continuation.rs
+++ b/prover/src/continuation.rs
@@ -698,6 +698,12 @@ fn prove_epoch(
     )
     .map_err(|e| Error::Prover(format!("{e:?}")))?;
 
+    // Emit this epoch's per-table timing report (same formatter as the monolithic
+    // path). `start.label` is 1-based (index + 1), so subtract 1 for the 0-based
+    // epoch number. Gated: zero overhead when the feature is off.
+    #[cfg(feature = "instruments")]
+    crate::instruments::print_epoch_report(&format!("EPOCH {}", start.label - 1));
+
     let l2g_root = proof
         .proofs
         .last()
@@ -878,7 +884,7 @@ fn prove_global(
         pairs.push((air as AirRef, trace, &()));
     }
 
-    Prover::multi_prove(
+    let proof = Prover::multi_prove(
         pairs,
         &mut global_transcript(
             elf_bytes,
@@ -890,7 +896,14 @@ fn prove_global(
         #[cfg(feature = "disk-spill")]
         stark::storage_mode::StorageMode::Ram,
     )
-    .map_err(|e| Error::Prover(format!("{e:?}")))
+    .map_err(|e| Error::Prover(format!("{e:?}")))?;
+
+    // Cross-epoch global-memory proof: emit its per-table timing report too,
+    // using the shared monolithic formatter. Gated: zero overhead when off.
+    #[cfg(feature = "instruments")]
+    crate::instruments::print_epoch_report("GLOBAL");
+
+    Ok(proof)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/prover/src/instruments.rs
+++ b/prover/src/instruments.rs
@@ -71,175 +71,7 @@ pub fn print_report(
     row_top("AIR construction", air_construction, total);
 
     if let Some(ref mp) = mp {
-        let round1 = mp.main_commits + mp.aux_build + mp.aux_commit;
-
-        row_top("Pre-pass (domains/twiddles)", mp.prepass, total);
-        row_top("Round 1", round1, total);
-        row_sub("  Main trace commits", mp.main_commits, total);
-        row_sub(
-            "    Main LDE (fused GPU: LDE+Keccak+Merkle / CPU: LDE only)",
-            mp.round1_sub.main_lde,
-            total,
-        );
-        row_sub(
-            "    Main commit (Merkle, CPU only)",
-            mp.round1_sub.main_merkle,
-            total,
-        );
-        row_sub("  Aux trace build (parallel)", mp.aux_build, total);
-        row_sub(
-            "    LogUp fingerprint (CPU)",
-            mp.round1_sub.aux_fingerprint,
-            total,
-        );
-        row_sub(
-            "    LogUp batch invert (CPU)",
-            mp.round1_sub.aux_invert,
-            total,
-        );
-        row_sub(
-            "    LogUp term combine (CPU)",
-            mp.round1_sub.aux_term,
-            total,
-        );
-        row_sub(
-            "    LogUp accumulate scan (CPU)",
-            mp.round1_sub.aux_accumulate,
-            total,
-        );
-        row_sub("  Aux trace commit", mp.aux_commit, total);
-        row_sub(
-            "    Aux LDE (fused GPU: LDE+Keccak+Merkle / CPU: LDE only)",
-            mp.round1_sub.aux_lde,
-            total,
-        );
-        row_sub(
-            "    Aux commit (Merkle, CPU only)",
-            mp.round1_sub.aux_merkle,
-            total,
-        );
-        row_top("Rounds 2\u{2013}4", mp.rounds_2_4, total);
-
-        // Merge split tables: MEMW[0..4] → MEMW x5
-        let mut merged: BTreeMap<String, MergedTable> = BTreeMap::new();
-        for (name, rows, dur, sub_ops) in &mp.table_timings {
-            let base = base_name(name).to_string();
-            let entry = merged.entry(base).or_insert(MergedTable {
-                total_dur: Duration::ZERO,
-                total_rows: 0,
-                count: 0,
-                sub_ops: stark::instruments::TableSubOps::default(),
-            });
-            entry.total_dur += *dur;
-            entry.total_rows += rows;
-            entry.count += 1;
-            entry.sub_ops.constraints += sub_ops.constraints;
-            entry.sub_ops.comp_decompose += sub_ops.comp_decompose;
-            entry.sub_ops.comp_commit += sub_ops.comp_commit;
-            entry.sub_ops.ood += sub_ops.ood;
-            entry.sub_ops.deep_comp += sub_ops.deep_comp;
-            entry.sub_ops.deep_extend += sub_ops.deep_extend;
-            entry.sub_ops.fri_commit += sub_ops.fri_commit;
-            entry.sub_ops.queries += sub_ops.queries;
-        }
-
-        let mut sorted: Vec<_> = merged.into_iter().collect();
-        sorted.sort_by(|a, b| b.1.total_dur.cmp(&a.1.total_dur));
-
-        let threshold = total.as_secs_f64() * 0.02;
-        let mut others_dur = Duration::ZERO;
-        let mut others_count = 0usize;
-
-        for (name, t) in &sorted {
-            if t.total_dur.as_secs_f64() >= threshold {
-                let display_name = if t.count > 1 {
-                    format!("{name} x{}", t.count)
-                } else {
-                    name.clone()
-                };
-                let label = format!("    {:<18} {:>6}", display_name, fmt_rows(t.total_rows),);
-                row_sub(&label, t.total_dur, total);
-            } else {
-                others_dur += t.total_dur;
-                others_count += 1;
-            }
-        }
-        if others_count > 0 {
-            let label = format!("    ({others_count} others)");
-            row_sub(&label, others_dur, total);
-        }
-
-        // Sub-operation totals across all tables
-        let mut total_constraints = Duration::ZERO;
-        let mut total_comp_decompose = Duration::ZERO;
-        let mut total_comp_commit = Duration::ZERO;
-        let mut total_ood = Duration::ZERO;
-        let mut total_deep_comp = Duration::ZERO;
-        let mut total_deep_extend = Duration::ZERO;
-        let mut total_fri_commit = Duration::ZERO;
-        let mut total_queries = Duration::ZERO;
-        for (_, t) in &sorted {
-            total_constraints += t.sub_ops.constraints;
-            total_comp_decompose += t.sub_ops.comp_decompose;
-            total_comp_commit += t.sub_ops.comp_commit;
-            total_ood += t.sub_ops.ood;
-            total_deep_comp += t.sub_ops.deep_comp;
-            total_deep_extend += t.sub_ops.deep_extend;
-            total_fri_commit += t.sub_ops.fri_commit;
-            total_queries += t.sub_ops.queries;
-        }
-
-        let sub_ops_sum = total_constraints
-            + total_comp_decompose
-            + total_comp_commit
-            + total_ood
-            + total_deep_comp
-            + total_deep_extend
-            + total_fri_commit
-            + total_queries;
-        if sub_ops_sum > Duration::ZERO {
-            let mut sub_ops: Vec<(&str, Duration)> = vec![
-                ("R2  evaluate", total_constraints),
-                ("R2  decompose_and_extend_d2", total_comp_decompose),
-                ("R2  commit_bit_reversed (comp-poly)", total_comp_commit),
-                ("R3  OOD evaluation", total_ood),
-                ("R4  deep_composition_poly_evals", total_deep_comp),
-                ("R4  interpolate+evaluate_fft", total_deep_extend),
-                ("R4  fri::commit_phase", total_fri_commit),
-                ("R4  queries & openings", total_queries),
-            ];
-            sub_ops.sort_by(|a, b| b.1.cmp(&a.1));
-            eprintln!(
-                "  {}",
-                "    \u{2500}\u{2500} sub-operation totals (all tables) \u{2500}\u{2500}",
-            );
-            for (label, dur) in &sub_ops {
-                row_sub(&format!("    {label}"), *dur, total);
-            }
-        }
-
-        // Cross-round totals: all FFT work and all Merkle work
-        let total_fft = mp.round1_sub.main_lde
-            + mp.round1_sub.aux_lde
-            + total_comp_decompose
-            + total_deep_extend;
-        let total_merkle = mp.round1_sub.main_merkle
-            + mp.round1_sub.aux_merkle
-            + total_comp_commit
-            + total_fri_commit;
-        eprintln!();
-        eprintln!(
-            "  {:<36} {:>7.2}s  {:>5.1}%",
-            "Total FFT",
-            total_fft.as_secs_f64(),
-            pct(total_fft, total)
-        );
-        eprintln!(
-            "  {:<36} {:>7.2}s  {:>5.1}%",
-            "Total Merkle",
-            total_merkle.as_secs_f64(),
-            pct(total_merkle, total)
-        );
+        print_multi_prove(mp, total);
     }
 
     eprintln!("  {}", "─".repeat(58));
@@ -274,4 +106,202 @@ pub fn print_report(
         eprintln!("  {}", "─".repeat(56));
         eprintln!();
     }
+}
+
+/// Print the mp-derived per-table timing block (Round 1 sub-ops, Rounds 2-4,
+/// merged per-table-kind timings, sub-operation totals, and cross-round FFT /
+/// Merkle totals) to stderr, as a percentage of `total`.
+///
+/// Shared by the monolithic [`print_report`] and the per-epoch continuation
+/// [`print_epoch_report`], so both paths format identically from a single source.
+fn print_multi_prove(mp: &stark::instruments::MultiProveTiming, total: Duration) {
+    let round1 = mp.main_commits + mp.aux_build + mp.aux_commit;
+
+    row_top("Pre-pass (domains/twiddles)", mp.prepass, total);
+    row_top("Round 1", round1, total);
+    row_sub("  Main trace commits", mp.main_commits, total);
+    row_sub(
+        "    Main LDE (fused GPU: LDE+Keccak+Merkle / CPU: LDE only)",
+        mp.round1_sub.main_lde,
+        total,
+    );
+    row_sub(
+        "    Main commit (Merkle, CPU only)",
+        mp.round1_sub.main_merkle,
+        total,
+    );
+    row_sub("  Aux trace build (parallel)", mp.aux_build, total);
+    row_sub(
+        "    LogUp fingerprint (CPU)",
+        mp.round1_sub.aux_fingerprint,
+        total,
+    );
+    row_sub(
+        "    LogUp batch invert (CPU)",
+        mp.round1_sub.aux_invert,
+        total,
+    );
+    row_sub(
+        "    LogUp term combine (CPU)",
+        mp.round1_sub.aux_term,
+        total,
+    );
+    row_sub(
+        "    LogUp accumulate scan (CPU)",
+        mp.round1_sub.aux_accumulate,
+        total,
+    );
+    row_sub("  Aux trace commit", mp.aux_commit, total);
+    row_sub(
+        "    Aux LDE (fused GPU: LDE+Keccak+Merkle / CPU: LDE only)",
+        mp.round1_sub.aux_lde,
+        total,
+    );
+    row_sub(
+        "    Aux commit (Merkle, CPU only)",
+        mp.round1_sub.aux_merkle,
+        total,
+    );
+    row_top("Rounds 2\u{2013}4", mp.rounds_2_4, total);
+
+    // Merge split tables: MEMW[0..4] → MEMW x5
+    let mut merged: BTreeMap<String, MergedTable> = BTreeMap::new();
+    for (name, rows, dur, sub_ops) in &mp.table_timings {
+        let base = base_name(name).to_string();
+        let entry = merged.entry(base).or_insert(MergedTable {
+            total_dur: Duration::ZERO,
+            total_rows: 0,
+            count: 0,
+            sub_ops: stark::instruments::TableSubOps::default(),
+        });
+        entry.total_dur += *dur;
+        entry.total_rows += rows;
+        entry.count += 1;
+        entry.sub_ops.constraints += sub_ops.constraints;
+        entry.sub_ops.comp_decompose += sub_ops.comp_decompose;
+        entry.sub_ops.comp_commit += sub_ops.comp_commit;
+        entry.sub_ops.ood += sub_ops.ood;
+        entry.sub_ops.deep_comp += sub_ops.deep_comp;
+        entry.sub_ops.deep_extend += sub_ops.deep_extend;
+        entry.sub_ops.fri_commit += sub_ops.fri_commit;
+        entry.sub_ops.queries += sub_ops.queries;
+    }
+
+    let mut sorted: Vec<_> = merged.into_iter().collect();
+    sorted.sort_by(|a, b| b.1.total_dur.cmp(&a.1.total_dur));
+
+    let threshold = total.as_secs_f64() * 0.02;
+    let mut others_dur = Duration::ZERO;
+    let mut others_count = 0usize;
+
+    for (name, t) in &sorted {
+        if t.total_dur.as_secs_f64() >= threshold {
+            let display_name = if t.count > 1 {
+                format!("{name} x{}", t.count)
+            } else {
+                name.clone()
+            };
+            let label = format!("    {:<18} {:>6}", display_name, fmt_rows(t.total_rows),);
+            row_sub(&label, t.total_dur, total);
+        } else {
+            others_dur += t.total_dur;
+            others_count += 1;
+        }
+    }
+    if others_count > 0 {
+        let label = format!("    ({others_count} others)");
+        row_sub(&label, others_dur, total);
+    }
+
+    // Sub-operation totals across all tables
+    let mut total_constraints = Duration::ZERO;
+    let mut total_comp_decompose = Duration::ZERO;
+    let mut total_comp_commit = Duration::ZERO;
+    let mut total_ood = Duration::ZERO;
+    let mut total_deep_comp = Duration::ZERO;
+    let mut total_deep_extend = Duration::ZERO;
+    let mut total_fri_commit = Duration::ZERO;
+    let mut total_queries = Duration::ZERO;
+    for (_, t) in &sorted {
+        total_constraints += t.sub_ops.constraints;
+        total_comp_decompose += t.sub_ops.comp_decompose;
+        total_comp_commit += t.sub_ops.comp_commit;
+        total_ood += t.sub_ops.ood;
+        total_deep_comp += t.sub_ops.deep_comp;
+        total_deep_extend += t.sub_ops.deep_extend;
+        total_fri_commit += t.sub_ops.fri_commit;
+        total_queries += t.sub_ops.queries;
+    }
+
+    let sub_ops_sum = total_constraints
+        + total_comp_decompose
+        + total_comp_commit
+        + total_ood
+        + total_deep_comp
+        + total_deep_extend
+        + total_fri_commit
+        + total_queries;
+    if sub_ops_sum > Duration::ZERO {
+        let mut sub_ops: Vec<(&str, Duration)> = vec![
+            ("R2  evaluate", total_constraints),
+            ("R2  decompose_and_extend_d2", total_comp_decompose),
+            ("R2  commit_bit_reversed (comp-poly)", total_comp_commit),
+            ("R3  OOD evaluation", total_ood),
+            ("R4  deep_composition_poly_evals", total_deep_comp),
+            ("R4  interpolate+evaluate_fft", total_deep_extend),
+            ("R4  fri::commit_phase", total_fri_commit),
+            ("R4  queries & openings", total_queries),
+        ];
+        sub_ops.sort_by(|a, b| b.1.cmp(&a.1));
+        eprintln!("      \u{2500}\u{2500} sub-operation totals (all tables) \u{2500}\u{2500}");
+        for (label, dur) in &sub_ops {
+            row_sub(&format!("    {label}"), *dur, total);
+        }
+    }
+
+    // Cross-round totals: all FFT work and all Merkle work
+    let total_fft =
+        mp.round1_sub.main_lde + mp.round1_sub.aux_lde + total_comp_decompose + total_deep_extend;
+    let total_merkle =
+        mp.round1_sub.main_merkle + mp.round1_sub.aux_merkle + total_comp_commit + total_fri_commit;
+    eprintln!();
+    eprintln!(
+        "  {:<36} {:>7.2}s  {:>5.1}%",
+        "Total FFT",
+        total_fft.as_secs_f64(),
+        pct(total_fft, total)
+    );
+    eprintln!(
+        "  {:<36} {:>7.2}s  {:>5.1}%",
+        "Total Merkle",
+        total_merkle.as_secs_f64(),
+        pct(total_merkle, total)
+    );
+}
+
+/// Print the per-table timing report for a single continuation-epoch prove.
+///
+/// Feature-gated; called right after each `multi_prove` on the continuation
+/// path (`prove_epoch`/`prove_global`). Drains the timing `store`d by that
+/// `multi_prove` via [`stark::instruments::take`] and reuses the shared
+/// [`print_multi_prove`] formatter, so per-epoch output matches the monolithic
+/// per-table report (minus the execute/trace/AIR phases, which are not measured
+/// per epoch). `total` is derived from the mp phase sum, so percentages are
+/// relative to this epoch's proving time. `label` names the section, e.g.
+/// "EPOCH 0" / "GLOBAL".
+pub fn print_epoch_report(label: &str) {
+    let Some(mp) = stark::instruments::take() else {
+        return;
+    };
+    let round1 = mp.main_commits + mp.aux_build + mp.aux_commit;
+    let total = mp.prepass + round1 + mp.rounds_2_4;
+
+    eprintln!();
+    eprintln!("=== {label} ===");
+    eprintln!("  {:<36} {:>8}  {:>5}", "Phase", "Wall", "%",);
+    eprintln!("  {}", "─".repeat(58));
+    print_multi_prove(&mp, total);
+    eprintln!("  {}", "─".repeat(58));
+    eprintln!("  {:<36} {:>7.2}s", "TOTAL", total.as_secs_f64());
+    eprintln!();
 }


### PR DESCRIPTION
## Bug

The `instruments` cargo feature prints a rich per-table-kind timing report
(merges split tables by kind, e.g. `MEMW[0..4] -> MEMW x5`, aggregates
count / rows / duration / sub-ops, sorted by cost). That report was only ever
emitted on the **monolithic** `prove()` path, from the
`#[cfg(feature = "instruments")]` block in `prover/src/lib.rs`.

The **continuation** path never went through that block: `prove_epoch` and
`prove_global` in `prover/src/continuation.rs` call `Prover::multi_prove`
directly. `multi_prove` *does* `instruments::store(MultiProveTiming { .. })` for
every call, so the per-table data was already being computed and stored — but
nothing on the continuation path ever printed it. Result:
`prove --continuations` with `--features instruments` produced **no** per-table
report at all.

## Fix

Feature-gated only (zero cost, and byte-for-byte identical compile, when the
feature is off):

- `prover/src/instruments.rs`: factor the mp-derived per-table block out of
  `print_report` into a shared `print_multi_prove(mp, total)` helper, and add
  `print_epoch_report(label)` which drains the timing stored by the preceding
  `multi_prove` via `stark::instruments::take()` and formats it with that same
  helper (so both paths format from a single source of truth). Also inlined a
  literal into one `eprintln!` format string to silence a pre-existing
  `clippy::print_literal` that only trips under `--features instruments`;
  rendered output is unchanged.
- `prover/src/continuation.rs`: after each `Prover::multi_prove`, call
  `print_epoch_report`, labeled `EPOCH N` for each epoch (from the 1-based
  `EpochStart.label`) and `GLOBAL` for the cross-epoch memory proof.

The monolithic path's output is unchanged (same statements, same order — the
mp block was moved into a function and called with the same `mp`/`total`). No
proving logic changed; this is purely gated reporting.

Note on `GLOBAL`: its per-epoch `total` is derived from the sum of the proving
phases, so for a trivially small global proof (a couple of tiny tables that run
in parallel) individual table percentages can exceed 100% — an honest artifact
of parallel per-table timing against a tiny sequential-phase denominator (the
monolithic formatter has the same parallel overlap, just diluted by a larger
wall-clock total). The `EPOCH N` reports, which carry the real work, read
normally.

## Verification

Built and ran a continuation prove that exercises `prove_epoch` (x2) +
`prove_global`:

```
cargo build --release -p cli --features instruments
./target/release/cli prove executor/program_artifacts/asm/fib_iterative_500k.elf \
    --output /tmp/cont.proof --continuations --epoch-size-log2 18
```

Per-epoch reports now print. Sample (trimmed):

```
=== EPOCH 0 ===
  Phase                                    Wall      %
  --------------------------------------------------------
  Pre-pass (domains/twiddles)             0.03s    1.0%
  Round 1                                 1.30s   38.8%
    Main trace commits                    0.59s          17.7%
    ...
  Rounds 2-4                              2.01s   60.1%
      BITWISE              1.0M           0.82s          24.5%
      MEMW_R               524K           0.47s          13.9%
      EQ                    66K           0.32s           9.7%
      CPU                  262K           0.32s           9.6%
      ...
      (16 others)                         0.67s          20.0%
      -- sub-operation totals (all tables) --
      R4  queries & openings              1.09s          32.7%
      R3  OOD evaluation                  0.66s          19.7%
      ...
  Total FFT                               0.79s   23.6%
  Total Merkle                            0.86s   25.7%
  --------------------------------------------------------
  TOTAL                                   3.34s

=== EPOCH 1 ===
  ... (same layout) ...

=== GLOBAL ===
  ... (same layout) ...
```

- Feature ON: reports print per epoch (`EPOCH 0`, `EPOCH 1`, `GLOBAL`).
- Feature OFF (`cargo build --release -p cli`): zero instruments lines in the
  continuation prove output; compiles clean (all new code is
  `#[cfg(feature = "instruments")]`).
- `cargo test --release -p lambda-vm-prover --lib`: 521 passed, 0 failed.
- `clippy --features instruments` (which CI's `make lint` does not exercise)
  is clean on the changed crates; all three `make lint` clippy passes exit 0;
  `cargo fmt --check` is clean on the changed crates.
</content>
