### PR TITLE
feat(prover): spill the aux LDE under StorageMode::Disk

### DIFF
--- a/crypto/stark/src/gpu_lde.rs
+++ b/crypto/stark/src/gpu_lde.rs
@@ -1553,7 +1553,7 @@ where
 
     // Aux: de-interleaved ext3 slabs -> row-major interleaved host Vec.
     let aux_data: Vec<FieldElement<E>> =
-        if lde_trace.num_aux_cols() == 0 || !lde_trace.aux_data.is_empty() {
+        if lde_trace.num_aux_cols() == 0 || !lde_trace.aux_data.row_major_data().is_empty() {
             Vec::new()
         } else {
             let Some(h) = lde_trace.gpu_aux() else {

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -275,8 +275,10 @@ where
 struct Lde<Field: IsFFTField, FieldExtension: IsField> {
     /// Row-major main LDE buffer + its column count.
     main: (Vec<FieldElement<Field>>, usize),
-    /// Row-major aux LDE buffer + its column count (`(vec![], 0)` if no aux).
-    aux: (Vec<FieldElement<FieldExtension>>, usize),
+    /// Row-major aux LDE, as a `Table` whose `width` is the column count (an
+    /// empty, zero-width table if no aux). `Table` rather than a bare `Vec` so
+    /// the buffer can be disk-spilled for the whole rounds 2-4 window.
+    aux: Table<FieldExtension>,
     /// Device-side main LDE buffer, populated only when the R1 GPU fused
     /// pipeline ran for this table. Kept so R2/R3/R4 GPU paths can read
     /// the LDE without re-H2D.
@@ -302,7 +304,9 @@ where
         blowup_factor: usize,
     ) -> Round1<Field, FieldExtension> {
         let (main_data, num_main_cols) = lde.main;
-        let (aux_data, num_aux_cols) = lde.aux;
+        let aux_data = lde.aux;
+        #[cfg(feature = "cuda")]
+        let num_aux_cols = aux_data.width;
 
         // Stage-3 device-only detection, inferred from the ACTUAL buffer state
         // (not the gate's intent): a table whose round-1 D2H was skipped has an
@@ -322,8 +326,8 @@ where
         #[cfg(feature = "cuda")]
         let main_empty = num_main_cols > 0 && main_data.is_empty();
         #[cfg(feature = "cuda")]
-        let host_trace_empty =
-            main_empty || (num_aux_cols > 0 && aux_data.is_empty() && lde.gpu_aux.is_some());
+        let host_trace_empty = main_empty
+            || (num_aux_cols > 0 && aux_data.row_major_data().is_empty() && lde.gpu_aux.is_some());
         #[cfg(feature = "cuda")]
         let device_num_rows = lde
             .gpu_main
@@ -336,7 +340,6 @@ where
             main_data,
             num_main_cols,
             aux_data,
-            num_aux_cols,
             step_size,
             blowup_factor,
         );
@@ -1407,9 +1410,9 @@ pub trait IsStarkProver<
                     }
                 }
             }
-            (aux_data, num_aux_cols)
+            Table::from_row_major(aux_data, num_aux_cols)
         } else {
-            (Vec::new(), 0)
+            Table::new(Vec::new(), 0)
         };
 
         Ok(commitment.build_round1(
@@ -3323,11 +3326,11 @@ pub trait IsStarkProver<
         #[cfg(feature = "cuda")]
         type AuxResult<FE> = (
             Option<TableCommit<FE>>,
-            (Vec<FieldElement<FE>>, usize),
+            Table<FE>,
             Option<math_cuda::lde::GpuLdeExt3>,
         );
         #[cfg(not(feature = "cuda"))]
-        type AuxResult<FE> = (Option<TableCommit<FE>>, (Vec<FieldElement<FE>>, usize));
+        type AuxResult<FE> = (Option<TableCommit<FE>>, Table<FE>);
         // R1 aux commit and rounds 2 to 4 share the peak working set: the main
         // and aux LDEs are co-resident, plus the composition and Merkle
         // transients (in the scratch factor). The aux width comes from the AIR
@@ -3484,7 +3487,7 @@ pub trait IsStarkProver<
                                 let root = tree.root;
                                 return Ok((
                                     Some(TableCommit::plain(tree, root)),
-                                    (aux_data, num_cols),
+                                    Table::from_row_major(aux_data, num_cols),
                                     Some(handle),
                                 ));
                             }
@@ -3580,7 +3583,7 @@ pub trait IsStarkProver<
                                 crate::instruments::accum_r1_aux(aux_lde_dur, Duration::ZERO);
                                 return Ok((
                                     Some(TableCommit::plain(tree, root)),
-                                    (aux_data, num_cols),
+                                    Table::from_row_major(aux_data, num_cols),
                                     Some(handle),
                                 ));
                             }
@@ -3627,15 +3630,30 @@ pub trait IsStarkProver<
                         #[cfg(feature = "instruments")]
                         crate::instruments::accum_r1_aux(aux_lde_dur, t_sub.elapsed());
 
+                        // Spill the aux LDE itself (`lde_size × aux_cols` ext3
+                        // elements, 24 B each — the dominant survivor of this
+                        // stage). It is write-once here and read-only from
+                        // rounds 2-4, so mmap-backing it frees the heap buffer
+                        // for the whole window and lets the OS evict the pages
+                        // under pressure.
+                        #[allow(unused_mut)]
+                        let mut aux_lde = Table::from_row_major(aux_data, total_cols);
+                        #[cfg(feature = "disk-spill")]
+                        if storage_mode == StorageMode::Disk {
+                            aux_lde
+                                .spill_to_disk()
+                                .map_err(|e| ProvingError::DiskSpill(format!("aux LDE: {e}")))?;
+                        }
+
                         #[cfg(feature = "cuda")]
-                        return Ok((Some(commit), (aux_data, total_cols), None));
+                        return Ok((Some(commit), aux_lde, None));
                         #[cfg(not(feature = "cuda"))]
-                        Ok((Some(commit), (aux_data, total_cols)))
+                        Ok((Some(commit), aux_lde))
                     } else {
                         #[cfg(feature = "cuda")]
-                        return Ok((None, (Vec::new(), 0), None));
+                        return Ok((None, Table::new(Vec::new(), 0), None));
                         #[cfg(not(feature = "cuda"))]
-                        Ok((None, (Vec::new(), 0)))
+                        Ok((None, Table::new(Vec::new(), 0)))
                     }
                 })()?;
             // Tuple shape is cfg-gated; `.0` is the optional TableCommit in

--- a/crypto/stark/src/table.rs
+++ b/crypto/stark/src/table.rs
@@ -313,6 +313,23 @@ impl<F: IsField> Table<F> {
         }
     }
 
+    /// Wrap a buffer the caller already produced in row-major order, skipping
+    /// `new`'s 2-D revalidation — that `debug_assert` clones the whole buffer,
+    /// which is prohibitive for LDE-sized data.
+    pub(crate) fn from_row_major(data: Vec<FieldElement<F>>, width: usize) -> Self {
+        if width == 0 {
+            return Self::new(Vec::new(), 0);
+        }
+        let height = data.len() / width;
+        Self {
+            data,
+            width,
+            height,
+            #[cfg(feature = "disk-spill")]
+            mmap_backing: None,
+        }
+    }
+
     /// Creates a Table instance from a vector of the intended columns.
     pub fn from_columns(columns: Vec<Vec<FieldElement<F>>>) -> Self {
         if columns.is_empty() {
@@ -336,6 +353,7 @@ impl<F: IsField> Table<F> {
     }
 
     /// Given a row index, returns a reference to that row as a slice of field elements.
+    #[inline]
     pub fn get_row(&self, row_idx: usize) -> &[FieldElement<F>] {
         #[cfg(feature = "disk-spill")]
         if let Some(ref backing) = self.mmap_backing {
@@ -424,6 +442,7 @@ impl<F: IsField> Table<F> {
     }
 
     /// Given row and column indexes, returns the stored field element in that position of the table.
+    #[inline]
     pub fn get(&self, row: usize, col: usize) -> &FieldElement<F> {
         #[cfg(feature = "disk-spill")]
         if let Some(ref backing) = self.mmap_backing {

--- a/crypto/stark/src/trace.rs
+++ b/crypto/stark/src/trace.rs
@@ -321,7 +321,9 @@ where
     /// Row-major main-trace buffer of length `num_rows * num_main_cols`.
     pub(crate) main_data: Vec<FieldElement<F>>,
     /// Row-major auxiliary-trace buffer of length `num_rows * num_aux_cols`.
-    pub(crate) aux_data: Vec<FieldElement<E>>,
+    /// A `Table` rather than a bare `Vec` so it can carry a disk-spilled
+    /// (mmap-backed) buffer — see the aux-LDE spill in the prover's aux stage.
+    pub(crate) aux_data: Table<E>,
     pub(crate) num_main_cols: usize,
     pub(crate) num_aux_cols: usize,
     pub(crate) num_rows: usize,
@@ -467,7 +469,7 @@ where
 
         Self {
             main_data,
-            aux_data,
+            aux_data: Table::from_row_major(aux_data, num_aux_cols),
             num_main_cols,
             num_aux_cols,
             num_rows,
@@ -483,21 +485,24 @@ where
     /// Build an LDETraceTable directly from row-major flat buffers. Skips the
     /// O(N·M) col→row transpose that `from_columns` pays — the caller produces
     /// the buffers row-major already (e.g. via `coset_lde_full_expand_row_major`).
+    ///
+    /// `aux_data` arrives as a `Table` so an already disk-spilled aux LDE keeps
+    /// its mmap backing instead of being pulled back onto the heap; its `width`
+    /// is the aux column count.
     pub fn from_row_major(
         main_data: Vec<FieldElement<F>>,
         num_main_cols: usize,
-        aux_data: Vec<FieldElement<E>>,
-        num_aux_cols: usize,
+        aux_data: Table<E>,
         trace_step_size: usize,
         blowup_factor: usize,
     ) -> Self {
         let lde_step_size = trace_step_size * blowup_factor;
+        let num_aux_cols = aux_data.width;
         let num_rows = if num_main_cols > 0 {
             debug_assert_eq!(main_data.len() % num_main_cols, 0);
             main_data.len() / num_main_cols
         } else if num_aux_cols > 0 {
-            debug_assert_eq!(aux_data.len() % num_aux_cols, 0);
-            aux_data.len() / num_aux_cols
+            aux_data.height
         } else {
             0
         };
@@ -566,7 +571,7 @@ where
             self.main_data = main_data;
         }
         if !aux_data.is_empty() {
-            self.aux_data = aux_data;
+            self.aux_data = Table::from_row_major(aux_data, self.num_aux_cols);
         }
         self.host_trace_empty = false;
     }
@@ -636,7 +641,7 @@ where
     /// Get a single aux-trace element by (row, col).
     #[inline]
     pub fn get_aux(&self, row: usize, col: usize) -> &FieldElement<E> {
-        &self.aux_data[row * self.num_aux_cols + col]
+        self.aux_data.get(row, col)
     }
 
     /// Borrow a full main-trace row as a contiguous slice (row-major buffer).
@@ -648,7 +653,7 @@ where
     /// Borrow a full aux-trace row as a contiguous slice (row-major buffer).
     #[inline]
     pub fn aux_row(&self, row: usize) -> &[FieldElement<E>] {
-        &self.aux_data[row * self.num_aux_cols..(row + 1) * self.num_aux_cols]
+        self.aux_data.get_row(row)
     }
 
     /// Gather a full main-trace row into an owned Vec.
@@ -878,7 +883,7 @@ where
             // buffer-level check as the main arm: mixed states are valid here.
             #[cfg(feature = "cuda")]
             assert!(
-                lde_trace.num_aux_cols() == 0 || !lde_trace.aux_data.is_empty(),
+                lde_trace.num_aux_cols() == 0 || !lde_trace.aux_data.row_major_data().is_empty(),
                 "R3 barycentric (aux) fell back to the host trace, but it is device-only (empty)"
             );
             let inv_denoms_v =


### PR DESCRIPTION
## What

Under `StorageMode::Disk` + `feature = "disk-spill"` the aux stage already spills the aux **trace** (`spill_aux_to_disk`) and the aux **Merkle tree** (`spill_tree`), but the aux **LDE** — `lde_size × aux_cols` ext3 elements at 24 B each, the largest of the three by a wide margin — had no spill path. It stayed heap-resident from the aux commit all the way through rounds 2-4, so Disk mode reclaimed almost nothing of the aux stage's actual footprint (tree spilling covers ~32 B/row × 2 against the LDE's 24 B × `aux_cols` per row).

## Mechanism

The aux LDE is **write-once** at the aux commit and **read-only** afterwards (constraint evaluation and the DEEP/OOD scan read it sequentially; query openings hit a handful of random rows via `gather_aux_row`). That is exactly the shape a write-once mmap wants: spill it once, read it back page-by-page, and let the OS evict pages under pressure.

Rather than inventing a second mmap container, this reuses the one the codebase already has: `Table<F>`, the row-major field-element buffer with `spill_to_disk()` / `row_major_data()` / `get()` / `get_row()` / `advise_drop_cache()` that already backs spilled trace tables.

- `Lde.aux` and `LDETraceTable::aux_data` change from `(Vec<FieldElement<E>>, usize)` / `Vec<FieldElement<E>>` to `Table<E>` (its `width` carries the column count).
- The CPU aux-commit path wraps the LDE buffer and spills it immediately after `commit_rows_bit_reversed` + `spill_tree`, i.e. at the point where nothing reads it again until rounds 2-4.
- `Table::from_row_major` is added as a non-validating constructor: `Table::new`'s `debug_assert!(validate_2d_structure(..))` clones the entire buffer into a `Vec<Vec<_>>`, which is fine for trace-sized data and prohibitive for LDE-sized data in debug builds.
- I/O errors surface as `ProvingError::DiskSpill`; no `unwrap`/`expect` on fallible I/O.

Behaviour-neutral off the feature and off Disk mode: an unspilled `Table` is the same buffer with the same row-major indexing. `get`/`get_row` gained `#[inline]` since they are now on the hot aux read path. The CUDA arms are untouched apart from the mechanical type change (`aux_data.is_empty()` → `aux_data.row_major_data().is_empty()`, which is also *more* correct: a spilled aux LDE is no longer mistaken for a device-only empty buffer).

## Measured

`cargo test --release -p lambda-vm-prover --features disk-spill --test calibration -- --nocapture` (`fib_iterative_372k`), 5 runs per arm. The sampler polls every 10 ms, so single runs are noisy — ranges are given rather than point estimates.

| arm | `origin/main` (d898a423) | this branch |
|---|---|---|
| Disk (`FORCE_DISK_SPILL=1`) | 2.615 – 2.825 GB | **2.290 – 2.378 GB** |
| Ram (auto) | 2.988 – 4.344 GB | 3.940 – 4.337 GB |

Disk mode: about **−403 MB / −14.8 %** peak heap, with non-overlapping ranges across all 10 runs. Ram mode is statistically indistinguishable, as intended — the two ranges overlap almost entirely and the spread is dominated by sampler noise.

`peak_bytes` is unchanged and still counts the aux LDE for every table, so it remains a conservative over-estimate; the calibration assert only gets more headroom.

## Scope note: the main LDE

`Lde.main` / `LDETraceTable::main_data` is the same shape — write-once in `commit_main_trace`, read-only afterwards — and would now spill through the identical mechanism. It is also the bigger target on `main`, since the Round 1 main commit is a phase-wide barrier and *all* N main LDEs are live at once. Deliberately left out to keep this diff reviewable; it is a clean follow-up now that the container is in place.

## Interaction with #897

On `main` the aux LDEs are k-bounded (`k = cores/3` co-resident), which is why the win here is a few hundred MB rather than multiple GB. #897 makes **all `num_airs`** of them co-resident on the CPU path (+4.6 GB measured on the real block) — at which point this spill is what makes Disk mode actually reclaim that memory instead of leaving the dominant term on the heap. The code region (`aux_stage` internals) is untouched by #897, so this merges cleanly either way and is based on `main` so it can land independently.

## Review order

Part of a 4-PR series around the CPU scheduler change:

1. `fix/pr897-review-comments` → into #897 — comment/doc alignment + simplifications; review first, merges into #897.
2. #897 (`fix/cpu-prover-scheduler`) → `main` — the scheduler fix (+9.8 % peak heap / −12.5 % prove time, measured on the real block).
3. `fix/peak-bytes-estimator` → `main` — makes `auto_storage::peak_bytes` model the ~10 AIR kinds it omits, adds a keccak calibration case, wires `calibration.rs` into CI.
4. `fix/aux-lde-spill` → `main` (**this PR**) — reviewed last: its payoff appears mainly post-#897 (all-N aux residency), and it only engages when the estimator (fixed in PR 3) actually selects Disk. On keccak-heavy workloads the current estimator under-predicts and picks `Ram`, so this spill path stays dormant there until `fix/peak-bytes-estimator` lands (or `FORCE_DISK_SPILL=1` is set).

## Validation

- `FORCE_DISK_SPILL=1 cargo test --release -p lambda-vm-prover --features disk-spill -- disk_spill count_table_lengths` — 3 passed, 1 failed: `count_table_lengths_matches_nonempty_hint_trace` panics on a missing `hint_min.elf` fixture (added by #876, not built in the local artifacts dir). Verified identical failure on clean `origin/main`, so it is a fixture gap, not a regression.
- `cargo test --release -p stark --features disk-spill disk_spill` — 5 passed.
- `cargo test --release -p stark` — 217 passed.
- `make lint` — all four clippy passes (default, `--no-default-features` + `debug-checks`, `disk-spill`, `cuda`) clean, `cargo fmt --check --all` clean.
