### PR TITLE
fix(prover): emit missing marker on continuation verify paths

### DIFF
--- a/prover/src/continuation.rs
+++ b/prover/src/continuation.rs
@@ -806,6 +806,9 @@ fn verify_epoch(
         None => return Ok(false),
     };
 
+    stark::profile_markers::step_marker::<{ stark::profile_markers::STEP_AIRS_AND_BUS_BALANCE_DONE }>(
+    );
+
     if !Verifier::multi_verify_views(&refs, proof, &mut seed(), &expected) {
         return Ok(false);
     }
@@ -964,6 +967,9 @@ fn verify_global(
     for air in &gm_airs {
         refs.push(air as AirRef);
     }
+
+    stark::profile_markers::step_marker::<{ stark::profile_markers::STEP_AIRS_AND_BUS_BALANCE_DONE }>(
+    );
 
     Verifier::multi_verify_views(
         &refs,


### PR DESCRIPTION
## Summary
- `verify_epoch`'s per-epoch verify and `verify_global` (continuation.rs) call `Verifier::multi_verify_views` directly, without the `STEP_AIRS_AND_BUS_BALANCE_DONE` marker that `prover/lib.rs`'s monolithic `verify_proof_parts` emits before its own `multi_verify_views` call.
- The recursion-block profile test (`test_recursion_profile_blowup4_block`) buckets cycles by the latest marker observed, so on the continuation path the "multi_verify setup (transcript replay phase A/B, per-table fork)" step reported a flat 0% — its real cost was silently folded into whichever bucket was already active (airs_and_bus_balance for the first epoch, step4:openings carried over for later epochs/the global proof).
- Adds the same marker call at both continuation call sites, matching the monolithic path.

## Test plan
- [x] `cargo check -p lambda-vm-prover --lib`
- [x] `make test-profile-recursion-block` — step 2 now reports 17,041,080 cycles (1.16%) instead of 0