### PR TITLE
fix(guest): take the zero-copy input via the safe get_private_input_slice

### DIFF
--- a/executor/programs/rust/ethrex/src/main.rs
+++ b/executor/programs/rust/ethrex/src/main.rs
@@ -5,15 +5,12 @@ use lambda_vm_ethrex_crypto::LambdaVmEcsmCrypto;
 use rkyv::rancor::Error;
 
 pub fn main() {
-    // Zero-copy private input: `ef_io::read_input` returns a pointer+len into
-    // the memory-mapped input region (host pre-loads it before execution), so
-    // rkyv deserializes straight from the input. `get_private_input()` would
-    // `to_vec()` the whole input first — a full extra copy plus one large
-    // allocation (~52k cycles on a 20-tx block).
-    let mut input_ptr: *const u8 = core::ptr::null();
-    let mut input_len: usize = 0;
-    unsafe { lambda_vm_syscalls::ef_io::read_input(&mut input_ptr, &mut input_len) };
-    let input = unsafe { core::slice::from_raw_parts(input_ptr, input_len) };
+    // Zero-copy private input: borrow the memory-mapped input region in place
+    // (the host pre-loads it before execution) so rkyv deserializes straight
+    // out of it. `get_private_input()` is this same slice plus a `to_vec()` —
+    // a full extra copy and one large allocation (~50k cycles on a 20-tx
+    // block).
+    let input = lambda_vm_syscalls::syscalls::get_private_input_slice();
     let input = rkyv::from_bytes::<ProgramInput, Error>(input).unwrap();
     // LambdaVM crypto provider, defined in the lambda_vm repo and injected here
     // (so crypto changes don't require an ethrex PR — see `crypto/ethrex-crypto`).


### PR DESCRIPTION
Review fix on top of #886, targeting that branch so it lands inside it.

The zero-copy read is the right call — `get_private_input()` really does copy the
whole input for nothing. But `syscalls::get_private_input_slice` already borrows
the mapped region in place and returns `&'static [u8]`, and `get_private_input`
is literally that call plus a `to_vec()`. So dropping to the slice is the entire
win, without the pointer plumbing:

```rust
let input = lambda_vm_syscalls::syscalls::get_private_input_slice();
let input = rkyv::from_bytes::<ProgramInput, Error>(input).unwrap();
```

Three things that buys beyond the line count:

- **No raw pointers in guest code.** `syscalls.rs` keeps the region layout and its
  one `unsafe` block in a single place — the stated reason
  `get_private_input_slice` exists. Re-reading the length prefix in the guest
  duplicates layout knowledge that has to stay in step with the executor.
- **Restores the length-prefix clamp.** `get_private_input_slice` bounds the prefix
  by `MAX_PRIVATE_INPUT_SIZE`; `ef_io::read_input` returns it raw. The executor
  rejects oversized inputs, so honest runs are byte-identical either way — but a
  forged prefix built a slice reaching past the region instead of a bounded one.
  Robustness, not soundness: private input is prover-chosen by definition.
- **Drops a dependency on unspecified behavior.** `ef_io::read_input` documents
  `buf_ptr` as unspecified when `buf_size == 0`, and the previous code fed it to
  `from_raw_parts` regardless. Harmless in practice (the implementation always
  writes it, and ethrex input is never empty), but not a contract to lean on.

`bench_vs/lambda/recursion` already reads its blob exactly this way.

The measured win should be unchanged — both forms skip the same `to_vec()` — but
it is worth re-running the cycle counts from #886 to confirm, since that number
is the whole point of the PR.

### Verified locally

- `make executor/program_artifacts/rust/ethrex.elf` — builds clean.
- `cd tooling/ethrex-tests && cargo test --release -- --include-ignored --skip test_ethrex_real_block`
  (CI's exact command) — 4 passed, 0 failed. `test_ethrex` executes the rebuilt
  guest ELF and compares its public output against a native `execution_program`
  run, so the changed read path is covered.
- `rustfmt --check` clean.

Not re-measured: the cycle deltas, and proving-level coverage
(`test_prove_ethrex_empty_block` is `#[ignore]` and no CI job selects it).