### PR TITLE
fix(gpu): harden the downgrade downloads, parallelize the recovery transposes

### DIFF
--- a/crypto/stark/src/gpu_lde.rs
+++ b/crypto/stark/src/gpu_lde.rs
@@ -1512,6 +1512,12 @@ where
                 return false;
             }
             let (m, lde) = (h.m, h.lde_size);
+            // Short download: degrade like the sibling paths
+            // (`download_main_lde_row_major`, `materialize_aux_trace_host`)
+            // rather than panic on the slab slicing below.
+            if slabs.len() != m * lde * 3 {
+                return false;
+            }
             let mut interleaved = vec![0u64; m * lde * 3];
             for c in 0..m {
                 for k in 0..3 {
@@ -1525,6 +1531,10 @@ where
             // is [u64; 3].
             unsafe {
                 let mut v = std::mem::ManuallyDrop::new(interleaved);
+                debug_assert!(
+                    v.len().is_multiple_of(3) && v.capacity().is_multiple_of(3),
+                    "interleaved len/capacity must be a multiple of 3 for Fp3 reinterpret"
+                );
                 Vec::from_raw_parts(
                     v.as_mut_ptr() as *mut FieldElement<E>,
                     v.len() / 3,

--- a/crypto/stark/src/gpu_lde.rs
+++ b/crypto/stark/src/gpu_lde.rs
@@ -26,6 +26,8 @@ use math::field::extensions_goldilocks::Degree3GoldilocksExtensionField;
 use math::field::goldilocks::GoldilocksField;
 use math::field::traits::{IsFFTField, IsField, IsSubFieldOf};
 use math::traits::AsBytes;
+#[cfg(feature = "parallel")]
+use rayon::prelude::{IndexedParallelIterator, ParallelIterator, ParallelSliceMut};
 
 use crate::config::{Commitment, FriLayerMerkleTreeBackend};
 use crate::domain::Domain;
@@ -1518,12 +1520,31 @@ where
             if slabs.len() != m * lde * 3 {
                 return false;
             }
+            // Parallel de-interleaved slabs → row-major interleaved: each row
+            // chunk gathers from the source slabs independently.
             let mut interleaved = vec![0u64; m * lde * 3];
-            for c in 0..m {
-                for k in 0..3 {
-                    let slab = &slabs[(c * 3 + k) * lde..(c * 3 + k + 1) * lde];
-                    for r in 0..lde {
-                        interleaved[(r * m + c) * 3 + k] = slab[r];
+            if m > 0 {
+                #[cfg(feature = "parallel")]
+                {
+                    interleaved
+                        .par_chunks_exact_mut(m * 3)
+                        .enumerate()
+                        .for_each(|(r, dst)| {
+                            for (c, dst_col) in dst.chunks_exact_mut(3).enumerate() {
+                                for (k, d) in dst_col.iter_mut().enumerate() {
+                                    *d = slabs[(c * 3 + k) * lde + r];
+                                }
+                            }
+                        });
+                }
+                #[cfg(not(feature = "parallel"))]
+                {
+                    for (r, dst) in interleaved.chunks_exact_mut(m * 3).enumerate() {
+                        for (c, dst_col) in dst.chunks_exact_mut(3).enumerate() {
+                            for (k, d) in dst_col.iter_mut().enumerate() {
+                                *d = slabs[(c * 3 + k) * lde + r];
+                            }
+                        }
                     }
                 }
             }
@@ -1567,10 +1588,28 @@ where
     if col_major.len() != m * lde {
         return None;
     }
+    // Parallel col-major → row-major transpose: each row chunk gathers from
+    // the source columns independently.
     let mut row_major = vec![0u64; m * lde];
-    for c in 0..m {
-        for r in 0..lde {
-            row_major[r * m + c] = col_major[c * lde + r];
+    if m > 0 {
+        #[cfg(feature = "parallel")]
+        {
+            row_major
+                .par_chunks_exact_mut(m)
+                .enumerate()
+                .for_each(|(r, dst)| {
+                    for (c, d) in dst.iter_mut().enumerate() {
+                        *d = col_major[c * lde + r];
+                    }
+                });
+        }
+        #[cfg(not(feature = "parallel"))]
+        {
+            for (r, dst) in row_major.chunks_exact_mut(m).enumerate() {
+                for (c, d) in dst.iter_mut().enumerate() {
+                    *d = col_major[c * lde + r];
+                }
+            }
         }
     }
     // SAFETY: F == Goldilocks (gated above); FieldElement<Gl> is

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -3478,6 +3478,11 @@ pub trait IsStarkProver<
                             // the main LDE if this table was device-only — and
                             // continue fully host-backed on the arms below.
                             let mut recovered = crate::gpu_lde::materialize_aux_trace_host(*trace);
+                            // Once the aux download lands, the host aux trace is
+                            // populated: a later failure is the main-LDE
+                            // download's, and the error has to name that step
+                            // instead of claiming an empty aux trace.
+                            let aux_recovered = recovered;
                             if recovered && device_only {
                                 let mut cell = main_lde_cells[idx].lock().unwrap();
                                 if let Some((data, _)) = cell.as_mut()
@@ -3506,7 +3511,14 @@ pub trait IsStarkProver<
                             }
                             if !recovered {
                                 return Err(ProvingError::Fft(
-                                    "resident aux LDE failed; host aux trace is empty".to_string(),
+                                    if aux_recovered {
+                                        "resident aux LDE declined; the aux trace was recovered \
+                                         but the main-LDE download failed"
+                                    } else {
+                                        "resident aux LDE declined and the aux-trace download \
+                                         recovery failed"
+                                    }
+                                    .to_string(),
                                 ));
                             }
                             eprintln!(


### PR DESCRIPTION
Follow-ups on the device-only downgrade recovery: three hardenings and one
performance fix, all confined to the recovery path added by this branch.

## Hardenings

**Length check on the aux download.** The aux branch of
`materialize_lde_trace_host` sliced the downloaded slabs
(`slabs[(c*3+k)*lde..(c*3+k+1)*lde]`) without validating the download's
length, so a short download would panic — inside the very function whose job
is to degrade gracefully instead of aborting. Both sibling paths already
validate: `download_main_lde_row_major` checks `col_major.len() != m * lde`
and `materialize_aux_trace_host` checks `raw.len() != rows * cols * 3`. This
adds the matching `slabs.len() != m * lde * 3` check, returning false so the
caller takes its normal failure route.

**The `from_raw_parts` guard convention.** The ext3 `Vec::from_raw_parts`
reinterpret in the aux branch was missing the
`len/capacity is a multiple of 3` `debug_assert!` that the two other
same-shape sites in this file carry. Restored with the same message. It is
spelled with `is_multiple_of` rather than `% 3 == 0` because clippy's
`manual_is_multiple_of` rejects the older spelling at this site under
`-D warnings` (that spelling is also already used elsewhere in the file);
the check itself is identical.

**The error message named the wrong failure.** The failure error read
`"resident aux LDE failed; host aux trace is empty"`, which is now reachable
on two paths and false on one of them: when the aux download *succeeded* and
the follow-up main-LDE download failed, the host aux trace had just been
populated. The code now tracks which recovery step failed and says so —
`"resident aux LDE declined and the aux-trace download recovery failed"` vs
`"resident aux LDE declined; the aux trace was recovered but the main-LDE
download failed"`. Control flow is unchanged; only the message differs.

## Performance: parallelize the recovery conversions

Both host-side conversions on the recovery path were single-threaded nested
loops over the full LDE:

- the col-major → row-major main transpose in `download_main_lde_row_major`
- the de-interleaved-slabs → row-major-interleaved aux conversion in
  `materialize_lde_trace_host`

For MEMW at LDE 2^20 that is a 411 MB and a 327 MB buffer, each walked with a
strided access pattern on one core, directly on the recovery path's
wall-clock.

Worth being explicit about the memory shape, because it constrains the fix.
Peak host memory during recovery is `max(2 × main, main + 2 × aux)` — about
1.07 GB for MEMW at LDE 2^20 (411 MB main, 327 MB aux). **Reordering the
downloads cannot reduce this.** A downloaded buffer is retained for the rest
of the recovery, and installing it into the trace is a move, not a free, so
every ordering has both the download and its destination live at the same
time. The peak is a property of "download the whole thing, then convert the
whole thing", not of the order.

So the fix targets the part that is actually addressable without changing the
download strategy: the conversions now parallelize over **output** row chunks
using `par_chunks_exact_mut`, following the existing idiom in `trace.rs`
("Parallel col-major → row-major transpose"). Every element is still written
exactly once, no unsafe is involved, and the index math is byte-for-byte the
same — chunk `r` of width `m` is `row_major[r*m + c]`, and chunk `r` of width
`m*3` sub-chunked by 3 is `interleaved[(r*m + c)*3 + k]`. The layout was
verified against the kernels, so it is parallelized without altering it.
Gated on the `parallel` feature with the sequential loop retained otherwise,
and skipped when `m == 0` since `chunks_exact_mut(0)` panics.

These loops run on a scheduler driver thread holding no locks, so rayon is
safe here — unlike the pinned-staging unpack in math-cuda, which documents
why it cannot be parallelized and is untouched.

### Chunked D2H: considered and skipped

Replacing the full-buffer `clone_dtoh` with a chunked download into a small
reusable scratch would drop the peak from `max(2 × main, main + 2 × aux)` to
`artifact + scratch`. The API supports it — `stream.memcpy_dtoh` accepts a
`.slice(range)` view, as used at `crypto/math-cuda/src/inverse.rs:141` — so no
new math-cuda helper is needed. It was still skipped, because the chunking
unit fights the fix above:

- The contiguous unit on device is a column (main) or a slab (aux). Scattering
  one column into the row-major artifact writes with stride `m`, touching one
  cache line per element across the entire 411 MB output — per column. That is
  ~49 sweeps of the output instead of one.
- Those writes are strided across every output chunk, so they are not
  expressible in the safe `par_chunks_exact_mut` shape. A per-column chunked
  download would undo the parallelization on exactly the path whose wall-clock
  this PR is fixing.
- The row-block tiling that preserves both properties needs one ranged copy
  per column per tile: for `m = 49`, `lde = 2^20`, a 4096-row tile is 256
  tiles × 49 ≈ 12.5k copies of 32 KB, trading a single ~20 ms bulk transfer
  for a large multiple of that in per-copy overhead.

Trading measurable wall-clock for host peak that is not the binding
constraint here — this is a VRAM-pressure fix, and 1.07 GB of host memory is
not what is scarce — is the wrong call on a path that cannot be measured
locally. The ranged-D2H primitive is there if a future measurement shows host
peak does matter.

## Testing

Compiles under the cuda clippy pass (`make lint`, all four passes green,
including `--features lambda-vm-prover/cuda`), `make fmt` clean, and
`cargo check -p stark` for the non-cuda build. `stark` has no default
features, so both `cuda` with and without `parallel` were checked
explicitly.

**The touched code was not executed.** There is no CUDA toolchain on the
machine this was written on, and more fundamentally this is the recovery
path: it runs only when a device dispatch declines at runtime, which needs
real VRAM pressure or the fault-injection hooks proposed as a follow-up.
Validation here is by reading plus the merge-queue GPU job.
