### PR TITLE
fix(bench): flag /bench comparisons against a noisy baseline instead of verdicting them

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -431,6 +431,14 @@ jobs:
           TIME_SPREAD=$(awk "BEGIN { if ($TIME_MEDIAN > 0) printf \"%.1f\", (($TIME_MAX - $TIME_MIN) / $TIME_MEDIAN) * 100; else print \"0.0\" }")
           ALL_TIMES=$(echo $TIMES | tr ' ' '\n' | paste -sd '/' -)
 
+          # Say it at record time, not only at consume time: on push/dispatch these
+          # numbers become the cached baseline, and a noisy one mis-verdicts every
+          # /bench until the next refresh (2026-08-03: a 65.8%-spread baseline made
+          # healthy PRs read as ±20-35% for half an hour).
+          if awk "BEGIN { exit !($TIME_SPREAD > 5.0) }"; then
+            echo "::warning::Real-block prove-time spread ${TIME_SPREAD}% ($ALL_TIMES) — if this run publishes a baseline, /bench will flag comparisons against it as unreliable."
+          fi
+
           {
             echo "real_time_s=$TIME_MEDIAN"
             echo "real_peak_mb=$HEAP_MEDIAN"
@@ -471,7 +479,7 @@ jobs:
                 # grep could match two lines and write a multi-line step output.
                 get() { grep "^$1=" "$BASELINE_FILE" | head -1 | cut -d= -f2; }
                 for key in growth_heaps growth_slope_mb growth_r2 \
-                           real_time_s real_peak_mb real_input; do
+                           real_time_s real_peak_mb real_time_spread real_input; do
                   # A baseline predating the real block simply has no real_* keys; empty
                   # values hide the table rather than producing a bogus comparison.
                   echo "$key=$(get "$key")" >> "$GITHUB_OUTPUT"
@@ -620,6 +628,7 @@ jobs:
           BA_GROWTH_R2: ${{ steps.baseline-artifact.outputs.growth_r2 }}
           BA_REAL_TIME: ${{ steps.baseline-artifact.outputs.real_time_s }}
           BA_REAL_PEAK: ${{ steps.baseline-artifact.outputs.real_peak_mb }}
+          BA_REAL_SPREAD: ${{ steps.baseline-artifact.outputs.real_time_spread }}
           BA_REAL_INPUT: ${{ steps.baseline-artifact.outputs.real_input }}
           # Baseline run outputs
           BR_GROWTH_HEAPS: ${{ steps.baseline-run.outputs.growth_heaps }}
@@ -648,6 +657,7 @@ jobs:
             BASELINE_GROWTH_R2="$BA_GROWTH_R2"
             BASELINE_REAL_TIME="$BA_REAL_TIME"
             BASELINE_REAL_PEAK="$BA_REAL_PEAK"
+            BASELINE_REAL_SPREAD="$BA_REAL_SPREAD"
             BASELINE_REAL_INPUT="$BA_REAL_INPUT"
           else
             BASELINE_SRC="built from main"
@@ -656,6 +666,9 @@ jobs:
             BASELINE_GROWTH_R2="$BR_GROWTH_R2"
             BASELINE_REAL_TIME="$BR_REAL_TIME"
             BASELINE_REAL_PEAK="$BR_REAL_PEAK"
+            # A freshly-built baseline runs in this same session, so there is no
+            # recorded-earlier spread to distrust; empty suppresses the noise warning.
+            BASELINE_REAL_SPREAD=""
             # Freshly proven on this runner from $REAL_INPUT, so by construction the
             # same block the PR side used; the cached path carries its own label.
             BASELINE_REAL_INPUT="$PR_REAL_INPUT"
@@ -684,6 +697,7 @@ jobs:
           echo "pr_real_all_times=$PR_REAL_ALL_TIMES" >> "$GITHUB_OUTPUT"
           echo "baseline_real_time=$BASELINE_REAL_TIME" >> "$GITHUB_OUTPUT"
           echo "baseline_real_peak=$BASELINE_REAL_PEAK" >> "$GITHUB_OUTPUT"
+          echo "baseline_real_spread=$BASELINE_REAL_SPREAD" >> "$GITHUB_OUTPUT"
           # No baseline_real_input output: the comment never names the baseline's block
           # except on a mismatch, which real_mismatch below already carries.
 
@@ -746,6 +760,7 @@ jobs:
           PR_REAL_INPUT: ${{ steps.compare.outputs.pr_real_input }}
           BASE_REAL_TIME: ${{ steps.compare.outputs.baseline_real_time }}
           BASE_REAL_PEAK: ${{ steps.compare.outputs.baseline_real_peak }}
+          BASE_REAL_SPREAD: ${{ steps.compare.outputs.baseline_real_spread }}
           REAL_TIME_DIFF: ${{ steps.compare.outputs.real_time_diff }}
           REAL_TIME_PCT: ${{ steps.compare.outputs.real_time_pct }}
           REAL_PEAK_DIFF: ${{ steps.compare.outputs.real_peak_diff }}
@@ -786,6 +801,7 @@ jobs:
             const realInput = process.env.PR_REAL_INPUT;
             const baseRealTime = process.env.BASE_REAL_TIME;
             const baseRealPeak = process.env.BASE_REAL_PEAK;
+            const baseRealSpread = process.env.BASE_REAL_SPREAD;
             const realTimeDiff = process.env.REAL_TIME_DIFF;
             const realTimePct = process.env.REAL_TIME_PCT;
             const realPeakDiff = process.env.REAL_PEAK_DIFF;
@@ -816,18 +832,28 @@ jobs:
 
               const haveRealCmp = !!(baseRealTime && realTimePct && !realMismatch);
               if (haveRealCmp) {
+                // A noisy baseline invalidates every Δ in the table, so the row icons
+                // go neutral too — a 🟢 beside a number the warning below calls
+                // unreliable reads as a verdict anyway.
+                const baseNoisy = !!(baseRealSpread && parseFloat(baseRealSpread) > 5.0);
+                const rowIcon = (pct) => baseNoisy ? '❔' : icon(pct);
                 body += `| Metric | main | PR | Δ |\n`;
                 body += `|--------|------|----|---|\n`;
                 if (realPeak && baseRealPeak && realPeakPct) {
-                  body += `| **Peak heap** | ${baseRealPeak} MB | ${realPeak} MB | ${fmt(realPeakDiff)} MB (${fmt(realPeakPct)}%) ${icon(realPeakPct)} |\n`;
+                  body += `| **Peak heap** | ${baseRealPeak} MB | ${realPeak} MB | ${fmt(realPeakDiff)} MB (${fmt(realPeakPct)}%) ${rowIcon(realPeakPct)} |\n`;
                 }
-                body += `| **Prove time** | ${baseRealTime}s | ${realTime}s | ${fmt(realTimeDiff)}s (${fmt(realTimePct)}%) ${icon(realTimePct)} |\n\n`;
+                body += `| **Prove time** | ${baseRealTime}s | ${realTime}s | ${fmt(realTimeDiff)}s (${fmt(realTimePct)}%) ${rowIcon(realTimePct)} |\n\n`;
 
                 // Bands of 10%/3%, wider than a fast workload would need: 3 runs of a
                 // minutes-long prove resolve coarsely, so the middle is reported as
                 // unresolved rather than as "fine".
                 const rp = parseFloat(realTimePct);
-                if (rp > 10) {
+                // A noisy baseline invalidates the verdict, not just softens it: on
+                // 2026-08-03 a 65.8%-spread baseline verdicted healthy PRs at ±20-35%.
+                // Same 5% threshold as the PR-side spread note below.
+                if (baseNoisy) {
+                  body += `> ⚠️ **The cached baseline was noisy when it was recorded** (prove-time spread ${baseRealSpread}%), so the Δ column compares against an unreliable number and no verdict is drawn. Refresh it (Actions → "Benchmark (PR)" → Run workflow on main), then re-run \`/bench\` — or use \`/bench-abba\`, which measures both sides itself.\n`;
+                } else if (rp > 10) {
                   body += `> ⚠️ **Regression on the real block** — prove time up ${Math.abs(rp).toFixed(1)}%.\n`;
                 } else if (rp < -10) {
                   body += `> 🎉 **Improvement on the real block** — prove time down ${Math.abs(rp).toFixed(1)}%.\n`;

--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -435,7 +435,10 @@ jobs:
           # numbers become the cached baseline, and a noisy one mis-verdicts every
           # /bench until the next refresh (2026-08-03: a 65.8%-spread baseline made
           # healthy PRs read as ±20-35% for half an hour).
-          if awk "BEGIN { exit !($TIME_SPREAD > 5.0) }"; then
+          # 3%: the comment's verdict bands treat >=3% as a reportable delta, so a
+          # spread that could manufacture one is by definition too noisy. Keep in
+          # sync with the two 3.0 thresholds in the Comment step's renderer.
+          if awk "BEGIN { exit !($TIME_SPREAD > 3.0) }"; then
             echo "::warning::Real-block prove-time spread ${TIME_SPREAD}% ($ALL_TIMES) — if this run publishes a baseline, /bench will flag comparisons against it as unreliable."
           fi
 
@@ -835,7 +838,9 @@ jobs:
                 // A noisy baseline invalidates every Δ in the table, so the row icons
                 // go neutral too — a 🟢 beside a number the warning below calls
                 // unreliable reads as a verdict anyway.
-                const baseNoisy = !!(baseRealSpread && parseFloat(baseRealSpread) > 5.0);
+                // 3%, matching the verdict band below: a delta >=3% is reportable, so
+                // a spread that could manufacture one makes the baseline unusable.
+                const baseNoisy = !!(baseRealSpread && parseFloat(baseRealSpread) > 3.0);
                 const rowIcon = (pct) => baseNoisy ? '❔' : icon(pct);
                 body += `| Metric | main | PR | Δ |\n`;
                 body += `|--------|------|----|---|\n`;
@@ -850,7 +855,7 @@ jobs:
                 const rp = parseFloat(realTimePct);
                 // A noisy baseline invalidates the verdict, not just softens it: on
                 // 2026-08-03 a 65.8%-spread baseline verdicted healthy PRs at ±20-35%.
-                // Same 5% threshold as the PR-side spread note below.
+                // Same 3% threshold as the PR-side spread note below.
                 if (baseNoisy) {
                   body += `> ⚠️ **The cached baseline was noisy when it was recorded** (prove-time spread ${baseRealSpread}%), so the Δ column compares against an unreliable number and no verdict is drawn. Refresh it (Actions → "Benchmark (PR)" → Run workflow on main), then re-run \`/bench\` — or use \`/bench-abba\`, which measures both sides itself.\n`;
                 } else if (rp > 10) {
@@ -864,7 +869,7 @@ jobs:
                 } else {
                   body += `> ✅ No significant change.\n`;
                 }
-                if (realTimeSpread && parseFloat(realTimeSpread) > 5.0) {
+                if (realTimeSpread && parseFloat(realTimeSpread) > 3.0) {
                   const vals = realAllTimes ? realAllTimes.split('/').map(t => `${t}s`).join(' / ') : '';
                   body += `>\n> ⚠️ Real-block prove-time spread: ${realTimeSpread}% (${vals}) — the median above is less trustworthy than usual.\n`;
                 } else if (realTimeSpread && parseInt(realRuns) > 1) {

--- a/scripts/render_bench_comment.js
+++ b/scripts/render_bench_comment.js
@@ -138,6 +138,15 @@ const scenarios = {
     BASE_GROWTH_SLOPE: '2000', BASE_GROWTH_R2: '0.9980',
     GROWTH_SLOPE_DIFF: '7', GROWTH_SLOPE_PCT: '0.4',
   },
+  // The 2026-08-03 incident, verbatim: a baseline recorded during an external-load
+  // disturbance (spread 65.8%) verdicted a healthy, tight PR run (0.6% spread) as a
+  // -19.4% improvement. The warning must REPLACE the celebration, not sit beside it.
+  'J: noisy cached baseline — suppress the verdict': {
+    ...REAL, PR_REAL_TIME: '158.407', PR_REAL_PEAK: '52004',
+    REAL_RUNS: '3', REAL_TIME_SPREAD: '0.6', REAL_ALL_TIMES: '158.407/157.853/158.730',
+    BASE_REAL_TIME: '196.587', BASE_REAL_PEAK: '52060', BASE_REAL_SPREAD: '65.8',
+    REAL_TIME_DIFF: '-38.180', REAL_TIME_PCT: '-19.4', REAL_PEAK_DIFF: '-56', REAL_PEAK_PCT: '-0.1',
+  },
 };
 
 (async () => {

--- a/scripts/render_bench_comment.js
+++ b/scripts/render_bench_comment.js
@@ -138,6 +138,15 @@ const scenarios = {
     BASE_GROWTH_SLOPE: '2000', BASE_GROWTH_R2: '0.9980',
     GROWTH_SLOPE_DIFF: '7', GROWTH_SLOPE_PCT: '0.4',
   },
+  // Boundary for the 3% threshold: 3.5% must already suppress the verdict (a spread
+  // that can manufacture a reportable >=3% delta makes the baseline unusable). If
+  // someone loosens the threshold back past 3.5, this scenario's ❔/warning vanish.
+  'K: baseline spread just past the 3% line': {
+    ...REAL, PR_REAL_TIME: '158.407', PR_REAL_PEAK: '52004',
+    REAL_RUNS: '3', REAL_TIME_SPREAD: '0.6', REAL_ALL_TIMES: '158.407/157.853/158.730',
+    BASE_REAL_TIME: '162.100', BASE_REAL_PEAK: '52060', BASE_REAL_SPREAD: '3.5',
+    REAL_TIME_DIFF: '-3.693', REAL_TIME_PCT: '-2.3', REAL_PEAK_DIFF: '-56', REAL_PEAK_PCT: '-0.1',
+  },
   // The 2026-08-03 incident, verbatim: a baseline recorded during an external-load
   // disturbance (spread 65.8%) verdicted a healthy, tight PR run (0.6% spread) as a
   // -19.4% improvement. The warning must REPLACE the celebration, not sit beside it.


### PR DESCRIPTION
## What

A baseline records its own prove-time spread into the metrics artifact, but nothing ever read it back. Today (2026-08-03, ~15:05–15:35 UTC) an external-load disturbance on the bench runner produced a baseline of 196.587s with **65.8% spread** (168.2 / 297.5 / 196.6) — and for the next hour `/bench` confidently verdicted healthy, tight-spread PR runs against it: −19.4% 🎉 and −21.6% 🎉 on PRs that are actually flat, +34.7% 🔴 on a third.

Now, when the cached baseline's recorded spread exceeds **3%**:

- the improvement/regression verdict is **replaced** by a warning naming the baseline's spread — not printed beside it,
- the Δ row icons go neutral (❔),
- the warning says what to do: refresh the baseline (Actions → "Benchmark (PR)" → Run workflow on main) and re-run `/bench`, or use `/bench-abba`, which measures both sides itself and never trusts a recorded baseline.

3% rather than 5%: the verdict bands treat ≥3% as a reportable delta and 2–3% improvements get acted on, so a spread that could manufacture a reportable delta is by definition too noisy to verdict against. The PR-side "less trustworthy" note and the record-time warning are tightened to the same 3%, so one threshold means one thing everywhere. Healthy runs on this runner measure 0.6–2.8% spread, so 3% sits just above the observed-healthy band.

A freshly-built baseline (`built from main`) passes an empty spread — it runs in the same session as the PR side, so there is no recorded-earlier number to distrust.

The `pr-real` step also emits a `::warning::` at record time when its own spread exceeds 3%, so a push/dispatch run announces in its log that it is about to publish a baseline `/bench` will refuse to verdict against.

## Rendering

Scenario J in `render_bench_comment.js` reproduces today's incident verbatim (0.6%-spread PR side vs the 65.8%-spread baseline) and shows the warning in place of the celebration; scenario K pins the 3% boundary (a 3.5%-spread baseline must suppress the verdict); scenarios A–I are unchanged. The wiring check passes (the new `baseline_real_spread` output has its consumer).

`actionlint` findings identical to main — nothing new.