### PR TITLE
fix(instruments): restore the rounds 2-4 phase span and make the prover report honest

### DIFF
--- a/crypto/stark/src/instruments.rs
+++ b/crypto/stark/src/instruments.rs
@@ -6,12 +6,20 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 // Wall clock span timeline: the trustworthy per step latency breakdown.
 //
-// Spans open and close on the main thread at phase boundaries. They do not
-// overlap and sum to their parent, so the tree is a true latency breakdown
-// (unlike the accum_* thread local sub timers below, which sum per worker CPU
-// time across rayon threads and can exceed 100%). A parallel region is one span
-// around the blocking call; its internal split is reported separately as CPU
-// time, never mixed into the wall tree.
+// Top level phase spans open and close on the main thread at phase boundaries.
+// They do not overlap and sum to their parent, so that part of the tree is a
+// true latency breakdown (unlike the accum_* thread local sub timers below,
+// which sum per worker CPU time across rayon threads and can exceed 100%). A
+// parallel region is one span around the blocking call; its internal split is
+// reported separately as CPU time, never mixed into the wall tree.
+//
+// Per table spans are the exception. `multi_prove` runs one driver thread per
+// in flight table (`r1_aux_build`, `r1_aux_commit`, `rounds_2to4`), so up to
+// `table_parallelism()` of them are open at once: they DO overlap in wall time
+// and their sum exceeds their parent. They still nest correctly, because each
+// driver seeds its span depth from the spawning thread (`current_depth` /
+// `enter_depth`) instead of starting a fresh thread at depth 0 — but read them
+// as per table wall time, not as a share of the enclosing phase.
 //
 //     let _s = instruments::span("trace_build");   // RAII, stops on drop
 //
@@ -34,6 +42,32 @@ static SPAN_ORDER: AtomicU64 = AtomicU64::new(0);
 
 thread_local! {
     static SPAN_DEPTH: std::cell::Cell<u16> = const { std::cell::Cell::new(0) };
+}
+
+/// Depth the next span opened on this thread would be stamped with.
+///
+/// Read this on the thread that spawns workers and hand the value to
+/// [`enter_depth`] inside each worker: a freshly spawned OS thread starts at
+/// depth 0, so without it every span opened off the main thread is recorded as
+/// a root sibling of `prove_total` and the tree stops being a breakdown.
+pub fn current_depth() -> u16 {
+    SPAN_DEPTH.with(|d| d.get())
+}
+
+/// Restores the span depth this thread had before [`enter_depth`].
+#[must_use]
+pub struct DepthGuard(u16);
+
+/// Seed this thread's span depth from a parent thread, restoring the previous
+/// value when the returned guard drops.
+pub fn enter_depth(depth: u16) -> DepthGuard {
+    DepthGuard(SPAN_DEPTH.with(|d| d.replace(depth)))
+}
+
+impl Drop for DepthGuard {
+    fn drop(&mut self) {
+        SPAN_DEPTH.with(|d| d.set(self.0));
+    }
 }
 
 #[must_use]

--- a/crypto/stark/src/instruments.rs
+++ b/crypto/stark/src/instruments.rs
@@ -297,8 +297,15 @@ pub struct Round1SubOps {
 pub struct MultiProveTiming {
     pub prepass: Duration,
     pub main_commits: Duration,
+    /// Aux build wall time summed over the concurrent per-table drivers. It is
+    /// no longer a phase of its own — the fused chain runs it inside
+    /// `rounds_2_4`, so it overlaps itself and is a subset of that wall time,
+    /// not an addend.
     pub aux_build: Duration,
+    /// Aux commit, same accounting as `aux_build`.
     pub aux_commit: Duration,
+    /// Wall clock of the fused per-table region: aux build + aux commit +
+    /// rounds 2-4, all of it concurrent across `table_parallelism()` drivers.
     pub rounds_2_4: Duration,
     /// Sub-op breakdown for Round 1 (main + aux LDE vs Merkle).
     pub round1_sub: Round1SubOps,
@@ -312,6 +319,11 @@ static R1_MAIN_LDE_US: AtomicU64 = AtomicU64::new(0);
 static R1_MAIN_MERKLE_US: AtomicU64 = AtomicU64::new(0);
 static R1_AUX_LDE_US: AtomicU64 = AtomicU64::new(0);
 static R1_AUX_MERKLE_US: AtomicU64 = AtomicU64::new(0);
+// Aux build / aux commit wall time per table, summed across the concurrent
+// per-table drivers of the fused chain (so, like the sub-timers, this is a
+// CPU-style total that can exceed the fused region's wall clock).
+static AUX_BUILD_US: AtomicU64 = AtomicU64::new(0);
+static AUX_COMMIT_US: AtomicU64 = AtomicU64::new(0);
 // Aux build (LogUp) sub-phases, CPU time accumulated across tables/chunks.
 static AUX_FINGERPRINT_US: AtomicU64 = AtomicU64::new(0);
 static AUX_INVERT_US: AtomicU64 = AtomicU64::new(0);
@@ -360,6 +372,20 @@ pub fn accum_aux_accumulate(d: Duration) {
     AUX_ACCUM_US.fetch_add(d.as_micros() as u64, Ordering::Relaxed);
 }
 
+/// One table's aux build and aux commit wall time, from its fused-chain driver.
+pub fn accum_aux_phases(build: Duration, commit: Duration) {
+    AUX_BUILD_US.fetch_add(build.as_micros() as u64, Ordering::Relaxed);
+    AUX_COMMIT_US.fetch_add(commit.as_micros() as u64, Ordering::Relaxed);
+}
+
+/// Drain the summed per-table aux build / aux commit times.
+pub fn take_aux_phases() -> (Duration, Duration) {
+    (
+        Duration::from_micros(AUX_BUILD_US.swap(0, Ordering::Relaxed)),
+        Duration::from_micros(AUX_COMMIT_US.swap(0, Ordering::Relaxed)),
+    )
+}
+
 pub fn take_r1_sub() -> Round1SubOps {
     Round1SubOps {
         main_lde: Duration::from_micros(R1_MAIN_LDE_US.swap(0, Ordering::Relaxed)),
@@ -386,6 +412,8 @@ pub fn reset_all() {
     R1_MAIN_MERKLE_US.store(0, Ordering::Relaxed);
     R1_AUX_LDE_US.store(0, Ordering::Relaxed);
     R1_AUX_MERKLE_US.store(0, Ordering::Relaxed);
+    AUX_BUILD_US.store(0, Ordering::Relaxed);
+    AUX_COMMIT_US.store(0, Ordering::Relaxed);
     AUX_FINGERPRINT_US.store(0, Ordering::Relaxed);
     AUX_INVERT_US.store(0, Ordering::Relaxed);
     AUX_TERM_US.store(0, Ordering::Relaxed);

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -4012,3 +4012,198 @@ fn print_bus_balance_report<FieldExtension>(
         }
     }
 }
+
+/// Scheduling primitives only. These are free functions over `&[u64]` with no
+/// AIR, field or device dependency, so they are testable without a GPU — which
+/// matters because CI never exercises them concurrently: `ubuntu-latest` has
+/// 2-4 vCPU, so `table_parallelism()` floors to 1, and on non-cuda builds the
+/// budget is `u64::MAX`, which makes `VramGate` inert.
+#[cfg(test)]
+mod scheduler_tests {
+    use super::{VramGate, heaviest_first, run_admitted};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    /// Bound on how long a correct implementation may take to wake a waiter.
+    /// Only a failure deadline — never used to sequence the test.
+    const WAKE_DEADLINE: Duration = Duration::from_secs(10);
+
+    #[test]
+    fn heaviest_first_is_a_descending_permutation() {
+        let empty: [u64; 0] = [];
+        assert!(heaviest_first(&empty).is_empty());
+        assert_eq!(heaviest_first(&[3, 1, 2]), vec![0, 2, 1]);
+
+        let estimates = [7u64, 0, 7, 3, 100, 1];
+        let order = heaviest_first(&estimates);
+        let mut seen = order.clone();
+        seen.sort_unstable();
+        assert_eq!(
+            seen,
+            (0..estimates.len()).collect::<Vec<_>>(),
+            "must be a permutation of 0..n"
+        );
+        for w in order.windows(2) {
+            assert!(
+                estimates[w[0]] >= estimates[w[1]],
+                "must be descending by estimate, got {order:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn heaviest_first_breaks_ties_by_index() {
+        // `sort_by_key` is stable, so equal estimates keep ascending index
+        // order: the admission order is a pure function of the estimates, and
+        // does not vary run to run.
+        assert_eq!(heaviest_first(&[5, 5, 5]), vec![0, 1, 2]);
+        assert_eq!(heaviest_first(&[1, 5, 5, 1]), vec![1, 2, 0, 3]);
+    }
+
+    #[test]
+    fn run_admitted_fills_every_slot_exactly_once() {
+        // Includes the degenerate shapes: no work, one worker, more workers
+        // than tables, and `workers == 0` (clamped to 1 inside).
+        for (n, workers) in [(0, 4), (1, 1), (1, 8), (5, 0), (5, 1), (5, 8), (9, 4)] {
+            let estimates: Vec<u64> = (0..n).map(|i| i as u64 + 1).collect();
+            let runs: Vec<AtomicUsize> = (0..n).map(|_| AtomicUsize::new(0)).collect();
+            let gate = VramGate::new(u64::MAX);
+            let out = run_admitted(
+                &heaviest_first(&estimates),
+                &estimates,
+                &gate,
+                workers,
+                |idx| {
+                    runs[idx].fetch_add(1, Ordering::SeqCst);
+                    idx * 10
+                },
+            );
+            assert_eq!(out.len(), n, "one slot per table (n={n})");
+            for i in 0..n {
+                assert_eq!(
+                    runs[i].load(Ordering::SeqCst),
+                    1,
+                    "table {i} ran exactly once (n={n}, workers={workers})"
+                );
+                assert_eq!(
+                    out[i],
+                    Some(i * 10),
+                    "slot {i} holds its own result (n={n}, workers={workers})"
+                );
+            }
+            assert_eq!(*gate.used.lock().unwrap(), 0, "all permits released");
+        }
+    }
+
+    #[test]
+    fn concurrent_admissions_stay_under_budget() {
+        const BUDGET: u64 = 100;
+        const EACH: u64 = 40; // 2 fit, 3 do not
+        let estimates = vec![EACH; 16];
+        let gate = VramGate::new(BUDGET);
+        let in_flight = AtomicUsize::new(0);
+        let max_in_flight = AtomicUsize::new(0);
+        run_admitted(&heaviest_first(&estimates), &estimates, &gate, 8, |_| {
+            let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            max_in_flight.fetch_max(now, Ordering::SeqCst);
+            // Read under a held permit: the gate's own counter must never
+            // exceed the budget while anything is admitted.
+            assert!(
+                *gate.used.lock().unwrap() <= BUDGET,
+                "admitted bytes exceeded the budget"
+            );
+            in_flight.fetch_sub(1, Ordering::SeqCst);
+        });
+        assert!(
+            max_in_flight.load(Ordering::SeqCst) <= (BUDGET / EACH) as usize,
+            "more tables were in flight than the budget allows"
+        );
+        assert_eq!(*gate.used.lock().unwrap(), 0);
+    }
+
+    #[test]
+    fn oversized_request_is_admitted_alone_and_wakes_waiters() {
+        // A table bigger than the whole budget must still prove: it is admitted
+        // when nothing else holds bytes, rather than deadlocking forever.
+        let gate = VramGate::new(10);
+        let big = gate.acquire(100);
+        assert_eq!(
+            *gate.used.lock().unwrap(),
+            100,
+            "oversized request admitted alone"
+        );
+
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        std::thread::scope(|s| {
+            s.spawn(|| {
+                ready_tx.send(()).unwrap();
+                let permit = gate.acquire(5);
+                done_tx.send(()).unwrap();
+                drop(permit);
+            });
+            ready_rx.recv().unwrap();
+            drop(big);
+            assert!(
+                done_rx.recv_timeout(WAKE_DEADLINE).is_ok(),
+                "dropping a permit must wake a waiter"
+            );
+        });
+        assert_eq!(
+            *gate.used.lock().unwrap(),
+            0,
+            "permits release their bytes on drop"
+        );
+    }
+
+    /// Guards the instruments span tree: a driver thread starts at span depth
+    /// 0, so without the seeding in `run_admitted` every per-table span is
+    /// recorded as a root sibling of `prove_total` and the "% of total" column
+    /// stops meaning anything. Reads the depth directly instead of the global
+    /// span timeline, which other tests in this binary also write to.
+    #[cfg(feature = "instruments")]
+    #[test]
+    fn run_admitted_seeds_worker_span_depth() {
+        const PARENT_DEPTH: u16 = 3;
+        let outer = crate::instruments::enter_depth(PARENT_DEPTH);
+        let n = 6;
+        let estimates = vec![1u64; n];
+        let gate = VramGate::new(u64::MAX);
+        let seen = run_admitted(&heaviest_first(&estimates), &estimates, &gate, 4, |_| {
+            crate::instruments::current_depth()
+        });
+        for (i, depth) in seen.iter().enumerate() {
+            assert_eq!(
+                *depth,
+                Some(PARENT_DEPTH),
+                "table {i}'s driver must inherit the spawning thread's span depth"
+            );
+        }
+        drop(outer);
+        assert_eq!(
+            crate::instruments::current_depth(),
+            0,
+            "the calling thread's depth is restored"
+        );
+    }
+
+    #[test]
+    fn max_budget_gate_never_blocks() {
+        // The non-cuda / unqueryable-VRAM configuration. Two acquires that
+        // saturate `u64` must both be admitted.
+        let gate = VramGate::new(u64::MAX);
+        let held = gate.acquire(u64::MAX / 2);
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::scope(|s| {
+            s.spawn(|| {
+                let _permit = gate.acquire(u64::MAX / 2 + 1000);
+                tx.send(()).unwrap();
+            });
+            assert!(
+                rx.recv_timeout(WAKE_DEADLINE).is_ok(),
+                "a u64::MAX budget must never block an acquire"
+            );
+        });
+        drop(held);
+    }
+}

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -687,9 +687,17 @@ fn run_admitted<T: Send>(
         .map(|_| std::sync::Mutex::new(None))
         .collect();
     let cursor = std::sync::atomic::AtomicUsize::new(0);
+    // Spans opened inside `task` run on these worker threads, and a fresh OS
+    // thread's span depth starts at 0 — which would record every per-table
+    // span as a root instead of a child of the phase that spawned it. Carry
+    // the spawning thread's depth across the scope boundary.
+    #[cfg(feature = "instruments")]
+    let parent_depth = crate::instruments::current_depth();
     std::thread::scope(|scope| {
         for _ in 0..workers.max(1).min(order.len().max(1)) {
             scope.spawn(|| {
+                #[cfg(feature = "instruments")]
+                let _depth = crate::instruments::enter_depth(parent_depth);
                 loop {
                     let pos = cursor.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     if pos >= order.len() {

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -3255,11 +3255,6 @@ pub trait IsStarkProver<
             }
         }
 
-        // The per-table aux build (inside the fused chain) reports through the
-        // per-table spans; the phase-level buckets are folded into rounds_2_4.
-        #[cfg(feature = "instruments")]
-        let aux_build_elapsed = Duration::ZERO;
-
         // Pre-fork all transcripts (cheap, sequential — must match verifier ordering)
         let table_transcripts: Vec<_> = (0..num_airs)
             .map(|idx| {
@@ -3348,6 +3343,8 @@ pub trait IsStarkProver<
 
             #[cfg(feature = "instruments")]
             let __sp = crate::instruments::span("r1_aux_build");
+            #[cfg(feature = "instruments")]
+            let t_aux_build = Instant::now();
             let bus_public_inputs = if air.has_aux_trace() {
                 air.build_auxiliary_trace(*trace, &lookup_challenges)
             } else {
@@ -3371,16 +3368,20 @@ pub trait IsStarkProver<
                     .map_err(|e| ProvingError::DiskSpill(format!("aux trace: {e}")))?;
             }
             #[cfg(feature = "instruments")]
+            let aux_build_dur = t_aux_build.elapsed();
+            #[cfg(feature = "instruments")]
             drop(__sp);
 
             #[cfg(feature = "instruments")]
             let __sp = crate::instruments::span("r1_aux_commit");
+            #[cfg(feature = "instruments")]
+            let t_aux_commit = Instant::now();
             let aux_full: AuxResult<FieldExtension> =
                 (|| -> Result<AuxResult<FieldExtension>, ProvingError> {
                     if air.has_aux_trace() {
                         let lde_size = domain.interpolation_domain_size * domain.blowup_factor;
 
-                        // Same gate as the main commit (Phase A): skip the aux
+                        // Same gate as the Round 1 main commit: skip the aux
                         // host D2H when device-only, so both buffers are left
                         // empty together for this table.
                         #[cfg(feature = "cuda")]
@@ -3522,6 +3523,8 @@ pub trait IsStarkProver<
                 transcript_cells[idx].lock().unwrap().append_bytes(&c.root);
             }
             #[cfg(feature = "instruments")]
+            crate::instruments::accum_aux_phases(aux_build_dur, t_aux_commit.elapsed());
+            #[cfg(feature = "instruments")]
             drop(__sp);
 
             #[cfg(feature = "cuda")]
@@ -3609,8 +3612,6 @@ pub trait IsStarkProver<
 
         #[cfg(feature = "instruments")]
         let phase_start = Instant::now();
-        #[cfg(feature = "instruments")]
-        let aux_commit_elapsed = Duration::ZERO;
 
         let peak_order = heaviest_first(&peak_estimates);
 
@@ -3665,6 +3666,10 @@ pub trait IsStarkProver<
         let table_timings = table_timings_mx.into_inner().unwrap();
         #[cfg(feature = "instruments")]
         {
+            // Aux build/commit are no longer phases of their own: each table's
+            // driver runs them inside the fused region, so these are sums over
+            // concurrent drivers and are a subset of `rounds_2_4`, not addends.
+            let (aux_build_elapsed, aux_commit_elapsed) = crate::instruments::take_aux_phases();
             // Store timing data for the top-level report in prove_with_options.
             // Uses a thread-local to avoid changing multi_prove's return type.
             crate::instruments::store(crate::instruments::MultiProveTiming {

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -246,7 +246,7 @@ type MainCommitTuple<F> = (
 type MainCommitTuple<F> = (TableCommit<F>, (Vec<FieldElement<F>>, usize));
 
 /// Round 1 commitment artifacts — Merkle trees, roots, challenges, and bus inputs.
-/// Borrowed (not consumed) when building `Round1` in Phase D.
+/// Borrowed (not consumed) when building `Round1`.
 pub(crate) struct Round1Commitments<Field, FieldExtension>
 where
     Field: IsFFTField + IsSubFieldOf<FieldExtension>,
@@ -260,10 +260,18 @@ where
     bus_public_inputs: Option<BusPublicInputs<FieldExtension>>,
 }
 
-/// LDE columns for main (Phase A) and auxiliary (Phase C) traces, consumed by value in Phase D.
+/// Main and auxiliary LDE columns, consumed by value when the table's `Round1`
+/// is assembled.
 ///
-/// Memory trade-off: all N tables' LDE columns are live simultaneously between Phase A/C
-/// and Phase D (O(N × cols × lde_size)).
+/// Memory trade-off, asymmetric since the per-table scheduler fused aux build,
+/// aux commit and rounds 2-4 into one task:
+/// - main: produced by the Round 1 main commit, which is a phase-wide barrier,
+///   so all N tables' main LDEs are live at once (O(N × main_cols × lde_size)).
+/// - aux: produced and consumed inside the same fused task, so at most
+///   `table_parallelism()` of them coexist (O(k × aux_cols × lde_size)).
+///
+/// Under `debug-checks` the fused task is split around the cross-table bus
+/// balance check, so there the aux LDEs are all-N-live like the main ones.
 struct Lde<Field: IsFFTField, FieldExtension: IsField> {
     /// Row-major main LDE buffer + its column count.
     main: (Vec<FieldElement<Field>>, usize),
@@ -566,8 +574,17 @@ where
 }
 
 /// Number of tables to process concurrently in `multi_prove`.
-/// Default: num_cores / 3 (benchmarked optimal on both M3 Pro and EPYC 9454P).
-/// Override with `TABLE_PARALLELISM` env var.
+///
+/// Defaults: `num_cores / 3` on CPU builds (benchmarked optimal on both M3 Pro
+/// and EPYC 9454P — every table there is pure host work), `num_cores * 2 / 3`
+/// under `cuda`, where most in-flight tables sit in GPU waits so more of them
+/// pay (swept flat at ~2/3 of the cores on a 16-core/RTX 5090 box). Both arms
+/// are overridden by the `TABLE_PARALLELISM` env var. Without the `parallel`
+/// feature this is hardcoded to 1 and the env var is ignored.
+///
+/// Not only the prover's `k`: `auto_storage::decide` feeds this into the
+/// RAM-vs-Disk storage estimate, so the `cuda` arm also doubles that transient
+/// term (see `peak_bytes`).
 pub fn table_parallelism() -> usize {
     #[cfg(feature = "parallel")]
     {
@@ -615,12 +632,6 @@ fn estimate_table_vram_bytes(main_cols: usize, aux_cols: usize, lde_size: usize)
     lde_term.saturating_add(tree_term)
 }
 
-/// Plan contiguous table chunks for parallel proving. A chunk grows until it
-/// hits `k` tables or its summed VRAM estimate would exceed `budget`; a single
-/// table larger than `budget` runs solo. With `budget == u64::MAX` (non-cuda,
-/// or VRAM not binding) chunks fall back to fixed size `k`, identical to the
-/// old `step_by(k)`, so scheduling and the proof are unchanged. Returns
-/// `(start, end)` half open ranges covering `0..estimates.len()` in order.
 /// Byte-budget admission gate for concurrently proven tables. `acquire`
 /// blocks until the requested bytes fit under the budget, releasing on
 /// permit drop. An oversized request is admitted alone (when nothing else
@@ -1043,9 +1054,9 @@ pub trait IsStarkProver<
     }
 
     /// Compute the main-trace LDE and commit. Returns a `TableCommit` along
-    /// with the owned LDE columns (consumed later in Phase D) and (under
-    /// cuda) the optional device LDE buffer kept alive for downstream rounds
-    /// when the R1 fused GPU pipeline ran.
+    /// with the owned LDE columns (consumed later by the table's fused task)
+    /// and (under cuda) the optional device LDE buffer kept alive for
+    /// downstream rounds when the R1 fused GPU pipeline ran.
     ///
     /// `precomputed`: if present, the leading `num_cols` columns are committed
     /// as a separate Merkle tree (the precomputed split for preprocessed
@@ -1329,8 +1340,8 @@ pub trait IsStarkProver<
 
     /// Recompute Round1 from the trace, reusing the Merkle trees stored in commitments.
     ///
-    /// Only used by `run_debug_checks` — Phase D consumes the cached LDE
-    /// directly and does not go through this path.
+    /// Only used by `run_debug_checks` — the production path consumes the
+    /// cached LDE directly and does not go through here.
     #[cfg(feature = "debug-checks")]
     fn reconstruct_round1(
         air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,
@@ -1406,7 +1417,15 @@ pub trait IsStarkProver<
     }
 
     /// Reconstruct Round1 for every table, print the bus balance report, and
-    /// validate each trace. Called once after Phase C commits.
+    /// validate each trace.
+    ///
+    /// Cross-table (bus balance) checks need every table's commitments at once,
+    /// so under `debug-checks` the fused per-table chain is split into two
+    /// admitted passes and this runs once, on the main thread, between them.
+    ///
+    /// `pair_cells` is the same per-table slot vector the drivers use. Each
+    /// driver only ever locks its own index, so locking them here — after the
+    /// aux pass has joined and before the rounds pass starts — is uncontended.
     #[cfg(feature = "debug-checks")]
     fn run_debug_checks(
         pair_cells: &[std::sync::Mutex<AirTracePair<'_, Field, FieldExtension, PI>>],
@@ -3076,7 +3095,7 @@ pub trait IsStarkProver<
         // of the tables proved concurrently so large blocks don't exhaust VRAM.
         // It is an extra ceiling on top of `k` (it never raises concurrency). On
         // non-cuda builds, or when the budget can't be queried, it is `u64::MAX`
-        // and chunking falls back to fixed size `k`.
+        // and the gate is inert — concurrency is then bounded by `k` alone.
         #[cfg(feature = "cuda")]
         let vram_budget = math_cuda::device::backend()
             .map(|b| b.vram_budget_bytes())
@@ -3126,7 +3145,7 @@ pub trait IsStarkProver<
         }
 
         // =====================================================================
-        // Round 1, Phase A: Commit all main traces (parallel in chunks of K)
+        // Round 1: Commit all main traces (VRAM-admitted, up to K concurrent)
         // =====================================================================
         // All main trace commitments must be in the transcript before sampling
         // LogUp challenges.
@@ -3139,8 +3158,9 @@ pub trait IsStarkProver<
         let mut main_commits: Vec<TableCommit<Field>> = Vec::with_capacity(num_airs);
         let mut main_ldes: Vec<(Vec<FieldElement<Field>>, usize)> = Vec::with_capacity(num_airs);
         // Optional device-side LDE handle per table, populated only when the
-        // R1 fused GPU pipeline produced one. Threaded through Phase D's zip
-        // chain so each handle stays paired with its table by construction.
+        // R1 fused GPU pipeline produced one. Indexed by table, and moved into
+        // the per-table `gpu_main_cells` slots below so each handle stays
+        // paired with its table across the fused chain.
         #[cfg(feature = "cuda")]
         let mut main_gpu_handles: Vec<Option<math_cuda::lde::GpuLdeBase>> =
             Vec::with_capacity(num_airs);
@@ -3206,7 +3226,7 @@ pub trait IsStarkProver<
         }
 
         // =====================================================================
-        // Round 1, Phase B: Sample shared LogUp challenges
+        // Round 1: Sample shared LogUp challenges
         // =====================================================================
 
         let lookup_challenges: Vec<FieldElement<FieldExtension>> = if needs_lookup_challenges {
@@ -3218,16 +3238,13 @@ pub trait IsStarkProver<
         };
 
         // =====================================================================
-        // Phase C + Rounds 2-4: Forked per table
+        // Aux build + aux commit + Rounds 2-4: fused per table
         // =====================================================================
         // Each table gets an independent transcript fork (cloned from the shared
-        // state after Phase B, domain-separated by table index). This matches
-        // the verifier's forking and makes per-table proving independent.
+        // state after the LogUp challenges, domain-separated by table index).
+        // This matches the verifier's forking and makes per-table proving
+        // independent.
         //
-        // Split into two passes for parallelism:
-        //   Pass 1 (parallel): Build all auxiliary traces (fingerprint + batch inversion)
-        //   Pass 2 (parallel): Fork transcript → extract → LDE → commit
-
         // Aux build, aux commit and rounds 2-4 run FUSED per table below (one
         // driver chains all three for its table, so tables never wait on a
         // phase barrier); only this sequential prep runs here.
@@ -3266,10 +3283,10 @@ pub trait IsStarkProver<
             })
             .collect();
 
-        // Parallel aux commit in chunks of K. The closure returns a cfg-gated
-        // AuxResult. Under cuda it carries the optional ext3 GPU LDE handle as
-        // a third element, so Phase D's zip chain keeps it paired with its
-        // table without a separate handle vector.
+        // The aux stage of the fused chain returns a cfg-gated AuxResult. Under
+        // cuda it carries the optional ext3 GPU LDE handle as a third element,
+        // so the handle stays inside its own table's task and never needs a
+        // separate handle vector.
         #[cfg(feature = "cuda")]
         type AuxResult<FE> = (
             Option<TableCommit<FE>>,

--- a/prover/src/auto_storage.rs
+++ b/prover/src/auto_storage.rs
@@ -48,7 +48,8 @@ pub const SAFETY_FRACTION_DEN: u64 = 10;
 /// `(rows, main_cols, aux_cols, num_main_merkle_trees)` for a single table.
 type TableSpec = (u64, u64, u64, u64);
 
-/// Bytes alive for the duration of phase D (LDE columns + main/aux Merkle).
+/// Bytes counted as alive for the whole proof (LDE columns + main/aux Merkle).
+/// Deliberately an over-estimate for the aux half — see `peak_bytes`.
 fn persistent_per_table(spec: TableSpec, blowup: u64) -> u64 {
     let (rows, main_cols, aux_cols, main_trees) = spec;
     let main_lde = rows
@@ -228,19 +229,31 @@ pub fn decide(lengths: &TableLengths, blowup_factor: u8) -> StorageMode {
 }
 
 /// Peak RAM estimate in bytes for a proof whose trace shape matches `lengths`.
+///
+/// `table_parallelism` is the prover's `k` (`stark::prover::table_parallelism`),
+/// and it is not only a prover knob: `decide` feeds it in here, so the `cuda`
+/// arm's `cores * 2 / 3` doubles the transient term below versus the CPU arm's
+/// `cores / 3` and makes `Disk` more likely. That direction is safe (it
+/// over-estimates), but it means a change to `k` changes the storage decision.
 pub fn peak_bytes(lengths: &TableLengths, blowup_factor: u8, table_parallelism: usize) -> u64 {
     let blowup = blowup_factor as u64;
     let k = table_parallelism.max(1);
     let specs = table_specs(lengths);
 
-    // Persistent: every table's LDE + main/aux Merkle is alive across phase D.
+    // Persistent: every table's main LDE + Merkle really is alive at once (the
+    // Round 1 main commit is a phase-wide barrier). The aux LDE no longer is —
+    // it is produced and consumed inside one table's fused task, so at most k
+    // coexist — but it is still counted for every table here, which keeps this
+    // an over-estimate rather than making the bound unsound.
     let persistent_total: u64 = specs
         .iter()
         .map(|s| persistent_per_table(*s, blowup))
         .fold(0u64, u64::saturating_add);
 
-    // Transient: only k tables run round 2-4 in parallel. Conservative bound is
-    // the top-k tables by transient bytes (worst possible chunk assignment).
+    // Transient: only k tables run the fused aux+rounds task at a time. The
+    // top-k tables by transient bytes bound it; with the scheduler's
+    // heaviest-first admission that top-k is also the set actually admitted
+    // first, so this is the realistic peak, not a worst case.
     let mut transient_per: Vec<u64> = specs
         .iter()
         .map(|s| transient_per_table(*s, blowup))

--- a/prover/src/instruments.rs
+++ b/prover/src/instruments.rs
@@ -71,11 +71,13 @@ pub fn print_report(
     row_top("AIR construction", air_construction, total);
 
     if let Some(ref mp) = mp {
-        let round1 = mp.main_commits + mp.aux_build + mp.aux_commit;
-
+        // Round 1's main commits are the last phase-level barrier: every main
+        // root must be in the transcript before the shared LogUp challenges are
+        // sampled. Aux build, aux commit and rounds 2-4 are fused per table, so
+        // they are reported under one wall-clock parent below, with their
+        // components as concurrent (summed-over-drivers) sub-rows.
         row_top("Pre-pass (domains/twiddles)", mp.prepass, total);
-        row_top("Round 1", round1, total);
-        row_sub("  Main trace commits", mp.main_commits, total);
+        row_top("Round 1 (main trace commits)", mp.main_commits, total);
         row_sub(
             "    Main LDE (fused GPU: LDE+Keccak+Merkle / CPU: LDE only)",
             mp.round1_sub.main_lde,
@@ -86,7 +88,15 @@ pub fn print_report(
             mp.round1_sub.main_merkle,
             total,
         );
-        row_sub("  Aux trace build (parallel)", mp.aux_build, total);
+        row_top(
+            "Rounds 2\u{2013}4 (aux build+commit fused)",
+            mp.rounds_2_4,
+            total,
+        );
+        eprintln!(
+            "      \u{2500}\u{2500} below: summed across concurrent drivers \u{2500}\u{2500}"
+        );
+        row_sub("  Aux trace build", mp.aux_build, total);
         row_sub(
             "    LogUp fingerprint (CPU)",
             mp.round1_sub.aux_fingerprint,
@@ -118,7 +128,7 @@ pub fn print_report(
             mp.round1_sub.aux_merkle,
             total,
         );
-        row_top("Rounds 2\u{2013}4", mp.rounds_2_4, total);
+        eprintln!("      \u{2500}\u{2500} per table (R2\u{2013}4) \u{2500}\u{2500}");
 
         // Merge split tables: MEMW[0..4] → MEMW x5
         let mut merged: BTreeMap<String, MergedTable> = BTreeMap::new();
@@ -209,10 +219,7 @@ pub fn print_report(
                 ("R4  queries & openings", total_queries),
             ];
             sub_ops.sort_by(|a, b| b.1.cmp(&a.1));
-            eprintln!(
-                "  {}",
-                "    \u{2500}\u{2500} sub-operation totals (all tables) \u{2500}\u{2500}",
-            );
+            eprintln!("      \u{2500}\u{2500} sub-operation totals (all tables) \u{2500}\u{2500}");
             for (label, dur) in &sub_ops {
                 row_sub(&format!("    {label}"), *dur, total);
             }

--- a/scripts/bench_prover_scaling.sh
+++ b/scripts/bench_prover_scaling.sh
@@ -74,15 +74,17 @@ parse_run() {
     /^  Trace build/         { v = secs(); if (v) print "t_trace_build=" v }
     /^  AIR construction/    { v = secs(); if (v) print "t_air="         v }
     /^  Pre-pass/            { v = secs(); if (v) print "t_prepass="     v }
+    # "Round 1 (main trace commits)" is the whole of round 1 now; aux build and
+    # aux commit are fused into the per-table region and reported under
+    # "Rounds 2-4" as sums over the concurrent drivers, so they can exceed it.
     /^  Round 1 /            { v = secs(); if (v) print "t_round1="      v }
-    /Main trace commits/     { v = secs(); if (v) print "t_main_commits="v }
     /Aux trace build/        { v = secs(); if (v) print "t_aux_build="   v }
     /Aux trace commit/       { v = secs(); if (v) print "t_aux_commit="  v }
     /Rounds 2/               { v = secs(); if (v) print "t_rounds24="    v }
-    /Main expand_columns_to_lde/{ v = secs(); if (v) print "t_main_lde=" v }
-    /Aux expand_columns_to_lde/ { v = secs(); if (v) print "t_aux_lde="  v }
-    /Main commit \(Merkle\)/ { v = secs(); if (v) print "t_main_merkle=" v }
-    /Aux commit \(Merkle\)/  { v = secs(); if (v) print "t_aux_merkle="  v }
+    /Main LDE/               { v = secs(); if (v) print "t_main_lde="    v }
+    /Aux LDE/                { v = secs(); if (v) print "t_aux_lde="     v }
+    /Main commit \(Merkle/   { v = secs(); if (v) print "t_main_merkle=" v }
+    /Aux commit \(Merkle/    { v = secs(); if (v) print "t_aux_merkle="  v }
     /^  Total FFT/           { v = secs(); if (v) print "t_total_fft="   v }
     /^  Total Merkle/        { v = secs(); if (v) print "t_total_merkle="v }
     /^  TOTAL /              { v = secs(); if (v) print "t_total="       v }
@@ -90,9 +92,13 @@ parse_run() {
     /After trace build/      { print "h_trace_build="  $(NF-1) }
     /After AIR/              { print "h_air="          $(NF-1) }
     /After pool alloc/       { print "h_pool_alloc="   $(NF-1) }
+    # NOTE: the "After aux build" / "After aux commit" heap snapshots were
+    # removed when aux build/commit were fused into the per-table scheduler --
+    # with k tables in flight there is no single moment at which either has
+    # finished, so the snapshot had no meaning. "After main commits" is the
+    # last phase-wide barrier, and "Peak heap" still guards the region below
+    # it, so the heap-growth regressions keep coverage of the fused region.
     /After main commits/     { print "h_main_commits=" $(NF-1) }
-    /After aux build/        { print "h_aux_build="    $(NF-1) }
-    /After aux commit/       { print "h_aux_commit="   $(NF-1) }
     ' "$stderr"
 
     grep -o 'Peak heap: [0-9]*' "$stdout" | awk '{print "peak=" $3}'
@@ -184,15 +190,14 @@ print_row "Execute"                t_execute     s
 print_row "Trace build"            t_trace_build s
 print_row "AIR construction"       t_air         s
 print_row "Pre-pass"               t_prepass     s
-print_row "Round 1"                t_round1      s
-print_row "  Main trace commits"   t_main_commits s
+print_row "Round 1 (main commits)"  t_round1      s
 print_row "    Main LDE"           t_main_lde    s
 print_row "    Main Merkle"        t_main_merkle s
+print_row "Rounds 2-4 (fused)"     t_rounds24    s
 print_row "  Aux trace build"      t_aux_build   s
 print_row "  Aux trace commit"     t_aux_commit  s
 print_row "    Aux LDE"            t_aux_lde     s
 print_row "    Aux Merkle"         t_aux_merkle  s
-print_row "Rounds 2-4"             t_rounds24    s
 print_row "Total FFT (all rounds)" t_total_fft   s
 print_row "Total Merkle"           t_total_merkle s
 print_row "TOTAL"                  t_total       s
@@ -206,8 +211,8 @@ if [[ "$MODE" == "heap" ]]; then
     print_row "After AIR construction" h_air          mb
     print_row "After pool alloc"       h_pool_alloc   mb
     print_row "After main commits"     h_main_commits mb
-    print_row "After aux build"        h_aux_build    mb
-    print_row "After aux commit"       h_aux_commit   mb
+    # "After aux build" / "After aux commit" intentionally absent: see the NOTE
+    # in parse_run. Peak heap covers the fused region they used to bracket.
     print_row "Peak heap"              peak           mb
 fi
 
@@ -270,8 +275,9 @@ if [[ "$MODE" == "heap" ]]; then
     regress "After AIR construction" h_air          mb
     regress "After pool alloc"       h_pool_alloc   mb
     regress "After main commits"     h_main_commits mb
-    regress "After aux build"        h_aux_build    mb
-    regress "After aux commit"       h_aux_commit   mb
+    # The "After aux build" / "After aux commit" heap-growth guards were dropped
+    # with their snapshots (see the NOTE in parse_run). "Peak heap" is the
+    # remaining regression guard over the fused per-table region.
     regress "Peak heap"              peak           mb
 fi
 


### PR DESCRIPTION
Review fixes for the per-table scheduler, targeting `gpu-opt-table-scheduler` so they land with it. No scheduler behaviour changes: the fused chain, gate semantics, heaviest-first ordering and the `cores * 2 / 3` constant are untouched.

## 1. The rounds 2–4 phase wall vanished from the timeline

This is the one that matters, because it is the instrument the GPU campaign reads its numbers from.

On `origin/main`, `rounds_2to4` was **one span wrapping the chunk loop** (`prover.rs:3503`), so it measured the phase. The scheduler moved it inside the per-table closure (`:3568`), one instance per table. `scripts/profiling/phase_table.py:129` does `e["wall_ns"] += s["wall_ns"]` — it **sums spans that share a label** — so that row became the sum of N concurrent tables, up to k× the real wall clock and able to print >100%. And with the span consumed per table, **nothing was left measuring the phase at all**. Same story for `r1_aux_build` and `r1_aux_commit`, which were also phase-level spans on main (`:3143`, `:3225`).

Fix (`2fa9d75e`): reopen `rounds_2to4` on the calling thread around the whole fused region (`prover.rs:3611-3619`, dropped at `:3664`), and rename the per-table spans to `r1_aux_build_table` / `r1_aux_commit_table` / `rounds_2to4_table` so a per-instance label can never be summed into a phase row.

This also repairs `LAMBDA_VM_NSYS_CAPTURE_SPAN=rounds_2to4` (`scripts/profiling/README.md:115`): with the label on the per-table span, N concurrent driver threads each called `cuProfilerStart`/`Stop`, and the first table to finish stopped the capture while the rest were still running. One phase span means one capture range again.

Verified on `prove(fib_iterative_1M)` with `--features instruments` — phase spans sum to their parent exactly:

```
  proving                                     11.585s   96.4%
    r1_prepass                              148.229ms    1.2%
    r1_main_commit                             2.493s   20.8%
    rounds_2to4                                8.943s   74.5%      <- restored
r1_aux_build_table                          408.711ms    3.4%      <- per instance
rounds_2to4_table                              2.946s   24.5%
...
```

0.148 + 2.493 + 8.943 = 11.584 vs `proving` 11.585.

**The span `depth` field is not the problem, and is deliberately left alone.** Worker-thread spans do record `depth = 0`, but `phase_table.py:121` takes its denominator from `max(s["wall_ns"] for _, s in pathed)` — the longest span, not the root of the ancestor stack — so the "% of total" column was always correct and `README.md:77` stays accurate. And `prover/src/continuation.rs` has recorded spans off worker threads since before this PR (`:1146, :1205, :1299, :1328, :1415`), with the comment at `:1051-1053` saying so outright. So `instruments.rs:5-14`'s claim that spans "do not overlap and sum to their parent" was already inaccurate on main. It is rewritten to describe what the data actually is — including the label-summing trap that caused this bug.

## 2. The timing report was self-inconsistent (same commit — compile-coupled)

`aux_build_elapsed` / `aux_commit_elapsed` were pinned to `Duration::ZERO`. That was **deliberate** (`prover.rs:3250-3251` documents the folding); the report just never got updated to match. Consequences, all in the terminal report every `--features instruments` user sees:

- `prover/src/instruments.rs:74` computed `round1 = main_commits + aux_build + aux_commit`, so `:77` "Round 1" and `:78` "  Main trace commits" printed the **identical number**.
- `:89` / `:110` printed a plausible `0.00s` for the two aux buckets while `accum_r1_aux` kept their children populated (`prover.rs:3410`, `:3449`, `:3497`) — nonzero children under zero parents, and a *fabricated* zero rather than a missing row.
- "Round 1" understated by the whole aux stage while "Rounds 2–4" absorbed it.

The fused stages genuinely have no wall-clock phase of their own any more, so rather than resurrect separate timers the report now shows the two phases that remain, with the aux CPU-time rows grouped under the fused phase behind headers that say they are summed over tables:

```
  Round 1 (main trace commits)            1.41s   12.9%
      Main LDE (fused GPU: …)             2.29s   20.9%
      Main commit (Merkle, CPU only)      1.88s   17.2%
  Rounds 2–4 (aux build+commit fused in)  9.25s   84.4%
      ── aux build (CPU, summed over tables) ──
      LogUp fingerprint (CPU)             2.65s   24.2%
      …
      ── aux commit (CPU, summed over tables) ──
      Aux LDE (fused GPU: …)              3.02s   27.6%
      …
      ── per table (R2–4 wall) ──
```

The dead `MultiProveTiming::aux_build` / `aux_commit` fields are removed, which is why this lands in the same commit as fix 1.

## 3. Bench script rows whose sources no longer exist (`e6bf4a8a`)

`scripts/bench_prover_scaling.sh` still parsed, printed and ran heap-growth regressions on `snap("After aux build")` / `snap("After aux commit")`, which the scheduler deleted (present on `origin/main` at `prover.rs:3216`, `:3486`). Not silent — `regress` skips a missing key and prints "(insufficient data)", `print_row` prints `-` — but two guards were comparing nothing. Re-adding the snapshots is impossible: with k tables in flight there is no single moment at which either stage has finished. Removed, with a NOTE saying why and naming the guards that still bracket the fused region ("After main commits", "Peak heap"). Kept deliberately minimal — this script has no Makefile target and no workflow referencing it.

## 4. Stale comments (`5221d655`, comments only)

The one a reviewer would be actively **misled** by: `prover.rs:3134-3135` and `:3266` said the GPU LDE handles stay paired with their table via "Phase D's zip chain … by construction". That mechanism is gone — pairing is index-keyed mutex cells (`gpu_main_cells`, filled at `:3311`, taken at `:3534`), and the aux handle never leaves its own table's task.

Also: the orphaned `plan_table_chunks` doc that `VramGate`'s rustdoc had absorbed (`:618-623` — `VramGate` is private so `cargo doc` won't render it by default, but it is still wrong); `Lde`'s "all N tables' LDE columns are live simultaneously" (`:263-266`), now stating the real asymmetric bound — main LDEs all-N, aux LDEs ≤ k because each is created in `aux_stage`, moved by value into `rounds_stage` and dropped in `build_round1` inside one task, **except under `debug-checks`** where the two-pass split holds all N across `run_debug_checks`; the "Split into two passes" block contradicting the comment two lines below it (`:3219-3221`); `table_parallelism`'s single-arm doc (`:568-570`); and the "Phase D" sweep — 7 references with **no definition left**, its banner deleted while A/B/C kept theirs.

`prover/src/auto_storage.rs` is **not** touched: `origin/main...gpu-opt-table-scheduler` is `crypto/stark/src/prover.rs` and nothing else, so its stale comments are pre-existing and out of scope here. Verifier-side "Phase A/B/C" naming is likewise left alone.

## 5. CI: exercise the scheduler concurrently (`e843d328`)

`table_parallelism()` defaults to `(cores / 3).max(1)`, and every job in `pr_main.yaml` is `runs-on: ubuntu-latest` with no larger-runner label, so **PR CI proves with exactly one driver thread today** — the concurrent path never runs, and `VramGate` is additionally inert on non-cuda builds (`vram_budget = u64::MAX` makes `acquire`'s condition always true).

`TABLE_PARALLELISM: 6` on **shard 1 only** of the 4-way "Prover tests" matrix is the smallest change that puts several real table closures in flight concurrently on a PR. The other three shards keep default-k coverage; the expression yields an empty string there, which fails to parse and falls back to the default, so it is inert. `prover/Cargo.toml:8` is `default = ["parallel"]`, so the env arm is the live one.

This is not a substitute for GPU coverage — `gpu-tests.yml` on `merge_group` rents a ≥16-core RTX 5090, taking the cuda arm (`cores * 2 / 3`, k≈10) with a finite VRAM budget, so both the concurrent and blocking paths already run before merge. **The gap this closes is PR-time only.**

No unit tests were added for `VramGate` / `run_admitted` / `heaviest_first`: the properties worth pinning are either structural (`heaviest_first` is `(0..n).collect()` + `sort_by_key`), already covered end-to-end (a slot mixup in `run_admitted` is schedule-independent and trips one of the three `.expect("run_admitted fills every slot")` sites or fails `multi_verify`), or unreachable from the call sites (`k` is `.max(1)`'d, `order` is always a full permutation). The one property with teeth — an over-budget table being admitted alone — **hangs** rather than fails if it regresses, which on an 8-10 minute shard burns to the job timeout.

## Verified locally — none of it GPU-verified

No CUDA on this machine (`math-cuda` builds via nvcc stubs), and `gpu-tests` does not run on PRs, so **nothing here has been exercised on a real device.**

- `cargo check -p stark` with each of `instruments`, `debug-checks`, `disk-spill`, `cuda`, and combined `instruments,cuda,debug-checks,disk-spill`; same for `-p lambda-vm-prover` — all clean.
- `cargo clippy -p stark --features cuda --all-targets` — 30 warnings, the same set as the base branch (pre-existing "needlessly taken reference" noise in `tests/fri_tests.rs`, `tests/prover_tests.rs`, `tests/row_pair_opening_tests.rs`, `lookup.rs`, `logup_gpu.rs`). `cargo clippy -p lambda-vm-prover --features instruments` is warning-free — the new separator lines are plain literals, and the one pre-existing `print_literal` on the adjacent "sub-operation totals" separator was inlined to match.
- `cargo fmt --all` then `--check` — clean.
- `cargo test --release -p stark --lib` — 202 passed, 0 failed.
- `cargo test --release -p lambda-vm-prover --features instruments --test bench_single -- --ignored --nocapture` for the timeline and report above, on CPU with k = 5.
- `bash -n scripts/bench_prover_scaling.sh`; workflow YAML parsed with `yq` to confirm the `env` landed on the right step.
