### PR TITLE
Fix stale hint-ecall comments

### DIFF
--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -9,7 +9,8 @@ thiserror = "1.0.68"
 rustc-demangle = "0.1"
 ecsm = { path = "../crypto/ecsm" }
 # Host-side computation of non-constraining hints (modular inverse / sqrt) for the
-# `Hint` ecall — same k256 arithmetic the guest verifies against. BENCH ONLY.
+# `Hint` ecall — same k256 arithmetic the guest verifies against. Production code:
+# `compute_hint` runs in every proving execution of a hint-using guest.
 k256 = { version = "0.13", default-features = false, features = ["arithmetic", "expose-field"] }
 
 [dev-dependencies]

--- a/executor/programs/rust/hint_min/src/main.rs
+++ b/executor/programs/rust/hint_min/src/main.rs
@@ -5,9 +5,10 @@
 //! deliberately not modelled) so we can get prove→verify to balance before scaling
 //! to ethrex.
 //!
-//! Buffers are 8-byte aligned so the writes land in the aligned MEMW table, which is
-//! a preference rather than a requirement — `classify_memw` routes unaligned accesses
-//! to the general MEMW table, and the ethrex call site is in fact unaligned.
+//! Buffers are 8-byte aligned so the writes land in the aligned MEMW table — the same
+//! choice the ethrex call site makes (`get_hint` in `crypto/ethrex-crypto` wraps its
+//! output in an `align(8)` buffer). Alignment is a preference rather than a
+//! requirement — `classify_memw` routes unaligned accesses to the general MEMW table.
 
 use lambda_vm_syscalls as syscalls;
 


### PR DESCRIPTION
- executor/Cargo.toml: drop the BENCH ONLY label on the k256 dep. 515a921d3 removed those labels everywhere else; compute_hint is production executor code reached by real ecrecover proofs.
- hint_min: the ethrex call site is aligned, not unaligned — get_hint in crypto/ethrex-crypto wraps its output in an align(8) buffer.