### PR TITLE
docs(prover): allow 6->2 step-marker transition on the continuation path

### DIFF
--- a/prover/src/tests/recursion_smoke_test.rs
+++ b/prover/src/tests/recursion_smoke_test.rs
@@ -827,6 +827,13 @@ fn test_recursion_execute_1query() {
 /// the `3,4,5,6` cycle (one per table). A transition outside
 /// `{1->2, 2->3, 3->4, 4->5, 5->6, 6->3}` means the marker convention broke —
 /// wrong immediate decoded, or a stale/mismatched build.
+///
+/// That transition set is the monolithic path's. The continuation guest
+/// (`continuation` feature) re-emits `STEP_AIRS_AND_BUS_BALANCE_DONE` before
+/// each epoch's `multi_verify_views` (`continuation::verify_epoch`) and once
+/// more before the global-memory verify (`continuation::verify_global`), so
+/// there `6->2` is also a valid transition. This test runs the monolithic
+/// guest, where those markers never fire.
 #[test]
 #[ignore = "slow: runs the in-VM STARK verifier (minutes on CI)"]
 fn test_recursion_step_markers_observed_in_order() {


### PR DESCRIPTION
## Summary
- The doc comment on `test_recursion_step_markers_observed_in_order` defines the valid step-marker transitions as `{1->2, 2->3, 3->4, 4->5, 5->6, 6->3}` and states any other transition means the marker convention broke.
- That set only covers the monolithic verify path. With #855, the continuation guest re-emits `STEP_AIRS_AND_BUS_BALANCE_DONE` before each epoch's `multi_verify_views` (`continuation::verify_epoch`) and once more before the global-memory verify (`continuation::verify_global`), making `6->2` a legitimate transition there.
- Extends the comment to note the set is monolithic-only, so the documented invariant isn't read as universal (the test itself is unaffected — it runs the monolithic `recursion-min` guest, where the continuation markers never fire).

## Test plan
- [x] Comment-only change; no code touched