### PR TITLE
fix(gpu): drain htod_via on error; narrow the merkle-tail threshold

### DIFF
--- a/crypto/math-cuda/src/device.rs
+++ b/crypto/math-cuda/src/device.rs
@@ -685,6 +685,15 @@ pub fn htod_via<T: cudarc::driver::DeviceRepr>(
     // the device writes on `stream`; `dst.len() >= src_host.len()` (asserted),
     // so every chunk's byte range stays within `dst`.
     let (dst_base, _record) = dst.device_ptr_mut(stream);
+    // Declared after the slot's MutexGuard so it drops FIRST: once a chunk's
+    // DMA is in flight, any `?`-return below must drain the stream before the
+    // guard releases the slot, or the next locker's `ensure_capacity` could
+    // `cuMemFreeHost` the slab while the device is still reading it. Same
+    // hazard `async_dtoh_via` guards against on its record-event failure.
+    let mut drain = DrainOnErr {
+        stream,
+        armed: false,
+    };
     let src = src_host.as_ptr() as *const u8;
     let n_elems = src_host.len();
     let mut elem_off = 0usize;
@@ -698,18 +707,26 @@ pub fn htod_via<T: cudarc::driver::DeviceRepr>(
         // never read (by an in-flight DMA) and written at the same time.
         unsafe {
             std::ptr::copy_nonoverlapping(src.add(byte_off), staging.ptr as *mut u8, this_bytes);
-            cudarc::driver::sys::cuMemcpyHtoDAsync_v2(
+            let r = cudarc::driver::sys::cuMemcpyHtoDAsync_v2(
                 dst_base + byte_off as u64,
                 staging.ptr as *const core::ffi::c_void,
                 this_bytes,
                 stream.cu_stream(),
             )
-            .result()?;
+            .result();
+            // Armed even on failure: the driver may have enqueued the copy
+            // before reporting the error.
+            drain.armed = true;
+            r?;
         }
         // Single-buffered: wait for this chunk's DMA before the next memcpy
-        // reuses the slab.
+        // reuses the slab. Both calls can fail with the DMA still in flight,
+        // which is what `drain` covers.
         staging.record_event(stream)?;
         staging.sync_event()?;
+        // This chunk has landed; nothing is reading the slab until the next
+        // iteration re-arms.
+        drain.armed = false;
         elem_off += this_elems;
     }
     Ok(())

--- a/crypto/math-cuda/src/fri.rs
+++ b/crypto/math-cuda/src/fri.rs
@@ -41,8 +41,10 @@ fn check_fault_injection() -> Result<()> {
 }
 
 /// Device-side state across FRI commit iterations. Owns the current fold
-/// input (the previous layer's evals, Arc-shared with that layer's retained
-/// `gpu_evals`) and the inv_twiddles buffer. Freed when dropped.
+/// input (the previous layer's evals) and the inv_twiddles buffer. The input
+/// is an `Arc` because the caller may also retain it as that layer's
+/// `gpu_evals` — it does so only on the device-only path, where no host copy
+/// of the evals exists. Freed when the last holder drops.
 pub struct FriCommitState {
     pub stream: Arc<CudaStream>,
     /// Current fold input. Each fold allocates a fresh output buffer that is

--- a/crypto/math-cuda/src/merkle.rs
+++ b/crypto/math-cuda/src/merkle.rs
@@ -160,9 +160,20 @@ pub(crate) fn build_inner_tree_levels(
 ) -> Result<()> {
     // Once a level fits this many pairs, one single-block launch
     // (`keccak_merkle_tail`) builds all remaining levels with barriers
-    // between them: the top ~11 levels of a big tree are each smaller than
-    // the per-launch overhead they used to pay.
-    const TAIL_MAX_PAIRS: u64 = 2048;
+    // between them: the top levels of a big tree are each smaller than the
+    // per-launch overhead they used to pay.
+    //
+    // Set to the block width, so the entry level is exactly one permutation
+    // per thread and the tail adds NO serialization over the per-level
+    // launches it replaces. Going wider is not free: the tail grid-strides a
+    // single 128-thread block on one SM, so a level of `k` pairs costs
+    // `k / 128` *sequential* keccak-f1600s where separate launches would have
+    // spread them over `k / 128` parallel blocks. At 2048 the first four
+    // levels alone are 16+8+4+2 = 30 serial permutations against 4 parallel
+    // waves — order +100 us per large tree, to save 4 launches worth order
+    // 10 us. It stays on the critical path because the caller's 32-byte root
+    // `memcpy_dtoh` host-blocks on everything queued before it.
+    const TAIL_MAX_PAIRS: u64 = KECCAK_BLOCK_DIM as u64;
     let mut level_begin: u64 = (leaves_len - 1) as u64;
     while level_begin != 0 {
         let new_begin = level_begin / 2;

--- a/crypto/math-cuda/tests/batch_inverse.rs
+++ b/crypto/math-cuda/tests/batch_inverse.rs
@@ -72,6 +72,31 @@ fn batch_inverse_n1() {
     run(1, 1);
 }
 
+/// `batch_inverse_ext3_dev`'s own `n == 1` branch, which the host entry point
+/// above never reaches: `batch_inverse_ext3` short-circuits n==1 to
+/// `invert_ext3_host`, so only a direct device call exercises the single
+/// `invert_total_ext3` launch that serves this case.
+#[test]
+fn batch_inverse_dev_n1() {
+    let mut rng = ChaCha8Rng::seed_from_u64(7);
+    let x = rand_fp3_nonzero(&mut rng);
+    let expected = x.inv().expect("nonzero is invertible");
+
+    let be = math_cuda::device::backend().expect("cuda backend");
+    let stream = be.next_stream();
+    let input = stream.clone_htod(&ext3_to_u64s(&[x])).unwrap();
+
+    let out_dev = math_cuda::inverse::batch_inverse_ext3_dev(&input, 1, &stream).unwrap();
+    let got = stream.clone_dtoh(&out_dev).unwrap();
+    stream.synchronize().unwrap();
+
+    assert_eq!(
+        canon3(&got),
+        canon3(&ext3_to_u64s(&[expected])),
+        "device n==1 inverse"
+    );
+}
+
 #[test]
 fn batch_inverse_single_block() {
     // All single-block sizes (no recursion).

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -1027,10 +1027,12 @@ pub trait IsStarkProver<
         // Fused GPU split path for preprocessed tables (cuda only): one
         // row-major LDE of ALL columns plus two subset Merkle trees
         // (precomputed / multiplicity) built on device — leaves and levels are
-        // bit-identical to `commit_rows_bit_reversed_subset`, and the trees
-        // come back as full host trees so the preprocessed opening path and
-        // the process-wide precomputed-tree cache work unchanged. The handle
-        // keeps the LDE device-resident for the downstream GPU rounds.
+        // bit-identical to `commit_rows_bit_reversed_subset`. The precomputed
+        // tree comes back as a full host tree, so the process-wide
+        // precomputed-tree cache works unchanged; the multiplicity tree stays
+        // device-resident behind a root-only host tree and its opening paths
+        // are gathered on device. The handle keeps the LDE device-resident for
+        // the downstream GPU rounds.
         #[cfg(feature = "cuda")]
         if let Some((expected_precomputed_root, num_precomputed)) = precomputed {
             let (trace_slice, num_cols) = trace.main_data_row_major();
@@ -1527,6 +1529,20 @@ pub trait IsStarkProver<
         let constraints_dur = t_sub.elapsed();
         #[cfg(feature = "instruments")]
         let t_sub = Instant::now();
+
+        // Every arm below runs the HOST evaluator, which reads `get_main` /
+        // `get_aux`. Under device-only those buffers are intentionally empty,
+        // so landing here means the device decompose AND the `H` download both
+        // failed. Abort with the device-only contract's message rather than a
+        // bare index-out-of-bounds from somewhere inside the evaluator.
+        #[cfg(feature = "cuda")]
+        if precomputed_parts.is_none() {
+            assert!(
+                !round_1_result.lde_trace.host_trace_empty(),
+                "R2 composition fell back to the host evaluator, but the trace \
+                 is device-only (empty)"
+            );
+        }
 
         let lde_composition_poly_parts_evaluations = if let Some(parts) = precomputed_parts {
             parts


### PR DESCRIPTION
Review follow-ups for #875, rebased onto `e75bcbed` — **only what that commit did not already cover.** Your follow-up landed while I was writing this, so I dropped everything it addressed (gather bounds, the query-0 canary, the `test-faults` zero-total guard).

Compile-verified (`math-cuda --tests`, `stark --features cuda`), fmt and clippy clean. **Not GPU-verified** — no CUDA device here, and `gpu-tests` doesn't run on PRs.

## 1. `htod_via` can free the pinned slab under an in-flight DMA

The one memory-safety item; everything else here is polish.

Once a chunk's `cuMemcpyHtoDAsync_v2` is enqueued, `record_event(stream)?` / `sync_event()?` returning `Err` drops the staging `MutexGuard` with the device still reading the slab — the next locker's `ensure_capacity` can then `cuMemFreeHost` it mid-copy. `async_dtoh_via` guards exactly this (`device.rs:761-764`: *"if the record fails, drain the stream before the guard drops, or the next locker could free the slab mid-copy"*), and the file already ships `DrainOnErr` for it — `htod_via` was the one site not using it. Armed *before* checking the memcpy result, since the driver may enqueue before reporting an error.

Needs a CUDA failure mid-upload, so low probability.

## 2. `TAIL_MAX_PAIRS` 2048 → block width

The tail grid-strides a **single 128-thread block on one SM**, so a level of `k` pairs costs `k/128` *sequential* keccak-f1600s where the per-level launches spread them over `k/128` parallel blocks. Each `hash_merkle_parent` absorbs 64 B < the 136 B rate, so it's exactly one permutation per pair.

At 2048 the first four levels (2048/1024/512/256) are 16+8+4+2 = **30 serial permutations** against **4 parallel waves** — ~26 extra serial keccak-f latencies to save 4 launches. Rough ledger per large tree: cost ~78–156 µs (at 3–6 µs per serial permutation), saving ~6–10 µs of launch overhead. It stays on the critical path because the caller's 32-byte root `memcpy_dtoh` host-blocks on everything queued before it.

**Scale honestly: ~10–40 ms/epoch, i.e. 0.05–0.5% — this is a threshold that overshoots, not a regression that matters.** At the block width the entry level is exactly one permutation per thread: still collapses the top levels into one launch, with zero added serialization. The per-permutation latency is a model, not a 5090 measurement; the direction holds for any per-keccak-f latency above ~0.4 µs, magnitude ±2×.

## 3. R2 host-evaluator fallback panics with a bare index-OOB

If `evaluate_dev` succeeds but both `try_decompose_extend_d2_dev` and the `H` download fail under device-only, control reaches the host evaluator, which reads the intentionally-empty trace. Added the device-only contract assert, matching the other fallback arms. Narrow window; improves the message only.

## 4. Coverage: the device `n == 1` inverse path

`batch_inverse_ext3_dev`'s `n == 1` branch (a direct `launch_invert_total`) is never exercised — `batch_inverse_n1` goes through `batch_inverse_ext3`'s host-only short circuit at `inverse.rs:59-64`, as its own comment says. Added a direct device test; complements the `htod_via` round-trip test you added.

## 5. Two doc comments

- `prover.rs:1030` still said the split trees *"come back as full host trees so the preprocessed opening path and the process-wide precomputed-tree cache work unchanged"*. Half of it survives — the precomputed tree **is** still a full host tree and its cache is unchanged — but the multiplicity tree is now root-only + device-resident. This is the comment a reader consults before touching the `is_root_only` assert.
- `fri.rs:43` says `FriCommitState`'s input is Arc-shared with the layer's retained `gpu_evals`; since `gpu_evals: (!want_host).then_some(..)` that holds only on the device-only path.

---

## Flagged, not patched — three failure-mode calls that are yours

I checked these and deliberately left the code alone, because each is a design choice you made with a stated rationale rather than a defect.

1. **The R2 commit assert (`prover.rs:1669`).** I originally wanted this to be a rejectable `ProvingError` on the rejectable-beats-panic convention, and that was wrong — I checked the propagation and there is nothing to recover *to*. `ProvingError` is flattened at `continuation.rs:738` / `:931` via `.map_err(|e| Error::Prover(format!("{e:?}")))?` and propagates straight up; no caller retries, and there is no CPU-fallback-on-`ProvingError` path. The `EmptyCommitment` one line below is equally terminal. Panic and `Err` both end the prove with no proof, so the assert costs nothing and keeps the better message. **Leaving it as-is; no change wanted.** (The convention it appeared to violate is really about the *verifier*, where a malicious proof must be rejected rather than panic the process. This is a prover-side internal invariant with no attacker-controlled input.)

2. **`is_none_or` in the three contract asserts passes an empty *outer* Vec** (`num_parts == 0` → `.first() == None` → assert passes). Unreachable — R2 hits `EmptyCommitment` first — and note the right predicate differs per site: at R2 an empty outer Vec *should* fall through to `EmptyCommitment`, so a blanket swap to `is_some_and` would be wrong there. Hardening only.

3. **Your zero-total guard.** `#[cfg(any(debug_assertions, feature = "test-faults"))]` fixes the "never actually runs" problem for `test-cuda-fallback`. Two things it still doesn't reach: the other four GPU suites (plain `--release`) and production. It also still `assert_ne!`s, where the host Fermat it replaced returned `Err` that `try_compute_and_invert_inv_denoms_dev` maps to `None` → CPU fallback.

One more, lower confidence: **`prover.rs:2208`'s assert is now load-bearing in a way its predicate doesn't state.** Its loop reads the host trace *and* the host parts (2255), but it's gated on `!host_trace_empty()` alone. Sufficient today only because `want_host == !host_trace_empty()`. Decouple those later — e.g. "keep parts device-only whenever a handle exists" — and it silently stops covering 2255.

## Verified rather than changed

The two risky kernel rewrites are correct, checked numerically rather than by reading:

- `ntt_dit_8_levels_row_major` vs the per-level reference over Goldilocks, 9 `(log_n, m, gridDim.y)` combinations including `gridDim.y` not dividing `n/256` and `m` not a multiple of `T` — bit-identical in all.
- `keccak_merkle_tail` vs the multi-launch loop across 13 leaf counts including non-powers-of-two, with the grid-strided thread iterations executed in **reverse** order to expose any hidden intra-level dependency — every node buffer matched, not just the roots.

Also traced and found sound: every consumer of `lde_composition_poly_evaluations` under empty parts (each is either device-routed or assert-guarded — no path produces a silently wrong or silently empty proof); R3 parts-OOD equivalence argument-by-argument, including inv_denoms at `z_power` in both arms and matching `DenomSign`; per-part ordering device-vs-host; the Fermat exponent (`p³−2`, Hamming weight 127, no u128 overflow); the slab layout against `keccak_comp_poly_leaves_ext3`; the preprocessed/mult-tree pairing; and cross-stream ordering for every new resident consumer.

Residual risk worth naming: `build_comp_poly_tree_from_slabs_dev` and `gather_ext3_at` have no parity test, and they are the only sources of the composition root and the FRI sym evals under device-only — precisely where the host cross-checks are skipped. Rust-level equivalence I did verify (the tree builder launches the identical kernel with identical args over an identically-laid-out buffer), so the residual is kernel-level only.

