### PR TITLE
Review follow-ups for #876: the CI gap, three stale soundness comments, and three test gaps

### DIFF
--- a/.github/workflows/pr_main.yaml
+++ b/.github/workflows/pr_main.yaml
@@ -117,6 +117,15 @@ jobs:
         run: |
           cargo test --release -p executor --test flamegraph
 
+      # The unit tests under `executor/src/tests/` are a *lib* target (`pub mod tests;`
+      # in lib.rs), which none of the `--test <name>` steps above select — and the
+      # `test_ckzg` step below filters by name, so it doesn't run them either. Without
+      # this step they never run in CI. It shares the lib test binary with that step,
+      # so it costs a test run, not an extra compile.
+      - name: Run executor lib unit tests
+        run: |
+          cargo test --release -p executor --lib
+
       - name: Run ignored executor tests
         run: |
           cargo test --release -p executor test_ckzg -- --ignored

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,6 +585,7 @@ version = "0.1.0"
 dependencies = [
  "ecsm",
  "k256",
+ "lambda-vm-syscalls",
  "rustc-demangle",
  "serde",
  "serde_json",

--- a/crypto/ethrex-crypto/src/lib.rs
+++ b/crypto/ethrex-crypto/src/lib.rs
@@ -196,9 +196,12 @@ where
     let mut y: FieldElement = Option::from(FieldElement::from_bytes(&y_be.into()))?;
     let y2: FieldElement = y.square();
     // Verify the untrusted root: y² must equal x³+7. Negate `y2`, not `rhs`:
-    // `Neg` is `negate(1)` and only accepts magnitude 1, which `square()` always
-    // returns, whereas `rhs` is a sum and carries magnitude 2 — negating it would
-    // silently compute the wrong value in release, where the debug assert is gone.
+    // `Neg` is `negate(1)`, whose debug assert requires magnitude <= 1. `square()`
+    // always returns magnitude 1, whereas `rhs` is a sum carrying magnitude 2, so
+    // negating it would trip that assert and panic in debug builds. (The value would
+    // still come out right — `negate(m)` computes `2*(m+1)*P_limb - self`, which for a
+    // magnitude-2 operand stays non-negative — so this is a build-configuration
+    // hazard, not a wrong answer.)
     // (`ct_eq` is unusable here for the same reason as in `field_inv`.)
     if !bool::from((rhs + y2.negate(1)).normalizes_to_zero()) {
         return None;

--- a/crypto/ethrex-crypto/src/tests/hint_tests.rs
+++ b/crypto/ethrex-crypto/src/tests/hint_tests.rs
@@ -5,10 +5,12 @@
 //! inverse / square root, then verifies it in-circuit. These tests inject the
 //! oracle directly — an *honest* oracle (matching the executor's `compute_hint`)
 //! and a *lying* one — and assert the software fallback makes the result identical
-//! either way. That is the property C1 turns on: a bad hint can only make the guest
-//! do more work, never change its accept/reject outcome. On the guest this code is
-//! `cfg(target_arch = "riscv64")`; the `test` gate on `*_with_oracle` is what lets
-//! CI compile and exercise it on the host.
+//! either way. That is the property the whole hint design rests on: because the
+//! prover chooses the hinted bytes and the ecall adds no correctness constraint, a
+//! bad hint must only be able to make the guest do more work, never change its
+//! accept/reject outcome. On the guest this code is `cfg(target_arch = "riscv64")`;
+//! the `test` gate on `*_with_oracle` is what lets CI compile and exercise it on
+//! the host.
 
 use crate::*;
 
@@ -76,6 +78,26 @@ fn scalar_inv_lying_hint_falls_back_to_software() {
 }
 
 #[test]
+fn scalar_inv_canonical_but_wrong_hint_falls_back_to_software() {
+    // The `[0; 32]` / `[0xFF; 32]` lies above both die in `Scalar::from_repr` — they
+    // never reach the verify predicate. These two are perfectly canonical scalars that
+    // simply aren't the inverse, so they exercise the rejecting branch of
+    // `(x * inv) == 1` itself, which is the check that actually has to hold.
+    for k in [1u64, 2, 12345] {
+        let x = Scalar::from(k);
+        let sw = x.invert_vartime().unwrap();
+        for (name, lie) in [("inv + 1", sw + Scalar::ONE), ("-inv", -sw)] {
+            let lie_be: [u8; 32] = lie.to_bytes().into();
+            let got = scalar_inv_with_oracle(&x, |_| lie_be).expect("fallback recomputes");
+            assert_eq!(
+                got, sw,
+                "a canonical-but-wrong hint ({name}) must be rejected and recomputed (k={k})"
+            );
+        }
+    }
+}
+
+#[test]
 fn decompress_r_honest_hint_matches_software() {
     // x-coordinates of real points are guaranteed residues.
     for k in [1u64, 2, 5, 12345] {
@@ -110,6 +132,39 @@ fn decompress_r_lying_hint_falls_back_to_software() {
                 "lying hint must fall back to software (k={k})"
             );
         }
+    }
+}
+
+/// Sqrt oracle returning the *other* root (`−y`). Not a lie: `−y` is as valid a root
+/// of `x³+7` as `y`, so the in-guest verify accepts it and the software fallback
+/// never runs — fixing the sign is entirely on the parity-selection branch.
+fn negated_field_sqrt(rhs_be: &[u8; 32]) -> [u8; 32] {
+    let honest = honest_field_sqrt(rhs_be);
+    let y = Option::<FieldElement>::from(FieldElement::from_bytes(&honest.into()))
+        .expect("the honest root is canonical");
+    (-y).normalize().to_bytes().into()
+}
+
+#[test]
+fn decompress_r_negated_sqrt_hint_recovers_the_point() {
+    // The hinted root's parity is the host's choice — `compute_hint` returns whichever
+    // root k256's `sqrt()` picks, so the caller must not depend on it. With the honest
+    // oracle the parity branch fires only for the `k` values whose root happens to have
+    // the wrong parity; forcing the negation exercises the *other* half of the branch
+    // for every `k`. A `Some` here comes from the hinted path, not the fallback, so a
+    // broken parity fix would return `-P` and fail the comparison.
+    for k in [1u64, 2, 5, 12345] {
+        let p = (ProjectivePoint::GENERATOR * Scalar::from(k)).to_affine();
+        let (x, y) = affine_xy(&p).unwrap();
+        let rb = x.to_bytes();
+        let y_is_odd = (y.normalize().to_bytes()[31] & 1) == 1;
+        let got = decompress_r_with_oracle(&rb, y_is_odd, negated_field_sqrt)
+            .expect("the other root is still a root");
+        assert_eq!(
+            sec1(&got),
+            sec1(&p),
+            "a negated (but valid) root must still recover the point (k={k})"
+        );
     }
 }
 
@@ -183,6 +238,32 @@ fn field_inv_lying_hint_falls_back_to_software() {
                 got.normalize().to_bytes(),
                 sw.normalize().to_bytes(),
                 "lying hint must fall back to the software inverse (k={k})"
+            );
+        }
+    }
+}
+
+#[test]
+fn field_inv_canonical_but_wrong_hint_falls_back_to_software() {
+    // As in the scalar case: the `[0; 32]` / `[0xFF; 32]` lies die in
+    // `FieldElement::from_bytes`, so they never reach the verify predicate. These two
+    // parse cleanly and are simply not the inverse, exercising the rejecting branch of
+    // `x·inv − 1 == 0` — the check the fast path's soundness actually rests on.
+    for k in [1u64, 2, 12345] {
+        let x = fe_from_u64(k);
+        let sw = Option::<FieldElement>::from(x.invert())
+            .unwrap()
+            .normalize();
+        for (name, lie) in [
+            ("inv + 1", (sw + FieldElement::ONE).normalize()),
+            ("-inv", -sw),
+        ] {
+            let lie_be: [u8; 32] = lie.normalize().to_bytes().into();
+            let got = field_inv_with_oracle(&x, |_| lie_be).expect("fallback recomputes");
+            assert_eq!(
+                got.normalize().to_bytes(),
+                sw.to_bytes(),
+                "a canonical-but-wrong hint ({name}) must be rejected and recomputed (k={k})"
             );
         }
     }

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -14,6 +14,14 @@ ecsm = { path = "../crypto/ecsm" }
 k256 = { version = "0.13", default-features = false, features = ["arithmetic", "expose-field"] }
 
 [dev-dependencies]
+# Test-only: the guest-side syscall crate re-declares the `hint` selectors as `usize`
+# and they must stay equal to the `u64` copies here (see `hint_selectors_match_the_guest`).
+# Unlike `crypto/crypto`'s and `ethrex-crypto`'s copies of this dep, it is NOT
+# target-gated, so it does build on the host — safe because the only guest-only items
+# (the `#[global_allocator]` and the `_start`/`main` entrypoint) are already
+# `cfg(target_arch = "riscv64")` in that crate, and `executor::tests` is itself
+# `#[cfg(test)]`, so the non-test lib build never links it.
+lambda-vm-syscalls = { path = "../syscalls" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tiny-keccak = { version = "2.0", features = ["keccak"] }

--- a/executor/programs/rust/hint_multi/src/main.rs
+++ b/executor/programs/rust/hint_multi/src/main.rs
@@ -1,13 +1,15 @@
-//! Multi-hint P0/P2 guest for the Hint prover table: THREE `hint` ecalls
-//! (field inverse of three different small values), each result read back with
-//! ordinary `LOAD`s (XOR-accumulated) and the accumulator committed.
+//! Multi-hint P0/P2 guest for the Hint prover table: THREE `hint` ecalls, one per
+//! selector, each result read back with ordinary `LOAD`s (XOR-accumulated) and the
+//! accumulator committed.
 //!
 //! Complements `hint_min` (one hint, read back via `commit`): this exercises the
 //! parts the ethrex consumer relies on that a single-call guest does not —
-//! **multiple real HINT rows** (padded to a power of two) and **read-back of the
-//! hinted output via normal `LOAD` instructions** (whose MEMW reads must chain to
-//! the HINT table's writes). Buffers are 8-byte aligned so the writes land in the
-//! aligned MEMW table.
+//! **multiple real HINT rows** (padded to a power of two), **all three selectors**
+//! (`HINT_FIELD_INV` / `HINT_SCALAR_INV` / `HINT_FIELD_SQRT`, so the AIR's
+//! `selector < 3` range-check is exercised at every accepted value rather than only
+//! at 0) and **read-back of the hinted output via normal `LOAD` instructions**
+//! (whose MEMW reads must chain to the HINT table's writes). Buffers are 8-byte
+//! aligned so the writes land in the aligned MEMW table.
 
 use lambda_vm_syscalls as syscalls;
 
@@ -17,17 +19,23 @@ struct Aligned32([u8; 32]);
 pub fn main() {
     let mut acc = Aligned32([0u8; 32]);
 
-    for seed in [3u8, 5u8, 7u8] {
+    // One call per selector. 4 is a quadratic residue mod p, so the sqrt hint has a
+    // real root rather than the zeros `compute_hint` returns on a numeric failure.
+    for (hint_id, seed) in [
+        (syscalls::syscalls::HINT_FIELD_INV, 3u8),
+        (syscalls::syscalls::HINT_SCALAR_INV, 5u8),
+        (syscalls::syscalls::HINT_FIELD_SQRT, 4u8),
+    ] {
         let mut x = Aligned32([0u8; 32]);
         x.0[31] = seed;
-        let mut inv = Aligned32([0u8; 32]);
+        let mut out = Aligned32([0u8; 32]);
 
-        syscalls::syscalls::hint(syscalls::syscalls::HINT_FIELD_INV, &mut inv.0, &x.0);
+        syscalls::syscalls::hint(hint_id, &mut out.0, &x.0);
 
         // Read the hinted output back via ordinary loads and fold it in, so the
-        // MEMW reads of `inv` must chain to the HINT table's writes.
+        // MEMW reads of `out` must chain to the HINT table's writes.
         for i in 0..32 {
-            acc.0[i] ^= inv.0[i];
+            acc.0[i] ^= out.0[i];
         }
     }
 

--- a/executor/src/tests/hint_tests.rs
+++ b/executor/src/tests/hint_tests.rs
@@ -165,3 +165,32 @@ fn hint_syscall_rejects_an_unknown_selector() {
         );
     }
 }
+
+/// The guest's `lambda-vm-syscalls` crate re-declares the selectors as `usize`,
+/// linked to the `u64` copies here only by a comment. A divergence is **silent**:
+/// the ecall would trap on an unknown selector, or — worse for the selectors that
+/// stay in range — hand back the wrong function's answer, which the guest's
+/// verify-then-fallback swallows as "the host lied" and quietly recomputes in
+/// software. Nothing fails; the guest just runs ~2000× slower for the right result.
+/// This test is the only thing that would notice.
+///
+/// `is_valid_hint_selector`'s const-assert pins the AIR's range-check to this crate's
+/// accepted set, but nothing ties the *guest's* copy of the selectors to it — that is
+/// a third declaration, in a crate the workspace excludes, and this is what binds it.
+///
+/// The syscall number itself is not asserted here: the guest's copy is
+/// `#[cfg(target_arch = "riscv64")]` and private, so it does not exist in a host
+/// build. It is covered indirectly — a wrong number makes every `hint` guest fail
+/// to prove, which `test_prove_hint_min_rust_guest` catches loudly.
+#[cfg(test)]
+mod guest_constant_sync {
+    use super::{HINT_FIELD_INV, HINT_FIELD_SQRT, HINT_SCALAR_INV};
+    use lambda_vm_syscalls::syscalls as guest;
+
+    #[test]
+    fn hint_selectors_match_the_guest() {
+        assert_eq!(guest::HINT_FIELD_INV as u64, HINT_FIELD_INV);
+        assert_eq!(guest::HINT_SCALAR_INV as u64, HINT_SCALAR_INV);
+        assert_eq!(guest::HINT_FIELD_SQRT as u64, HINT_FIELD_SQRT);
+    }
+}

--- a/prover/src/tables/hint.rs
+++ b/prover/src/tables/hint.rs
@@ -356,12 +356,12 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
 /// The HINT table's single transition constraint: `mu·(1−mu) = 0`.
 ///
 /// `mu` is the multiplicity gating every one of this table's bus interactions
-/// (the `Ecall` receive, the `x12` register read, the four output writes, the
-/// 16 byte range-checks). It must be boolean, or a witness could put a non-`{0,1}`
-/// value on the `AreBytes`/MEMW sends. The LogUp argument already fixes `mu`'s value
-/// via the timestamp-unique `Ecall` tuple, but every other multiplicity-column table
-/// bit-constrains its column in-circuit; HINT does the same rather than being the
-/// lone exception that relies solely on bus balance.
+/// (the `Ecall` receive, the three register reads, the three `LT` range-checks, the
+/// four output writes, the 16 byte range-checks). It must be boolean, or a witness
+/// could put a non-`{0,1}` value on the `AreBytes`/MEMW sends. This is load-bearing,
+/// not a redundant restatement of a bus check: the `Ecall` bus pins only the *sum*
+/// of `mu` over the rows sharing a tuple — see the module-level docs for the
+/// spread-multiplicity witness it rules out.
 #[derive(Clone, Copy)]
 pub struct HintConstraints;
 

--- a/prover/src/test_utils.rs
+++ b/prover/src/test_utils.rs
@@ -897,9 +897,10 @@ pub fn create_halt_air(proof_options: &ProofOptions) -> ConcreteVmAir<EmptyConst
     )
 }
 
-/// Create HINT AIR: a receiver for the `hint` ecall (Ecall receive, x12 register
-/// read, four output MEMW writes, output byte range-checks) with a single boolean
-/// constraint on the multiplicity column `mu`.
+/// Create HINT AIR: a receiver for the `hint` ecall (Ecall receive, the x10/x11/x12
+/// register reads, the three ALU `LT` operand range-checks, four output MEMW writes,
+/// output byte range-checks) with a single boolean constraint on the multiplicity
+/// column `mu`.
 pub fn create_hint_air(proof_options: &ProofOptions) -> ConcreteVmAir<HintConstraints> {
     build_air(
         hint_cols::NUM_COLUMNS,

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -1212,10 +1212,11 @@ fn test_prove_ecsm_rust_guest() {
 
 /// End-to-end prove→verify for the non-constraining `Hint` ecall: the minimal Rust
 /// guest does one `hint` call (secp256k1 base-field inverse of 3) and commits the result.
-/// This exercises exactly the HINT table's bus surface (Ecall receive + the four
-/// 8-byte output MEMW writes) end-to-end through prove→verify, de-risking the bus
-/// balance before scaling to real consumers. The committed output must equal the
-/// value the executor's `compute_hint` produced (= 3^{-1} mod p).
+/// This exercises the whole HINT table bus surface (Ecall receive, the x10/x11/x12
+/// register reads, the two ALU `LT` operand range-checks, the four 8-byte output MEMW
+/// writes and the output byte range-checks) end-to-end through prove→verify, de-risking
+/// the bus balance before scaling to real consumers. The committed output must equal
+/// the value the executor's `compute_hint` produced (= 3^{-1} mod p).
 #[test]
 fn test_prove_hint_min_rust_guest() {
     let _ = env_logger::builder().is_test(true).try_init();
@@ -1242,11 +1243,13 @@ fn test_prove_hint_min_rust_guest() {
     assert_eq!(proof.public_output, expected.to_vec());
 }
 
-/// Multi-hint: three `hint` ecalls, each result read back with
+/// Multi-hint: three `hint` ecalls, one per selector, each result read back with
 /// ordinary `LOAD`s. Complements `test_prove_hint_min_rust_guest` by proving the
 /// paths the ethrex consumer relies on that a single-call guest doesn't: **multiple
-/// real HINT rows** (padded) and **read-back via normal LOAD** (MEMW reads chaining
-/// to the HINT writes). Committed output = XOR of the three field inverses.
+/// real HINT rows** (padded), **all three selectors** (so the AIR's `selector < 3`
+/// range-check is exercised at every accepted value, not only at 0) and **read-back
+/// via normal LOAD** (MEMW reads chaining to the HINT writes). Committed output =
+/// XOR of the three hinted values.
 #[test]
 fn test_prove_hint_multi_rust_guest() {
     let _ = env_logger::builder().is_test(true).try_init();
@@ -1265,15 +1268,22 @@ fn test_prove_hint_multi_rust_guest() {
         "hint_multi rust guest should verify"
     );
 
-    // Expected = XOR of field-inverses of 3, 5, 7 (32-byte BE), matching the guest.
+    // Expected = XOR of inv(3) mod p, inv(5) mod n and sqrt(4) mod p (32-byte BE),
+    // matching the guest's one-call-per-selector loop.
+    use executor::vm::instruction::execution::{
+        HINT_FIELD_INV, HINT_FIELD_SQRT, HINT_SCALAR_INV, compute_hint,
+    };
     let mut expected = [0u8; 32];
-    for seed in [3u8, 5u8, 7u8] {
+    for (hint_id, seed) in [
+        (HINT_FIELD_INV, 3u8),
+        (HINT_SCALAR_INV, 5u8),
+        (HINT_FIELD_SQRT, 4u8),
+    ] {
         let mut input = [0u8; 32];
         input[31] = seed;
-        let inv =
-            executor::vm::instruction::execution::compute_hint(0 /* HINT_FIELD_INV */, &input);
+        let out = compute_hint(hint_id, &input);
         for i in 0..32 {
-            expected[i] ^= inv[i];
+            expected[i] ^= out[i];
         }
     }
     assert_eq!(proof.public_output, expected.to_vec());


### PR DESCRIPTION
Review follow-ups for #876, as commits rather than comments so they can be taken or dropped
individually. Targets `feat/hint-ecall`, so merging brings them into #876 itself.

**Rebased and slimmed.** This originally carried the `out_addr` range-check, the "BENCH ONLY" label
removal, the `hint_min` alignment comment and a selector-bound const-assert. All four have since
landed independently on `feat/hint-ecall` (`5c55e4c1`, `1fa60ec6`, `2a5a6120`, `d3a85f49`) and have
been dropped rather than merged over. I checked both of the substantive ones rather than assuming
name-equivalence:

- **`5c55e4c1` (out_addr) is complete and equivalent** — the third `BusInteraction` on `ADDR_OUT_0`,
  the matching `LtOperation` in the trace builder, `lt_count += 2 → += 3` in `count_table_lengths`,
  and `with_capacity(26) → 27`. It derives the same seven-value window independently. Nothing left to
  do there.
- **`d3a85f49` (selector bound) is better than what this PR had** and supersedes it. It introduces
  `is_valid_hint_selector` as a single source of truth and const-asserts set equality in *both*
  directions; the const-assert here only checked the three constants were 0/1/2 and that the bound was
  one past, which would not have caught a fourth selector added *below* the bound. The AIR re-exports
  `HINT_SELECTOR_BOUND` rather than restating it, so there is no second declaration to drift.

What remains is five commits: one CI gap, three still-stale comments, and three test gaps.

The design itself holds up — I could not break the verify-then-fallback. An adversarial sweep of
5,138 end-to-end ecrecover comparisons plus ~7,000 per-seam, in both debug and release against the
vendored k256, found no hint for which `field_inv`, `scalar_inv` or `decompress_r` returns anything
other than what the pure-software path returns, and the fallback cannot be skipped. `y = 0` is
unreachable, `to_bytes()` normalises before serialising, and the `asm!` block cannot cache a stale
`*out`.

## The CI gap — `d7380474`

`test-executor` runs only `--test asm`, `--test rust`, `--test flamegraph` and a `test_ckzg`-filtered
`--ignored` step. Because `executor/src/lib.rs` has `#[cfg(test)] pub mod tests;`, everything under
`executor/src/tests/` is a **lib** target that no CI command selects — including the hint tests that
are the only coverage anywhere for `HintUnknownSelector`, `HintAddressOverflow` (both operands, plus
the accepted `2^32 − 32` boundary) and `compute_hint`'s three selectors.

I checked every `cargo test` / `nextest` invocation in the workflow. The nextest archive is scoped
`-p lambda-vm-prover -p stark -p crypto -p ecsm`, with executor absent — so nothing anywhere runs
them.

One step in an already-required job, and no added compile time: the lib test binary is already built
by the `test_ckzg` step. The mechanism is pre-existing (`ecsm_tests`, `keccak_tests`, `memory_tests`
were equally dark), so this is a missed opportunity rather than a regression in #876 — but it means
the operand-validation tests added by `5c55e4c1` are currently unrun too.

## Three comments that would mislead an auditor — `23384f9c`

These matter more than usual here, because in this table the doc comments *are* the soundness
argument. All three were checked against the current branch, and the operand work left them behind.

**`prover/src/tables/hint.rs`** — the `HintConstraints` doc says the LogUp argument "already fixes
`mu`'s value via the timestamp-unique `Ecall` tuple". That is the exact opposite of the module doc
~300 lines above, which correctly proves the `Ecall` bus pins only the *sum* of `mu` (the timestamp
is a free witness column) and that `IS_BIT` is therefore load-bearing. `git log -S` dates the stale
sentence to `ad21c37a` and the correct analysis to `be9066bf` — the later reversed the earlier and
the sentence was left behind.

It is the stated justification for the table's only algebraic constraint, so a future cleanup reading
it deletes `IS_BIT(mu)` and reopens the `+1/+1/−1` spread-multiplicity hole. The same doc block also
still lists the table's bus surface as one register read and no LT senders, which is now three reads
and three LT senders.

**`prover/src/test_utils.rs`** — `create_hint_air`'s doc still describes "x12 register read, four
output MEMW writes", with no mention of the `x10`/`x11` reads or the three LT senders.

**`crypto/ethrex-crypto/src/lib.rs`** — the comment justifying `negate(y2)` over `negate(rhs)` claims
that negating `rhs` "would silently compute the wrong value in release". Against vendored k256 0.13.4
that is false: `negate(m)` is `2*(m+1)*P_limb − self` and is value-correct at any magnitude absent
limb underflow, and for a magnitude-2 operand `4*P_limb − self ≥ 0`. The real consequence is tripping
its debug assert. The code's *choice* is right; only its stated reason is wrong — which matters,
because a reader who believes `negate` is value-incorrect above its declared magnitude may "fix" real
code on that basis.

## Test gaps

**`0b93d949` — pin the guest's selector constants against the executor's.** `d3a85f49` binds
executor ↔ AIR. The *guest* is a third declaration: `lambda-vm-syscalls` re-declares the same
selectors as `usize`, in a workspace-excluded crate, tied to nothing but a comment. That is a
different property and still unguarded.

The failure mode is silent, which is what makes it worth a test: a selector divergence makes the
verify-then-fallback swallow the wrong answer as "host lied", so the guest recomputes in software and
returns a *correct* result ~2000× slower, with nothing failing anywhere. Adds a
`#[cfg(test)]`-only dev-dependency on `syscalls`; verified it cannot reach the non-test build
(`cargo tree -p executor --edges normal` has zero occurrences) and that the guest-only hazards in
that crate — `global_allocator`, `entrypoint` — are already `cfg`-gated.

**`762b3540` — exercise all three selectors in `hint_multi`.** The guest called `HINT_FIELD_INV`
three times, so `HINT_SCALAR_INV` and `HINT_FIELD_SQRT` reached the prover nowhere. Now covers all
three at no extra CI cost: same guest, same single prove, expectation in `prove_elfs_tests` updated
to match. Both ELFs were rebuilt so the test runs against the new binary rather than a stale
artifact.

**`0c29db1b` — negated-sqrt and canonical-but-wrong hints.** Two gaps in the guest-side coverage.
Both lie shapes previously tested (`[0;32]`, `[0xFF;32]`) die in *parsing*, so the verify predicate's
rejecting branch was never exercised on a canonical value. And the negated-sqrt parity arm was
covered only by accident, via the parity of four hard-coded `k` values — I confirmed the branch is
live today by disabling the negation and watching `decompress_r_honest_hint_matches_software` fail,
but nothing pinned it.

## A note on the tamper tests

Worth stating plainly, because it applies to the operand tests on both sides of this rebase: the
tamper-style tests for `ADDR_OUT_0`, `ADDR_IN_0` and `SEL_0` are **defence-in-depth, not isolation
tests.** I measured this by reverting the range-check and re-running — editing `ADDR_OUT_0` also
unbalances the `x12` register read and the four MEMW writes, so the proof is rejected with or without
the LT sender. The two pre-existing siblings admit as much in their own doc comments.

The structural test is the one with teeth: with the fix reverted it fails (`left: 2, right: 3`). That
follows the precedent `test_hint_binds_out_addr_to_x12` already set in that file for exactly this
situation, and it is worth preferring for the LT senders too.

## Verification

On the rebased base, both hint guest ELFs rebuilt: `cargo test --release -p executor --lib` **36/36**
· `crypto/ethrex-crypto` **24/24** · `cargo test --release -p lambda-vm-prover hint` **13/13** ·
**`make lint` exit 0** (fmt-check + 4 clippy configurations, zero non-nvcc diagnostics).

## Not included — for the author

- **The PR body's numbers are stale**: 41 columns not 37, and 27 bus interactions after `5c55e4c1`,
  not 22. The Details and "In the AIR" sections also omit the `x10`/`x11` bindings and the LT
  range-checks — the checks that make the AIR's accepted set match the executor's, and so the ones an
  auditor most needs to see.
- **The Impact table needs re-baselining.** `5fd961a0` was the right control when written, but two
  perf PRs have landed between it and this branch — `9ccdaf28` (#861, guest thin LTO, whose own commit
  message measures −2.28%/−2.37% guest cycles on the ethrex fixtures; confirmed present in the
  treatment's guest manifest and absent at `5fd961a0`) and `d83b4d9e` (#863, GPU continuation
  proving). Roughly 2 points of the −44.1% belong to #861.

  More importantly the fixture is not representative: this PR's own `/bench` on the real block reports
  **−10.4% prove time and +2.1% peak heap**, against the body's −32% / −35%. The two reconcile —
  3 hints per ecrecover × 29 ecrecovers × ~67k cycles ≈ −11% of the real block's 50.78M guest cycles —
  because the 20-transfer fixture runs 9.16 ECSM per Mcycle against a real block's 2.28, so the work
  this PR accelerates is ~4× denser there. The prove-time win is real and well separated (0.7%
  spread); the suggestion is just to lead with the real-block number.

  The +2.1% heap is **not** the new table: a marginal always-on AIR measures ~5 MB (from the
  #874-vs-#896 stacked pair, with epoch count held fixed). Epochs are capped in *guest cycles*, so
  cutting cycles packed the same crypto into 11 epochs instead of 13, and peak heap moves in ~1 GiB
  quanta from power-of-two table padding.
- **`FIXED_TABLE_COUNT` coordination with #874.** Both take it 10 → 11 at byte-identical lines (86,
  546, 621), and #896 stacks on #874 while #879 stacks on this branch. Whichever merges second must
  resolve to **12**. A length assertion exists (`prove_elfs_tests.rs:2825`) but **nothing asserts the
  two AIR lists agree in *order*** — and lines 546 and 621 are separate conflict hunks, so an
  independent resolution can order them differently, which surfaces only as a prove/verify failure.
  ~10 lines zipping the lists by name would close that permanently.
- **`/profile_recursion`** was never run on this PR (the workflow exists and is one comment). An
  always-on table adds per-sub-proof cost to the recursion verifier in guest cycles and ~160–230 KB
  per epoch proof; unmeasured across #874/#876/#896 alike.
- `make lint` does not reach `crypto/ethrex-crypto` (own `[workspace]`), and it is drifting —
  `cargo fmt --check` there exits 1 with 86 diff lines at the merge-base. That is what the "test
  churn" in `ecrecover_tests.rs`/`ecsm_tests.rs`/`keccak_tests.rs` actually is: pure reformat, no new
  content.
- The rust-ELF cache key omits `crypto/ethrex-crypto/**`, though it is a path dep of the ethrex guest
  and now carries the hint safety argument. This PR is safe (it touches keyed paths), but a future PR
  touching only that crate would restore a stale `ethrex.elf`. The recursion-ELF key two jobs down
  already includes `crypto/**/src/**`.
