### PR TITLE
perf(programs): build the ethrex guest with thin LTO

### DIFF
--- a/executor/programs/rust/ethrex/Cargo.toml
+++ b/executor/programs/rust/ethrex/Cargo.toml
@@ -1,5 +1,12 @@
 [workspace]
 
+# Thin LTO measurably lowers executed guest cycles (~2.3% on the committed
+# ethrex_bench fixtures) at a small ELF-size cost, which is free in this VM
+# (execution is priced per executed instruction, not by ELF size). Cargo's
+# release default is lto = false / codegen-units = 16.
+[profile.release]
+lto = "thin"
+
 [package]
 name = "ethrex"
 version = "0.1.0"


### PR DESCRIPTION
## What

Add a `[profile.release]` with `lto = "thin"` to the ethrex guest crate
(`executor/programs/rust/ethrex/Cargo.toml`). The crate previously had no
`[profile.release]` at all, so it built with cargo's release defaults
(`lto = false`, `codegen-units = 16`).

## Why

Thin LTO measurably lowers the number of instructions the VM executes for a
real ethrex block, at no runtime cost — execution in this VM is priced per
executed instruction, so the small ELF-size increase is free.

Measured on the committed fixtures (same toolchain, same inputs):

| fixture | baseline (cycles) | thin-LTO (cycles) | Δ cycles | Δ % | Keccak | Ecsm |
|---|---|---|---|---|---|---|
| `ethrex_bench_4.bin`  |  3,841,262 |  3,750,291 |  −90,971 | −2.37% | 174 | 16 |
| `ethrex_bench_16.bin` | 11,616,950 | 11,352,127 | −264,823 | −2.28% | 356 | 64 |

The syscall invariants are identical before and after (Keccak 174 / Ecsm 16 for
`_4`, Keccak 356 / Ecsm 64 for `_16`) — the guest does exactly the same work;
LTO just compiles it into fewer executed instructions.

## Methodology

Deterministic A/B on a dedicated 32-core rig, same toolchain
(`nightly-2026-02-01`, `-Z build-std`, `riscv64im-lambda-vm-elf`), cycles read
via `cli execute --cycles` on the committed fixtures. The measurement noise
floor is exactly 0: the pristine baseline was built twice in separate
`CARGO_TARGET_DIR`s and produced byte-identical ELFs, so the deltas above are
the whole signal.

## Size

Guest ELF grows 3.64 MB → 3.82 MB (+4.9%). This is free here: the VM charges
per executed instruction, not by ELF size.

## Follow-up (out of scope)

A tuned variant — thin LTO plus `-C llvm-args=-inline-threshold=2500` /
`-unroll-threshold=2000` — measured a further ~2× improvement
(`ethrex_bench_16` 11,035,843, −5.00% total; `ethrex_bench_4` 3,616,998,
−5.84% total) at +66% ELF size. That inline/unroll tuning is deliberately left
out of this PR and can land as a separate change.
