### PR TITLE
bench(gpu): record the host CPU, and stop unrelated comments cancelling a running ABBA

### DIFF
--- a/.github/workflows/benchmark-gpu.yml
+++ b/.github/workflows/benchmark-gpu.yml
@@ -434,14 +434,10 @@ jobs:
             WORKLOAD=real CONTINUATIONS=1 EPOCH_SIZE_LOG2=$GPU_REAL_EPOCH_LOG2 \
             scripts/bench_abba.sh $REF_A origin/main $PAIRS"
 
-          # Record the host CPU before the long run. The paired Δ% cancels the host,
-          # but absolute seconds do not transfer between hosts — three RTX 5090
-          # rentals at the same price measured 59.9s / ~76s / ~114s per prove on the
-          # same block (2026-08-01/03 runs), tracking host CPU class — so every number
-          # this run prints should arrive with its host attached. Model + threads go
-          # to the PR comment and summary; full lscpu to the step log. Captured before
-          # the bench so a failed run still records which host class it failed on
-          # (outputs written before a later command fails survive the step failure).
+          # Absolute seconds don't transfer between hosts (same-price 5090 rentals
+          # span ~2x per prove with the host CPU; the paired Δ% cancels it), so every
+          # number this run prints arrives with its host attached. Captured before
+          # the bench so a failed run still records the host it failed on.
           $SSH "lscpu" || true
           CPU_MODEL=$($SSH "lscpu 2>/dev/null | sed -n 's/^Model name:[[:space:]]*//p' | head -1" 2>/dev/null || true)
           [ -n "$CPU_MODEL" ] || CPU_MODEL=$($SSH "sed -n 's/^model name[[:space:]]*: //p' /proc/cpuinfo | head -1" 2>/dev/null || true)
@@ -471,8 +467,6 @@ jobs:
         run: |
           {
             echo "## GPU ABBA — ${WORKLOAD:-ethrex} (vs main)"
-            # The host line makes the absolute seconds interpretable — they vary ~2x
-            # across same-price rentals with the host CPU; only the Δ% transfers.
             [ -n "$CPU_MODEL" ] && echo "Host: $CPU_MODEL (${CPU_THREADS:-?} threads)"
             if [ "$OUTCOME" = "success" ] && [ -s "$RUNNER_TEMP/abba_result.txt" ]; then
               echo '```'
@@ -508,10 +502,8 @@ jobs:
             const gpu = (process.env.GPU_NAME || '').replace('_', ' ');
             const price = process.env.OFFER_PRICE;
             const workload = process.env.WORKLOAD || 'ethrex';
-            // Host CPU: the seconds below vary ~2x across same-price rentals with the
-            // host CPU class (the prover is host-CPU-bound at the serial producer at
-            // this epoch), so the comment names the host the seconds belong to. On
-            // both success and failure — failures correlate with host classes too.
+            // Absolute seconds vary ~2x with the rented host's CPU — name the host
+            // they belong to (on failure too, so failures correlate with hosts).
             const cpuModel = process.env.CPU_MODEL;
             const cpuThreads = process.env.CPU_THREADS;
             const host = cpuModel ? ` · ${cpuModel}${cpuThreads ? ` (${cpuThreads} threads)` : ''}` : '';

--- a/.github/workflows/benchmark-gpu.yml
+++ b/.github/workflows/benchmark-gpu.yml
@@ -33,7 +33,16 @@ permissions:
   issues: write
 
 concurrency:
-  group: benchmark-gpu-${{ github.event.issue.number || github.run_id }}
+  # See bench-verify.yml: this workflow fires on EVERY issue_comment, and GitHub
+  # claims the concurrency group when the run is CREATED — before the job-level
+  # `if` skips it. With the old plain per-issue group, any comment on the PR
+  # evicted a running GPU ABBA mid-rental (2026-08-03: a `/bench 5` comment
+  # killed the run started 20 minutes earlier, ~40 min of paid box). Real
+  # /bench-gpu comments share the per-issue group, so a deliberate re-fire still
+  # replaces a stale run (cancel-in-progress stays true for that case — one
+  # rental per PR, newest request wins); every other comment and
+  # workflow_dispatch falls to a throwaway group and cannot evict anything.
+  group: ${{ startsWith(github.event.comment.body, '/bench-gpu') && format('benchmark-gpu-{0}', github.event.issue.number) || format('benchmark-gpu-ignore-{0}', github.run_id) }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/benchmark-gpu.yml
+++ b/.github/workflows/benchmark-gpu.yml
@@ -425,6 +425,24 @@ jobs:
             WORKLOAD=real CONTINUATIONS=1 EPOCH_SIZE_LOG2=$GPU_REAL_EPOCH_LOG2 \
             scripts/bench_abba.sh $REF_A origin/main $PAIRS"
 
+          # Record the host CPU before the long run. The paired Δ% cancels the host,
+          # but absolute seconds do not transfer between hosts — three RTX 5090
+          # rentals at the same price measured 59.9s / ~76s / ~114s per prove on the
+          # same block (2026-08-01/03 runs), tracking host CPU class — so every number
+          # this run prints should arrive with its host attached. Model + threads go
+          # to the PR comment and summary; full lscpu to the step log. Captured before
+          # the bench so a failed run still records which host class it failed on
+          # (outputs written before a later command fails survive the step failure).
+          $SSH "lscpu" || true
+          CPU_MODEL=$($SSH "lscpu 2>/dev/null | sed -n 's/^Model name:[[:space:]]*//p' | head -1" 2>/dev/null || true)
+          [ -n "$CPU_MODEL" ] || CPU_MODEL=$($SSH "sed -n 's/^model name[[:space:]]*: //p' /proc/cpuinfo | head -1" 2>/dev/null || true)
+          CPU_THREADS=$($SSH "nproc" 2>/dev/null || true)
+          echo "Host CPU: ${CPU_MODEL:-unknown} (${CPU_THREADS:-?} threads)"
+          {
+            echo "cpu_model=${CPU_MODEL}"
+            echo "cpu_threads=${CPU_THREADS}"
+          } >> "$GITHUB_OUTPUT"
+
           # pipefail so a failed remote bench (e.g. a prove that dies) propagates through the
           # tee pipe and fails this step, instead of being masked by tee's exit 0.
           set -o pipefail
@@ -439,9 +457,14 @@ jobs:
         env:
           OUTCOME: ${{ steps.bench.outcome }}
           WORKLOAD: ${{ steps.config.outputs.workload }}
+          CPU_MODEL: ${{ steps.bench.outputs.cpu_model }}
+          CPU_THREADS: ${{ steps.bench.outputs.cpu_threads }}
         run: |
           {
             echo "## GPU ABBA — ${WORKLOAD:-ethrex} (vs main)"
+            # The host line makes the absolute seconds interpretable — they vary ~2x
+            # across same-price rentals with the host CPU; only the Δ% transfers.
+            [ -n "$CPU_MODEL" ] && echo "Host: $CPU_MODEL (${CPU_THREADS:-?} threads)"
             if [ "$OUTCOME" = "success" ] && [ -s "$RUNNER_TEMP/abba_result.txt" ]; then
               echo '```'
               cat "$RUNNER_TEMP/abba_result.txt"
@@ -464,6 +487,8 @@ jobs:
           GPU_NAME: ${{ env.GPU_NAME }}
           OFFER_PRICE: ${{ steps.offer.outputs.price }}
           WORKLOAD: ${{ steps.config.outputs.workload }}
+          CPU_MODEL: ${{ steps.bench.outputs.cpu_model }}
+          CPU_THREADS: ${{ steps.bench.outputs.cpu_threads }}
         with:
           script: |
             const fs = require('fs');
@@ -474,9 +499,16 @@ jobs:
             const gpu = (process.env.GPU_NAME || '').replace('_', ' ');
             const price = process.env.OFFER_PRICE;
             const workload = process.env.WORKLOAD || 'ethrex';
+            // Host CPU: the seconds below vary ~2x across same-price rentals with the
+            // host CPU class (the prover is host-CPU-bound at the serial producer at
+            // this epoch), so the comment names the host the seconds belong to. On
+            // both success and failure — failures correlate with host classes too.
+            const cpuModel = process.env.CPU_MODEL;
+            const cpuThreads = process.env.CPU_THREADS;
+            const host = cpuModel ? ` · ${cpuModel}${cpuThreads ? ` (${cpuThreads} threads)` : ''}` : '';
 
             let body = `## GPU Benchmark (ABBA) — \`${head}\` vs \`main\` (${pairs} pairs)\n\n`;
-            body += `<sub>${gpu} · Vast.ai datacenter${price ? ` @ \$${price}/hr` : ''} · \`prover/cuda\` · ${workload} · drift-free A/B/B/A</sub>\n\n`;
+            body += `<sub>${gpu}${host} · Vast.ai datacenter${price ? ` @ \$${price}/hr` : ''} · \`prover/cuda\` · ${workload} · drift-free A/B/B/A</sub>\n\n`;
             if (process.env.OUTCOME === 'success') {
               const res = read(`${tmp}/abba_result.txt`) || read(`${tmp}/abba_out.txt`);
               body += '```\n' + res + '\n```\n';


### PR DESCRIPTION
Two fixes to the GPU ABBA workflow, both from today's runs.

## Record the rented host's CPU

Three RTX 5090 rentals at the same ~$0.67/hr measured **59.9s, ~76s and ~114s per prove** on the same block at the same epoch (the Jul 31 calibration box and the two Aug 1 ABBA runs). The prover is host-CPU-bound at the serial producer at epoch 2^22, so the absolute seconds are a property of whichever host Vast sold us that hour — the paired Δ% cancels it, which is why the ABBA verdicts stay valid. But nothing recorded *which* host each run got: no `lscpu`, no model name, anywhere in the logs. The 59.9s box turns out to have been a 48-core host; the two ABBA hosts are 16–32 cores by query and otherwise anonymous.

Now every run dumps `lscpu` to the step log and puts the CPU model + thread count in the PR comment's header line (`RTX 5090 · AMD EPYC … (32 threads) · Vast.ai …`) and the run summary — on **success and failure alike**, captured before the bench starts, so a run that dies mid-way still records the host class it failed on.

The offer query is deliberately left broad: the Δ% doesn't care which host it runs on. What the recorded models buy is the "how many seconds" question — the accumulated comments give per-host-class numbers with their qualifier attached, instead of a bare number that varies 2× between runs.

## Stop unrelated comments cancelling a running ABBA

The workflow fires on every `issue_comment`, and GitHub claims the concurrency group when the run is **created** — before the job-level `if` skips non-`/bench-gpu` comments. With the old plain per-issue group + `cancel-in-progress: true`, any comment on the PR evicted a running GPU ABBA mid-rental. Today a `/bench 5` comment killed the ABBA started 20 minutes earlier — ~40 min of paid box discarded, reported as "❌ Run failed".

This adopts the pattern `bench-verify.yml` documents and `bench-abba.yml` / `profile-recursion.yml` already use: only genuine `/bench-gpu` comments share the per-issue group — so a deliberate re-fire still replaces a stale run (one rental per PR, newest request wins) — and every other comment falls to a throwaway group that cannot evict anything.

`actionlint` findings identical to main.