### PR TITLE
perf(hint): big-endian hint ABI + ecall address validation

### DIFF
--- a/crypto/ethrex-crypto/Cargo.lock
+++ b/crypto/ethrex-crypto/Cargo.lock
@@ -292,6 +292,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlmalloc"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +574,8 @@ dependencies = [
 name = "lambda-vm-syscalls"
 version = "0.1.0"
 dependencies = [
+ "critical-section",
+ "dlmalloc",
  "embedded-alloc",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
@@ -1023,6 +1036,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/crypto/ethrex-crypto/src/lib.rs
+++ b/crypto/ethrex-crypto/src/lib.rs
@@ -16,6 +16,9 @@
 //! Every other `Crypto` method inherits the trait default (vetted pure-Rust
 //! crates: `ark-bn254`, `bls12_381`, `p256`, `sha2`, `ripemd`, …).
 
+// Only used by the host (non-riscv64) keccak fallback; the guest hashes via the
+// keccak_permute ecall and this import would be dead code there.
+#[cfg(not(target_arch = "riscv64"))]
 use ethrex_crypto::keccak::keccak_hash;
 use ethrex_crypto::{Crypto, CryptoError};
 use k256::elliptic_curve::group::prime::PrimeCurveAffine;
@@ -80,15 +83,15 @@ impl Crypto for LambdaVmEcsmCrypto {
 /// We compute the recovery directly rather than calling k256's
 /// `recover_from_prehash`, which internally runs a *second* lincomb to
 /// re-verify the key — doubling the ECSM ecalls for no gain here.
-/// Obtain a 32-byte little-endian hint for `x_le` via the executor `hint` ecall
+/// Obtain a 32-byte **big-endian** hint for `x_be` via the executor `hint` ecall
 /// (the host computes the modular inverse / sqrt; the value is provable via the
 /// prover's HINT table). The result is UNVERIFIED — every caller MUST check it
 /// in-guest (`x·inv == 1`, `y² == x³+7`), since the ecall adds no correctness
 /// constraint. BENCH scaffolding.
 #[cfg(target_arch = "riscv64")]
-fn get_hint(hint_id: usize, x_le: &[u8; 32]) -> [u8; 32] {
+fn get_hint(hint_id: usize, x_be: &[u8; 32]) -> [u8; 32] {
     let mut out = [0u8; 32];
-    lambda_vm_syscalls::syscalls::hint(hint_id, &mut out, x_le);
+    lambda_vm_syscalls::syscalls::hint(hint_id, &mut out, x_be);
     out
 }
 
@@ -99,17 +102,10 @@ fn scalar_inv(x: &Scalar) -> Option<Scalar> {
     #[cfg(target_arch = "riscv64")]
     {
         use k256::elliptic_curve::subtle::ConstantTimeEq;
-        let x_be = x.to_bytes();
-        let mut x_le = [0u8; 32];
-        for i in 0..32 {
-            x_le[i] = x_be[31 - i];
-        }
-        let inv_le = get_hint(lambda_vm_syscalls::syscalls::HINT_SCALAR_INV, &x_le);
-        let mut inv_be = k256::FieldBytes::default();
-        for i in 0..32 {
-            inv_be[i] = inv_le[31 - i];
-        }
-        let inv: Scalar = Option::from(Scalar::from_repr(inv_be))?;
+        // The hint ABI is big-endian — k256's native serialization, no reversals.
+        let x_be: [u8; 32] = x.to_bytes().into();
+        let inv_be = get_hint(lambda_vm_syscalls::syscalls::HINT_SCALAR_INV, &x_be);
+        let inv: Scalar = Option::from(Scalar::from_repr(inv_be.into()))?;
         // Verify the untrusted hint: x·inv must equal 1 (mod n).
         if bool::from((*x * inv).ct_eq(&Scalar::ONE)) {
             Some(inv)
@@ -136,17 +132,9 @@ fn decompress_r(r_bytes: &FieldBytes, y_is_odd: bool) -> Option<AffinePoint> {
         let seven: FieldElement = Option::from(FieldElement::from_bytes(&seven_bytes.into()))?;
         let x3: FieldElement = x.square() * x;
         let rhs: FieldElement = x3 + seven;
-        // Hinted sqrt (LE in/out), then verify y² == rhs canonically.
-        let rhs_be = rhs.to_bytes();
-        let mut rhs_le = [0u8; 32];
-        for i in 0..32 {
-            rhs_le[i] = rhs_be[31 - i];
-        }
-        let y_le = get_hint(lambda_vm_syscalls::syscalls::HINT_FIELD_SQRT, &rhs_le);
-        let mut y_be = [0u8; 32];
-        for i in 0..32 {
-            y_be[i] = y_le[31 - i];
-        }
+        // Hinted sqrt (BE in/out), then verify y² == rhs.
+        let rhs_be: [u8; 32] = rhs.to_bytes().into();
+        let y_be = get_hint(lambda_vm_syscalls::syscalls::HINT_FIELD_SQRT, &rhs_be);
         let mut y: FieldElement = Option::from(FieldElement::from_bytes(&y_be.into()))?;
         let y2: FieldElement = y.square();
         if y2.to_bytes() != rhs.to_bytes() {
@@ -285,23 +273,17 @@ fn ecsm_oracle(x: &FieldElement, k: &Scalar) -> Option<FieldElement> {
 ///
 /// Generic over the oracle so unit tests can substitute a software stand-in.
 /// Base-field inverse `x⁻¹ mod p`. On riscv64 the host supplies it via the
-/// `hint` ecall and we verify `x·inv == 1` (canonical byte compare to sidestep
-/// k256's lazy-normalized magnitudes); off-target it inverts in software.
+/// `hint` ecall and we verify `x·inv == 1`; off-target it inverts in software.
 #[cfg(any(target_arch = "riscv64", test))]
 fn field_inv(x: &FieldElement) -> Option<FieldElement> {
     #[cfg(target_arch = "riscv64")]
     {
-        let x_be = x.to_bytes();
-        let mut x_le = [0u8; 32];
-        for i in 0..32 {
-            x_le[i] = x_be[31 - i];
-        }
-        let inv_le = get_hint(lambda_vm_syscalls::syscalls::HINT_FIELD_INV, &x_le);
-        let mut inv_be = [0u8; 32];
-        for i in 0..32 {
-            inv_be[i] = inv_le[31 - i];
-        }
+        // The hint ABI is big-endian — k256's native serialization, no reversals.
+        let x_be: [u8; 32] = x.to_bytes().into();
+        let inv_be = get_hint(lambda_vm_syscalls::syscalls::HINT_FIELD_INV, &x_be);
         let inv: FieldElement = Option::from(FieldElement::from_bytes(&inv_be.into()))?;
+        // Canonical compare: k256's ct_eq compares internal (lazy) representations
+        // and can reject an arithmetically-equal product.
         if (*x * inv).to_bytes() == FieldElement::ONE.to_bytes() {
             Some(inv)
         } else {

--- a/executor/programs/rust/ethrex/Cargo.lock
+++ b/executor/programs/rust/ethrex/Cargo.lock
@@ -582,6 +582,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlmalloc"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,6 +1263,8 @@ dependencies = [
 name = "lambda-vm-syscalls"
 version = "0.1.0"
 dependencies = [
+ "critical-section",
+ "dlmalloc",
  "embedded-alloc",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
@@ -2481,6 +2494,15 @@ name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]

--- a/executor/programs/rust/hint_min/Cargo.lock
+++ b/executor/programs/rust/hint_min/Cargo.lock
@@ -27,6 +27,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "dlmalloc"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "embedded-alloc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +89,8 @@ dependencies = [
 name = "lambda-vm-syscalls"
 version = "0.1.0"
 dependencies = [
+ "critical-section",
+ "dlmalloc",
  "embedded-alloc",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
@@ -302,6 +315,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/executor/programs/rust/hint_min/src/main.rs
+++ b/executor/programs/rust/hint_min/src/main.rs
@@ -13,7 +13,7 @@ struct Aligned32([u8; 32]);
 pub fn main() {
     // input = 3 (little-endian), a valid invertible field element.
     let mut x = Aligned32([0u8; 32]);
-    x.0[0] = 3;
+    x.0[31] = 3; // big-endian hint input (ABI is BE)
     let mut inv = Aligned32([0u8; 32]);
 
     syscalls::syscalls::hint(

--- a/executor/programs/rust/hint_multi/Cargo.lock
+++ b/executor/programs/rust/hint_multi/Cargo.lock
@@ -27,6 +27,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "dlmalloc"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "embedded-alloc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +89,8 @@ dependencies = [
 name = "lambda-vm-syscalls"
 version = "0.1.0"
 dependencies = [
+ "critical-section",
+ "dlmalloc",
  "embedded-alloc",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
@@ -302,6 +315,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/executor/programs/rust/hint_multi/src/main.rs
+++ b/executor/programs/rust/hint_multi/src/main.rs
@@ -19,7 +19,7 @@ pub fn main() {
 
     for seed in [3u8, 5u8, 7u8] {
         let mut x = Aligned32([0u8; 32]);
-        x.0[0] = seed;
+        x.0[31] = seed; // big-endian hint input (ABI is BE)
         let mut inv = Aligned32([0u8; 32]);
 
         syscalls::syscalls::hint(syscalls::syscalls::HINT_FIELD_INV, &mut inv.0, &x.0);

--- a/executor/src/vm/instruction/execution.rs
+++ b/executor/src/vm/instruction/execution.rs
@@ -113,20 +113,18 @@ fn store_u256_le(memory: &mut Memory, addr: u64, bytes: &[u8; 32]) -> Result<(),
 
 /// BENCH ONLY. Compute a non-constraining hint (modular inverse / sqrt) with the
 /// same k256 arithmetic the guest verifies against. Input/output are 32-byte
-/// little-endian (matching the ECSM ABI). On any failure (non-canonical input,
-/// no inverse/sqrt) returns zeros; the guest's verify then fails loudly.
+/// **big-endian** — k256's native serialization (`to_bytes`/`from_bytes`), so
+/// neither the host nor the guest pays any byte-reversal loop. (The ECSM ecall
+/// ABI stays little-endian; the hint ABI is BE because every current consumer is
+/// k256-native.) On any failure (non-canonical input, no inverse/sqrt) returns
+/// zeros; the guest's verify then fails loudly.
 ///
 /// `pub` so the prover's `collect_hint_ops` can reproduce the exact output value
 /// the executor wrote to guest memory (the value is not carried in the CPU log).
-pub fn compute_hint(hint_id: u64, in_le: &[u8; 32]) -> [u8; 32] {
+pub fn compute_hint(hint_id: u64, in_be: &[u8; 32]) -> [u8; 32] {
     use k256::elliptic_curve::PrimeField;
-    // k256 serialization is big-endian; the ABI is little-endian.
-    let mut be = [0u8; 32];
-    for i in 0..32 {
-        be[i] = in_le[31 - i];
-    }
     let mut fb = k256::FieldBytes::default();
-    fb.copy_from_slice(&be);
+    fb.copy_from_slice(in_be);
 
     let out_be: [u8; 32] = match hint_id {
         HINT_FIELD_INV => {
@@ -153,11 +151,7 @@ pub fn compute_hint(hint_id: u64, in_le: &[u8; 32]) -> [u8; 32] {
         _ => [0u8; 32],
     };
 
-    let mut out_le = [0u8; 32];
-    for i in 0..32 {
-        out_le[i] = out_be[31 - i];
-    }
-    out_le
+    out_be
 }
 
 /// Checks the ECSM address-alignment assumption: `(addr mod 2^32) + max_offset < 2^32`.
@@ -524,10 +518,19 @@ impl Instruction {
                     SyscallNumbers::Hint => {
                         // BENCH ONLY. Non-constraining hint: host computes a modular
                         // inverse/sqrt and writes it to the guest, which verifies it.
-                        // a0 = hint_id, a1 = input addr (32-byte LE), a2 = output addr.
+                        // a0 = hint_id, a1 = input addr (32-byte BE), a2 = output addr.
                         let hint_id = registers.read(10)?;
                         let in_addr = registers.read(11)?;
                         let out_addr = registers.read(12)?;
+                        // The HINT table sends four 8-byte writes at out_addr +0/8/16/24,
+                        // so out_addr must be doubleword-aligned, and neither operand may
+                        // overflow the low 32-bit address limb (same constraint as ECSM).
+                        if out_addr % 8 != 0
+                            || !ecsm_addr_ok(in_addr, 31)
+                            || !ecsm_addr_ok(out_addr, 31)
+                        {
+                            return Err(ExecutionError::EcsmAddressOverflow);
+                        }
                         let input = load_u256_le(memory, in_addr)?;
                         let output = compute_hint(hint_id, &input);
                         store_u256_le(memory, out_addr, &output)?;

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -982,10 +982,12 @@ fn collect_hint_ops(
     let in_addr = register_state.read(11).0;
     let out_addr = register_state.read(12).0;
 
-    // Read the 32-byte little-endian input from the replayed memory.
+    // Read the 32-byte big-endian input from the replayed memory (4 batched
+    // doubleword reads, same map traffic shape as the output writes below).
     let mut input = [0u8; 32];
-    for (i, b) in input.iter_mut().enumerate() {
-        *b = memory_state.read_byte(in_addr.wrapping_add(i as u64)).0;
+    for i in 0..4 {
+        let (vals, _ts) = memory_state.read_bytes(in_addr.wrapping_add((8 * i) as u64), 8);
+        input[8 * i..8 * i + 8].copy_from_slice(&vals.map(|v| v as u8));
     }
 
     // Recompute the output exactly as the executor did (the value isn't in the log).

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -1234,9 +1234,9 @@ fn test_prove_hint_min_rust_guest() {
         "hint_min rust guest should verify"
     );
 
-    // Committed output must equal the hinted value (field inverse of 3, 32-byte LE).
+    // Committed output must equal the hinted value (field inverse of 3, 32-byte BE).
     let mut input = [0u8; 32];
-    input[0] = 3;
+    input[31] = 3; // big-endian hint input (ABI is BE)
     let expected =
         executor::vm::instruction::execution::compute_hint(0 /* HINT_FIELD_INV */, &input);
     assert_eq!(proof.public_output, expected.to_vec());
@@ -1265,11 +1265,11 @@ fn test_prove_hint_multi_rust_guest() {
         "hint_multi rust guest should verify"
     );
 
-    // Expected = XOR of field-inverses of 3, 5, 7 (32-byte LE), matching the guest.
+    // Expected = XOR of field-inverses of 3, 5, 7 (32-byte BE), matching the guest.
     let mut expected = [0u8; 32];
     for seed in [3u8, 5u8, 7u8] {
         let mut input = [0u8; 32];
-        input[0] = seed;
+        input[31] = seed; // big-endian hint input (ABI is BE)
         let inv =
             executor::vm::instruction::execution::compute_hint(0 /* HINT_FIELD_INV */, &input);
         for i in 0..32 {

--- a/syscalls/src/syscalls.rs
+++ b/syscalls/src/syscalls.rs
@@ -199,8 +199,9 @@ pub fn ecsm_mul(_xr: &mut [u8; 32], _xg: &[u8; 32], _k: &[u8; 32]) {
 
 /// BENCH ONLY. Ask the host for a non-constraining hint (modular inverse/sqrt).
 /// `hint_id` selects the operation ([`HINT_FIELD_INV`]/[`HINT_SCALAR_INV`]/
-/// [`HINT_FIELD_SQRT`]); `input`/`out` are 32-byte little-endian field/scalar
-/// elements. The result is UNVERIFIED — the caller MUST check it in-guest
+/// [`HINT_FIELD_SQRT`]); `input`/`out` are 32-byte **big-endian** field/scalar
+/// elements (k256's native serialization — no byte-reversal loops on either
+/// side). The result is UNVERIFIED — the caller MUST check it in-guest
 /// (e.g. `x·inv == 1`), since this ecall adds no correctness constraint.
 #[cfg(target_arch = "riscv64")]
 pub fn hint(hint_id: usize, out: &mut [u8; 32], input: &[u8; 32]) {
@@ -208,8 +209,8 @@ pub fn hint(hint_id: usize, out: &mut [u8; 32], input: &[u8; 32]) {
         asm!(
             "ecall",
             in("a0") hint_id,           // x10 = hint selector
-            in("a1") input.as_ptr(),    // x11 = input address (32-byte LE)
-            in("a2") out.as_mut_ptr(),  // x12 = output address (32-byte LE)
+            in("a1") input.as_ptr(),    // x11 = input address (32-byte BE)
+            in("a2") out.as_mut_ptr(),  // x12 = output address (32-byte BE)
             in("a7") HINT_SYSCALL_NUMBER,
         )
     }


### PR DESCRIPTION
The hint ecall's consumers are all k256-native (to_bytes/from_bytes are big-endian), so make the ABI big-endian end to end and delete the ~8 per-byte reversal loops per hint call (2 per consumer x3 + 2 in the host's compute_hint). ethrex 1-tx: 945,875 -> 916,372 cycles vs the LE branch, with byte-identical public output.

Also:
- Validate the Hint dispatch addresses: out_addr must be doubleword aligned (the HINT table sends four 8-byte writes at +0/8/16/24) and neither operand may overflow the low 32-bit address limb (same ecsm_addr_ok constraint as ECSM).
- collect_hint_ops reads the hint input with 4 batched doubleword reads instead of 32 byte reads.
- cfg-gate the stale ethrex_crypto::keccak::keccak_hash import (host-only keccak fallback; dead code + warning on riscv64).
- hint guests seed their inputs as true big-endian; prove-test expectations/comments updated to match.

Verify note: the guest verify stays a canonical to_bytes comparison on purpose -- k256's FieldElement::ct_eq compares lazy internal representations limb-wise (no normalization), so it can reject an arithmetically-equal product from a mul chain; canonical compare is the correct check here.

Verified: 14/14 ethrex-crypto tests, executor+prover build clean, riscv64 cross-check clean, 3/3 hint prove tests (min, multi, forged rejection), ethrex fixtures cycles 640,133 / 916,372 / 1,876,730 (empty/1-tx/10-tx) with byte-identical output vs baseline.