### PR TITLE
ECSM operand addresses: the AIR accepts 7 addresses the executor rejects (implementation deviates from spec/src/ecsm.toml)

### DIFF
--- a/executor/programs/asm/test_ecsm_limb_24.s
+++ b/executor/programs/asm/test_ecsm_limb_24.s
@@ -1,0 +1,31 @@
+	.attribute	5, "rv64i2p1_m2p0_zmmul1p0"
+	.globl	main
+main:
+	addi	sp, sp, -64
+	li	t0, 0x59F2815B16F81798
+	sd	t0, 0(sp)
+	li	t0, 0x029BFCDB2DCE28D9
+	sd	t0, 8(sp)
+	li	t0, 0x55A06295CE870B07
+	sd	t0, 16(sp)
+	li	t0, 0x79BE667EF9DCBBAC
+	sd	t0, 24(sp)
+	li	t0, 5
+	sd	t0, 32(sp)
+	sd	zero, 40(sp)
+	sd	zero, 48(sp)
+	sd	zero, 56(sp)
+	# a0 = 2^32 - 24  (low limb of the xR output address, high limb 0)
+	li	t1, 1
+	slli	t1, t1, 32
+	addi	a0, t1, -24
+	addi	a1, sp, 0
+	addi	a2, sp, 32
+	li	a7, -11
+	ecall
+	addi	sp, sp, 64
+	li	a0, 0
+	li	a7, 93
+	ecall
+.Lfunc_end1:
+	.size	main, .Lfunc_end1-main

--- a/executor/programs/asm/test_ecsm_limb_25.s
+++ b/executor/programs/asm/test_ecsm_limb_25.s
@@ -1,0 +1,31 @@
+	.attribute	5, "rv64i2p1_m2p0_zmmul1p0"
+	.globl	main
+main:
+	addi	sp, sp, -64
+	li	t0, 0x59F2815B16F81798
+	sd	t0, 0(sp)
+	li	t0, 0x029BFCDB2DCE28D9
+	sd	t0, 8(sp)
+	li	t0, 0x55A06295CE870B07
+	sd	t0, 16(sp)
+	li	t0, 0x79BE667EF9DCBBAC
+	sd	t0, 24(sp)
+	li	t0, 5
+	sd	t0, 32(sp)
+	sd	zero, 40(sp)
+	sd	zero, 48(sp)
+	sd	zero, 56(sp)
+	# a0 = 2^32 - 25  (low limb of the xR output address, high limb 0)
+	li	t1, 1
+	slli	t1, t1, 32
+	addi	a0, t1, -25
+	addi	a1, sp, 0
+	addi	a2, sp, 32
+	li	a7, -11
+	ecall
+	addi	sp, sp, 64
+	li	a0, 0
+	li	a7, 93
+	ecall
+.Lfunc_end1:
+	.size	main, .Lfunc_end1-main

--- a/executor/programs/asm/test_ecsm_limb_31.s
+++ b/executor/programs/asm/test_ecsm_limb_31.s
@@ -1,0 +1,31 @@
+	.attribute	5, "rv64i2p1_m2p0_zmmul1p0"
+	.globl	main
+main:
+	addi	sp, sp, -64
+	li	t0, 0x59F2815B16F81798
+	sd	t0, 0(sp)
+	li	t0, 0x029BFCDB2DCE28D9
+	sd	t0, 8(sp)
+	li	t0, 0x55A06295CE870B07
+	sd	t0, 16(sp)
+	li	t0, 0x79BE667EF9DCBBAC
+	sd	t0, 24(sp)
+	li	t0, 5
+	sd	t0, 32(sp)
+	sd	zero, 40(sp)
+	sd	zero, 48(sp)
+	sd	zero, 56(sp)
+	# a0 = 2^32 - 31  (low limb of the xR output address, high limb 0)
+	li	t1, 1
+	slli	t1, t1, 32
+	addi	a0, t1, -31
+	addi	a1, sp, 0
+	addi	a2, sp, 32
+	li	a7, -11
+	ecall
+	addi	sp, sp, 64
+	li	a0, 0
+	li	a7, 93
+	ecall
+.Lfunc_end1:
+	.size	main, .Lfunc_end1-main

--- a/executor/programs/asm/test_ecsm_limb_32.s
+++ b/executor/programs/asm/test_ecsm_limb_32.s
@@ -1,0 +1,30 @@
+	.attribute	5, "rv64i2p1_m2p0_zmmul1p0"
+	.globl	main
+main:
+	addi	sp, sp, -64
+	li	t0, 0x59F2815B16F81798
+	sd	t0, 0(sp)
+	li	t0, 0x029BFCDB2DCE28D9
+	sd	t0, 8(sp)
+	li	t0, 0x55A06295CE870B07
+	sd	t0, 16(sp)
+	li	t0, 0x79BE667EF9DCBBAC
+	sd	t0, 24(sp)
+	li	t0, 5
+	sd	t0, 32(sp)
+	sd	zero, 40(sp)
+	sd	zero, 48(sp)
+	sd	zero, 56(sp)
+	li	t1, 1
+	slli	t1, t1, 32
+	addi	a0, t1, -32
+	addi	a1, sp, 0
+	addi	a2, sp, 32
+	li	a7, -11
+	ecall
+	addi	sp, sp, 64
+	li	a0, 0
+	li	a7, 93
+	ecall
+.Lfunc_end1:
+	.size	main, .Lfunc_end1-main

--- a/executor/programs/asm/test_limb_cross_sd.s
+++ b/executor/programs/asm/test_limb_cross_sd.s
@@ -1,0 +1,14 @@
+	.attribute	5, "rv64i2p1_m2p0_zmmul1p0"
+	.globl	main
+main:
+	li	t1, 1
+	slli	t1, t1, 32
+	addi	t2, t1, -4        # 0xFFFFFFFC: an 8-byte store here spans into hi=1
+	li	t0, 0x0123456789ABCDEF
+	sd	t0, 0(t2)
+	ld	t3, 0(t2)
+	li	a0, 0
+	li	a7, 93
+	ecall
+.Lfunc_end1:
+	.size	main, .Lfunc_end1-main

--- a/executor/src/vm/instruction/execution.rs
+++ b/executor/src/vm/instruction/execution.rs
@@ -429,9 +429,13 @@ impl Instruction {
                         let addr_xr = registers.read(10)?;
                         let addr_xg = registers.read(11)?;
                         let addr_k = registers.read(12)?;
-                        if !ecsm_addr_ok(addr_xg, 31)
-                            || !ecsm_addr_ok(addr_xr, 31)
-                            || !ecsm_addr_ok(addr_k, 31)
+                        // PoC ONLY (adversarial adjudication): the env var lets a test
+                        // run the reference semantics WITHOUT this guard, to see whether
+                        // the resulting trace still satisfies the AIR.
+                        if std::env::var_os("ECSM_NO_LIMB_GUARD").is_none()
+                            && (!ecsm_addr_ok(addr_xg, 31)
+                                || !ecsm_addr_ok(addr_xr, 31)
+                                || !ecsm_addr_ok(addr_k, 31))
                         {
                             return Err(ExecutionError::EcsmAddressOverflow);
                         }

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -3581,7 +3581,10 @@ fn poc_ecsm_limb_gap_31() {
     let (rejects, ok) = ecsm_limb_poc("test_ecsm_limb_31");
     println!("RESULT off=31 executor_rejects={rejects} proof_verifies={ok}");
     assert!(rejects, "executor should reject 0xFFFF_FFE1");
-    assert!(ok, "SOUNDNESS GAP: proof verified for an execution the executor halts on");
+    assert!(
+        ok,
+        "SOUNDNESS GAP: proof verified for an execution the executor halts on"
+    );
 }
 
 #[test]
@@ -3650,5 +3653,8 @@ fn poc_ecsm_limb_gap_31_shows_pages_above_2p32() {
         .iter()
         .any(|r| (0..r.count).any(|i| r.base + i * (1u64 << 18) >= (1u64 << 32)));
     println!("RESULT has_page_at_or_above_2^32={above}");
-    assert!(above, "the xR write must have spilled past the 2^32 limb boundary");
+    assert!(
+        above,
+        "the xR write must have spilled past the 2^32 limb boundary"
+    );
 }

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -3526,3 +3526,129 @@ fn test_epoch_memory_bus_with_l2g_bookend() {
         "epoch Memory bus must balance with L2G bookend + PAGE excluding touched cells"
     );
 }
+
+// =============================================================================
+// PoC (adversarial adjudication): ECSM low-limb window
+// =============================================================================
+
+/// Shared body: `name` is an asm ELF whose ECSM output address (`a0`) has low
+/// limb `2^32 - off`. Returns `(executor_rejects_unpatched, prove_verify_ok)`.
+fn ecsm_limb_poc(name: &str) -> (bool, bool) {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let elf_bytes = crate::test_utils::asm_elf_bytes(name);
+    let elf = Elf::load(&elf_bytes).expect("Failed to load ELF");
+
+    // (1) Reference semantics: the unpatched executor must reject.
+    unsafe { std::env::remove_var("ECSM_NO_LIMB_GUARD") };
+    let ex = Executor::new(&elf, vec![]).expect("Failed to create executor");
+    let rejects = match ex.run() {
+        Err(e) => {
+            println!("[poc {name}] reference executor: {e:?}");
+            format!("{e:?}").contains("EcsmAddressOverflow")
+        }
+        Ok(_) => {
+            println!("[poc {name}] reference executor: COMPLETED (no guard hit)");
+            false
+        }
+    };
+
+    // (2) Same program, guard bypassed: does the resulting proof verify?
+    unsafe { std::env::set_var("ECSM_NO_LIMB_GUARD", "1") };
+    let opts = ProofOptions::default_test_options();
+    let ok = match crate::prove_with_options(&elf_bytes, &opts, &MaxRowsConfig::default()) {
+        Ok(proof) => match crate::verify_with_options(&proof, &elf_bytes, &opts, None, None) {
+            Ok(v) => {
+                println!("[poc {name}] prove OK, verify = {v}");
+                v
+            }
+            Err(e) => {
+                println!("[poc {name}] verify ERROR: {e:?}");
+                false
+            }
+        },
+        Err(e) => {
+            println!("[poc {name}] prove ERROR: {e:?}");
+            false
+        }
+    };
+    unsafe { std::env::remove_var("ECSM_NO_LIMB_GUARD") };
+    (rejects, ok)
+}
+
+#[test]
+fn poc_ecsm_limb_gap_31() {
+    // addr_xr low limb = 2^32 - 31 = 0xFFFF_FFE1. Executor: reject. AIR: ?
+    let (rejects, ok) = ecsm_limb_poc("test_ecsm_limb_31");
+    println!("RESULT off=31 executor_rejects={rejects} proof_verifies={ok}");
+    assert!(rejects, "executor should reject 0xFFFF_FFE1");
+    assert!(ok, "SOUNDNESS GAP: proof verified for an execution the executor halts on");
+}
+
+#[test]
+fn poc_ecsm_limb_gap_25() {
+    // addr_xr low limb = 2^32 - 25 = 0xFFFF_FFE7 — the last value in the window.
+    let (rejects, ok) = ecsm_limb_poc("test_ecsm_limb_25");
+    println!("RESULT off=25 executor_rejects={rejects} proof_verifies={ok}");
+    assert!(rejects);
+    assert!(ok);
+}
+
+#[test]
+fn poc_ecsm_limb_gap_24_negative_control() {
+    // addr_xr low limb = 2^32 - 24 = 0xFFFF_FFE8: dword base +24 leaves the limb,
+    // so the AIR's byte-0 token is non-canonical. Expect prove/verify to FAIL.
+    let (rejects, ok) = ecsm_limb_poc("test_ecsm_limb_24");
+    println!("RESULT off=24 executor_rejects={rejects} proof_verifies={ok}");
+    assert!(rejects);
+    assert!(!ok, "negative control: 0xFFFF_FFE8 should NOT be provable");
+}
+
+#[test]
+fn poc_ecsm_limb_gap_32_positive_control() {
+    // addr_xr low limb = 2^32 - 32 = 0xFFFF_FFE0: the largest value the EXECUTOR
+    // allows. Executor accepts AND the proof verifies — so the only thing that
+    // differs between this and off=31 is the guard, not the harness.
+    let (rejects, ok) = ecsm_limb_poc("test_ecsm_limb_32");
+    println!("RESULT off=32 executor_rejects={rejects} proof_verifies={ok}");
+    assert!(!rejects, "executor should ACCEPT 0xFFFF_FFE0");
+    assert!(ok);
+}
+
+#[test]
+fn poc_plain_sd_across_limb_boundary() {
+    // A plain 8-byte store at 0xFFFF_FFFC (spanning into high limb 1) is accepted
+    // by the executor AND provable: the VM's general MEMW path carries correctly
+    // across the 2^32 limb boundary. Only the ECSM ecall refuses it.
+    let _ = env_logger::builder().is_test(true).try_init();
+    let elf_bytes = crate::test_utils::asm_elf_bytes("test_limb_cross_sd");
+    let elf = Elf::load(&elf_bytes).expect("Failed to load ELF");
+    let ex = Executor::new(&elf, vec![]).expect("Failed to create executor");
+    let res = ex.run();
+    println!("[poc plain-sd] executor: {:?}", res.as_ref().err());
+    assert!(res.is_ok(), "plain limb-crossing sd must execute");
+    let opts = ProofOptions::default_test_options();
+    let proof = crate::prove_with_options(&elf_bytes, &opts, &MaxRowsConfig::default())
+        .expect("prove failed");
+    let ok = crate::verify_with_options(&proof, &elf_bytes, &opts, None, None).expect("verify err");
+    println!("RESULT plain-sd-across-limb proof_verifies={ok}");
+    assert!(ok, "limb-crossing plain store should be provable");
+}
+
+#[test]
+fn poc_ecsm_limb_gap_31_shows_pages_above_2p32() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let elf_bytes = crate::test_utils::asm_elf_bytes("test_ecsm_limb_31");
+    unsafe { std::env::set_var("ECSM_NO_LIMB_GUARD", "1") };
+    let opts = ProofOptions::default_test_options();
+    let proof = crate::prove_with_options(&elf_bytes, &opts, &MaxRowsConfig::default()).unwrap();
+    unsafe { std::env::remove_var("ECSM_NO_LIMB_GUARD") };
+    for r in &proof.runtime_page_ranges {
+        println!("RUNTIME PAGE base=0x{:016X} count={}", r.base, r.count);
+    }
+    let above = proof
+        .runtime_page_ranges
+        .iter()
+        .any(|r| (0..r.count).any(|i| r.base + i * (1u64 << 18) >= (1u64 << 32)));
+    println!("RESULT has_page_at_or_above_2^32={above}");
+    assert!(above, "the xR write must have spilled past the 2^32 limb boundary");
+}


### PR DESCRIPTION
> **Demonstration only — not for merge.** This branch adds a PoC harness and, to run it, gates the
> executor's `ecsm_addr_ok` guard behind an env var. It is here to document a finding and let you
> reproduce it, not to be merged.

## Summary

The ECSM AIR accepts operand addresses that the executor rejects. A witness whose operand low limb
falls in a **7-value window** balances every bus and **verifies**, while `cli execute` on the same
input aborts with `EcsmAddressOverflow`.

**The spec got this right — this is an implementation deviation, not a spec gap.**
`spec/src/ecsm.toml` specifies both the address range checks and carry-correct derivation of the
per-access addresses; `prover/src/tables/ecsm.rs` implements neither. Details in
[Root cause](#root-cause-the-implementation-does-not-follow-the-spec) below. Nothing needs to be
*designed* to fix this — the constraints already exist on paper and simply are not built.

The executor's `ecsm_addr_ok` guard is a compensating control for that deviation, and because the
guard and the AIR constrain *different things*, their accepted sets drifted apart — which is where
the window comes from.

One caveat on provenance: `spec/src/ecsm.toml` currently lives on the `spec/ecsm` branch and has not
been merged into `spec/main`, so the constraints are specified but not landed. That is worth
resolving alongside the code, since an unlanded spec is easy for a second implementation to miss.

Severity is **low**: nothing is forged, no address is aliased, and the reachable gain is
halt-vs-continue on an attacker-authored program. Filing it because it is a real
prover/verifier-vs-executor divergence in a shipped table, and because the spec deviation behind it
is worth correcting on its own terms.

## The divergence

`ecsm_addr_ok(addr, 31)` (`executor/src/vm/instruction/execution.rs`) requires
`(addr mod 2^32) + 31 < 2^32`, i.e. `lo32 <= 0xFFFF_FFE0`.

The AIR only needs `lo32 <= 0xFFFF_FFE7`. ECSM sends its four doubleword accesses as
`base_lo = ADDR_*_0 + 8i`, `base_hi = ADDR_*_1` — a bare field addition on the low limb with no
carry column. Each of those four *bases* must therefore be a canonical low limb, so the binding
constraint is `lo32 + 24 < 2^32`. The trailing 7 bytes of the last doubleword are fine, because
general MEMW carries bytes 1..7 correctly (`prover/src/tables/memw.rs`: byte 0 uses the raw
`(BASE_ADDRESS_0, BASE_ADDRESS_1)` pair, bytes 1..7 use
`base_0 + i - 2^32*carry[i]`, `base_1 + carry[i]`).

**Gap = `lo32 ∈ [0xFFFF_FFE1, 0xFFFF_FFE7]`, 7 values per operand**, plus a mapped page at high
limb `hi + 1`.

## Reproduction

```
cargo test --release -p lambda-vm-prover poc_ecsm -- --test-threads=1
```

| `a0` low limb | reference executor | proof verifies |
|---|---|---|
| `0xFFFF_FFE0` (off 32) | accepts | ✅ **positive control** |
| `0xFFFF_FFE1` (off 31) | `EcsmAddressOverflow` | ✅ **gap** |
| `0xFFFF_FFE7` (off 25) | `EcsmAddressOverflow` | ✅ **gap** |
| `0xFFFF_FFE8` (off 24) | `EcsmAddressOverflow` | ❌ rejected — LogUp bus does not balance |

The **off=24 / off=25** boundary is the load-bearing detail: it is exactly the ±1 the mechanism
predicts (byte 0 of doubleword 3 sits at `ADDR_0 + 24` with no carry), which is what distinguishes a
real mechanism from a harness that accepts everything.

Two supporting tests:
- `poc_plain_sd_across_limb_boundary` — a plain 8-byte `sd` at `0xFFFF_FFFC` spanning into high
  limb 1 is executor-accepted **and provable**. The VM supports limb-crossing accesses generally;
  only the ECSM ecall refuses them.
- `poc_ecsm_limb_gap_31_shows_pages_above_2p32` — the off=31 proof's declared runtime pages are
  `0xFFFC_0000` **and** `0x1_0000_0000`, confirming the write really did spill past 2^32.

Verification goes through the production `prove_with_options` / `verify_with_options` path. **The
only source change is the env-var gate on `ecsm_addr_ok`** — trace builder, AIR definitions and
verifier are untouched. Bypassing the executor guard is the point: a malicious prover builds traces
with its own tooling and is not bound by the reference executor, so the question that matters is
whether the *verifier* accepts the trace.

## Root cause: the implementation does not follow the spec

`spec/src/ecsm.toml` (on `spec/ecsm`) specifies two things the implementation omits.

**1. Range-check every address, not just the base** — `ec:c:range_addr_xG`:

```toml
kind = "interaction"
tag = "IS_HALF"
input = [["idx", ["idx", "addr_xG", "i"], "j"]]
iters = [["i", 0, 3], ["j", 0, 3]]
multiplicity = "μ"
```

`IS_HALF` over **i = 0..3**: all four doubleword addresses, both halves each.

**2. Derive the per-doubleword addresses with real addition** — `ec:c:extrapolate_addr_xG`:

```toml
kind = "template"
tag = "ADD"
input = [["cast", ["idx", "addr_xG", 0], "DWordWL"], ["cast", ["*", 8, "i"], "DWordWL"]]
output = ["cast", ["idx", "addr_xG", "i"], "DWordWL"]
iter = ["i", 1, 3]
```

So in the spec each `addr_xG[i]` is **its own DWordWL column**, tied to the base through the `ADD`
template — full 64-bit addition, carry into the high limb included.

`prover/src/tables/ecsm.rs` has no `addr_xG[i]` columns at all. It has `ADDR_XG_0`/`ADDR_XG_1` and
builds each access base as a `LinearTerm` `ADDR_XG_0 + 8i` with `base_hi = ADDR_XG_1` passed
through unchanged. No per-access column, no `ADD`, no carry, no `IS_HALF`. The same applies to
`addr_k` and `addr_xR`.

With the spec's constraints in place the window cannot exist: `IS_HALF` on all four addresses forces
each to be a canonical 32-bit-limbed value, and `ADD` propagates the carry, so the AIR's accepted
set is the executor's.

For contrast, `KECCAK` does implement this shape — it carry-propagates its lane addresses with real
carry pairs and needs no executor precondition.

## Impact

- **Not** an arbitrary write, value forgery, or address aliasing. Within the window MEMW's carry
  columns compute the *arithmetically correct* 64-bit addresses, so the bytes land where a correct
  RV64 machine would put them.
- The only false statement provable is "this program did not halt". Exploiting it needs an
  attacker-authored ELF that places such an address in an operand register, and the deployed guest
  is pinned by the DECODE commitment.
- Unreachable for the shipped guests: `ecsm_oracle` uses `[u8; 32]` stack arrays, and
  `STACK_TOP = 0xFFFF_FFFF_FFFF_FFF0` puts them at high limb `0xFFFF_FFFF`, where `hi + 1 = 2^32`
  is not representable by any page — so the stack case is blocked outright, independent of the low
  limb.

## Suggested direction

Implement `ec:c:range_addr_*` and `ec:c:extrapolate_addr_*` as written: per-access address columns
derived via `ADD`, with `IS_HALF` on each. That makes the AIR self-contained and lets
`ecsm_addr_ok` be relaxed or dropped.

**Do not "fix" this by relaxing the executor guard from `+31` to `+24`.** The two guards accept
*incomparable* sets, not nested ones. The AIR is more permissive on the low limb but strictly
**less** permissive on the high limb: whenever `lo32 >= 0xFFFF_FFE1` the tail bytes carry, so the
AIR needs `hi <= 0xFFFF_FFFE`. Relaxing the executor to `+24` would accept
`hi = 0xFFFF_FFFF` operands the AIR **cannot prove**, converting a low-severity soundness gap into
a liveness bug on honest executions. `+31` is the unique offset-only bound that is `hi`-independent:
it guarantees no byte of the 32-byte operand ever crosses `2^32`, so no carry is needed anywhere.

Relatedly, `addr_limb_ok`'s doc comment states that a straddling operand "makes the trace
unprovable". That is true of the `+8i` *base* derivation but false of MEMW's within-row bytes, and
it is the assumption the 7-value window lives in.

## Note on scope

The `HINT` table added in #876 reproduces the same `ADDR_OUT_0 + 8i` shape and has the same window;
that instance is addressed separately. This PR is only about ECSM on `main`.
