### PR TITLE
fix(gpu): review follow-ups on the round-4 residency PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -590,7 +590,7 @@ test-cuda-integration:
 test-cuda-fallback:
 	$(GPU_TEST_TIMEOUT) cargo test -p lambda-vm-prover --release --features test-cuda-faults \
 	    --test cuda_fallback_tests -- --ignored --nocapture --test-threads=1
-	cargo test -p lambda-vm-prover --release --features lambda-vm-prover/cuda \
+	$(GPU_TEST_TIMEOUT) cargo test -p lambda-vm-prover --release --features lambda-vm-prover/cuda \
 	    --test gpu_force_downgrade -- --ignored --nocapture --test-threads=1
 
 # The prover/stark/crypto/ecsm test suite with the GPU (cuda) path enabled (requires NVIDIA

--- a/crypto/math-cuda/src/barycentric.rs
+++ b/crypto/math-cuda/src/barycentric.rs
@@ -586,3 +586,28 @@ pub fn gather_rows_ext3_on_device(
     stream.synchronize()?;
     Ok(host)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::bary_num_chunks;
+
+    /// Pins which of the three terms binds, per regime. Pure arithmetic — the
+    /// kernels' parity across chunk counts is covered by
+    /// `tests/barycentric_multi.rs`, which allocates a GPU.
+    #[test]
+    fn bary_num_chunks_branches() {
+        // Rows-bound: the domain is too short to split further, whatever the
+        // grid wants. 2^14/8192 = 2, under the occupancy term's 2048/100 = 20.
+        assert_eq!(bary_num_chunks(100, 1 << 14), 2);
+        // Occupancy-bound: the columns alone nearly fill the grid, so the
+        // domain is split less than its length would allow. 2048/256 = 8,
+        // under the rows term's 2^17/8192 = 16.
+        assert_eq!(bary_num_chunks(256, 1 << 17), 8);
+        // Cap-bound: at production shapes both terms clear 64 (512 and 128).
+        assert_eq!(bary_num_chunks(4, 1 << 20), 64);
+        // Degenerate inputs still yield a launchable grid (>= 1 chunk).
+        assert_eq!(bary_num_chunks(0, 0), 1);
+        assert_eq!(bary_num_chunks(usize::MAX, 1 << 20), 1);
+        assert_eq!(bary_num_chunks(1, 0), 1);
+    }
+}

--- a/crypto/math-cuda/tests/barycentric_multi.rs
+++ b/crypto/math-cuda/tests/barycentric_multi.rs
@@ -140,14 +140,17 @@ fn run_ext3(log_trace: u32, blowup: usize, num_cols: usize, k_points: usize, see
 #[test]
 fn bary_base_multi_matches_single_point() {
     // Covers: k=1 degenerate, the production k=2, the kernel cap k=8, a
-    // single-chunk tiny n, and a column count that forces the chunk heuristic
-    // to its occupancy branch.
+    // single-chunk tiny n, a multi-chunk mid case, and the 64-chunk cap —
+    // the most chunks any shape can ask for, so parity is pinned at both
+    // ends of the chunk range. (`bary_num_chunks`'s own branch selection is
+    // covered by its unit tests; only the kernels are exercised here.)
     for (log_t, blowup, cols, k) in [
         (4u32, 2usize, 3usize, 1usize),
         (8, 4, 10, 2),
         (12, 2, 5, 3),
         (14, 2, 100, 2),
         (10, 2, 4, 8),
+        (20, 2, 4, 2),
     ] {
         run_base(log_t, blowup, cols, k, 3000 + log_t as u64 + k as u64);
     }
@@ -161,6 +164,7 @@ fn bary_ext3_multi_matches_single_point() {
         (10, 2, 3, 3),
         (14, 2, 40, 2),
         (10, 2, 4, 8),
+        (19, 2, 2, 2),
     ] {
         run_ext3(log_t, blowup, cols, k, 4000 + log_t as u64 + k as u64);
     }

--- a/crypto/stark/src/gpu_lde.rs
+++ b/crypto/stark/src/gpu_lde.rs
@@ -46,6 +46,12 @@ use crate::trace::LDETraceTable;
 /// measured sweep optimum on ethrex continuations (2^14 beats 2^15..2^19 and
 /// also beats "everything on GPU", where sub-2^14 tables lose to launch
 /// overhead). Override via env var for tuning.
+///
+/// The same value gates the whole dispatch layer, not just the commit: R2
+/// decompose, the R3 inv-denoms/barycentric contexts, R4 DEEP and the FRI
+/// fold all admit on it, so moving it moves every one of those floors
+/// together. The device-only envelope is the one gate that does NOT ride on
+/// it — see [`DEFAULT_DEVICE_ONLY_MIN_LDE`].
 const DEFAULT_GPU_LDE_THRESHOLD: usize = 1 << 14;
 
 fn gpu_lde_threshold() -> usize {
@@ -66,6 +72,15 @@ fn gpu_lde_threshold() -> usize {
 /// eligibility (the LOCKSTEP note below). Keep device-only to the large-table
 /// envelope where those paths are exercised; mid tables keep a host copy so a
 /// dispatch decline degrades to CPU instead of aborting.
+///
+/// That degradation covers the sites that READ the LDE — they all gate on
+/// `host_trace_empty()` and take their host arm. It does NOT cover the R4
+/// Merkle-proof gather: the host tree is root-only for every GPU-committed
+/// table (the tree stays resident from [`DEFAULT_GPU_LDE_THRESHOLD`] upward,
+/// whatever `retain_host_lde` says), so a declined `gather_proofs_dev` has
+/// nothing to fall back to and aborts regardless of the host LDE. Lowering
+/// the commit threshold therefore widens that one abort site even though it
+/// leaves this envelope alone.
 const DEFAULT_DEVICE_ONLY_MIN_LDE: usize = 1 << 19;
 
 fn gpu_device_only_threshold() -> usize {
@@ -2633,8 +2648,9 @@ where
 /// returning one [`Proof`] per position in the same order. Byte-identical to
 /// the host `MerkleTree::get_proof_by_pos` (guarded by the `merkle_gather`
 /// parity test), so R4 query openings can source proofs from the resident
-/// device tree instead of the host tree. Returns `None` on any cudarc error
-/// (the caller then falls back to the host tree).
+/// device tree instead of the host tree. Returns `None` on any cudarc error —
+/// which every caller treats as a hard abort, NOT a fallback: a resident tree
+/// leaves the host tree root-only, so there is no host path to walk.
 pub(crate) fn gather_proofs_dev(
     tree: &math_cuda::lde::GpuMerkleTree,
     positions: &[usize],
@@ -3162,7 +3178,8 @@ mod split_tree_tests {
     /// isolates the tree layout/hashing under test.
     #[test]
     fn split_trees_match_cpu_subset_commits() {
-        // Above the dispatch threshold (2^19 LDE) so the GPU path must engage.
+        // This shape's LDE is 2^19, well above the dispatch threshold, so the
+        // GPU path must engage.
         let n: usize = 1 << 18;
         let blowup: usize = 2;
         let m: usize = 5;

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -2687,9 +2687,11 @@ pub trait IsStarkProver<
                 !lde_trace.host_trace_empty(),
                 "R4 {what} opening fell back to the host tree, but it is device-only (empty)"
             );
-            // A root-only host tree means the nodes are device-resident: the
-            // host walk would emit an empty path for position 0 instead of
-            // failing, so a broken proofs↔tree pairing must abort here.
+            // A root-only host tree means the nodes are device-resident, so a
+            // broken proofs↔tree pairing must abort here. `get_proof_by_pos`
+            // already refuses a root-only tree, but the panic it produces
+            // downstream reads "FRI query index in bounds" — this names the
+            // real cause instead.
             assert!(
                 !tree.is_root_only(),
                 "R4 {what} opening fell back to a root-only host tree (nodes device-resident)"

--- a/crypto/stark/src/trace.rs
+++ b/crypto/stark/src/trace.rs
@@ -54,8 +54,10 @@ where
 }
 
 /// Device-resident row-major main trace, pre-uploaded ahead of the prove.
-/// Excluded from logical trace equality and opaque in `Debug`, matching
-/// [`ResidentMainTrace`].
+/// Opaque in `Debug` like [`ResidentMainTrace`], and fully excluded from
+/// logical trace equality: this is a cache of data the host trace still owns,
+/// so two traces that differ only here are equal. (`ResidentMainTrace` still
+/// compares its row count, because it can be the sole owner of the data.)
 #[cfg(feature = "cuda")]
 #[derive(Clone)]
 pub(crate) struct PreUploadedMainTrace {

--- a/scripts/profiling/README.md
+++ b/scripts/profiling/README.md
@@ -104,6 +104,7 @@ the phase that enqueued them even if they execute later.
 | `capture_env.sh` | env JSON to stdout — attach to anything you measure by hand |
 | `phase_table.py [--util u.csv]… tl.json…` | aggregate timelines; `--instances LABEL` adds per-instance tables for deeper repeated spans, `--min-pct X` hides noise rows |
 | `nsys_phase_busy.py report.sqlite [--top N]` | the GPU busy report from `nsys export --type sqlite` |
+| `h2d_histo.py report.sqlite` | H2D/D2H bytes grouped by (phase, innermost NVTX range, transfer size) — names the dominant uploaders inside a phase. Prints the top 20 per direction |
 | `nvml_sampler.py -o out.csv [-i 0.1]` | standalone 10 Hz GPU util sampler (epoch-ns timestamps, aligns with span `start_ns`) |
 | `timeline_to_perfetto.py tl.json > trace.json` | span tree for ui.perfetto.dev |
 
@@ -121,6 +122,15 @@ Useful prover knobs for A/B experiments (pre-existing, see plan §11):
 `LAMBDA_VM_DISABLE_DEVICE_ONLY`, `LAMBDA_VM_GPU_LDE_THRESHOLD`,
 `LAMBDA_VM_GPU_BARY_THRESHOLD`, `LAMBDA_VM_VRAM_BUDGET_MB`,
 `TABLE_PARALLELISM`.
+
+Residency and diagnostic knobs:
+
+| var | effect |
+|---|---|
+| `LAMBDA_VM_GPU_DEVICE_ONLY_THRESHOLD=<lde_size>` | minimum LDE size for the device-only envelope (default 2^19), independent of `LAMBDA_VM_GPU_LDE_THRESHOLD`. Raise it to shed device-only tables without giving up GPU commits — a finer instrument than `LAMBDA_VM_DISABLE_DEVICE_ONLY=1` |
+| `LAMBDA_VM_TRACE_PREUPLOAD_MB=<mb>` | budget for pre-uploading the epoch's biggest main traces from the builder thread, so R1 commits D2D-copy instead of paying their H2D. Default 0 (off); capped at a quarter of the device VRAM budget. Wall-neutral on a 5090 and it competes with the prove peak on small cards, so it is for PCIe-bound setups |
+| `LAMBDA_VM_GPU_FORCE_DOWNGRADE=1` | test hook: decline the device R2 path unconditionally, so every device-only table exercises the host recovery. Used by the `gpu_force_downgrade` test |
+| `LAMBDA_VM_GPU_XCHECK=1` | after each table, re-run the verifier's composition consistency check in-process; on a mismatch, recompute each device stage on host, report which one diverged, and abort. For localizing silent device-side corruption |
 
 ## Continuations: per-epoch data for parallelization
 

--- a/scripts/profiling/h2d_histo.py
+++ b/scripts/profiling/h2d_histo.py
@@ -33,7 +33,7 @@ def main():
     api = load_api_calls(con, tset)
     chain_at = build_range_lookup(nvtx)
 
-    def chain_for(corr, start):
+    def chain_for(corr):
         if corr in api:
             api_start, tid = api[corr]
             c = chain_at(tid, api_start)
@@ -55,7 +55,7 @@ def main():
     for start, end, kind, nbytes, corr in memcpys:
         if kind not in ("h2d", "d2h"):
             continue
-        chain = chain_for(corr, start)
+        chain = chain_for(corr)
         key = (kind, coarse_of(chain), innermost(chain), nbytes)
         h = hist[key]
         h[0] += 1


### PR DESCRIPTION
Follow-ups from a review of #888, targeting its branch so they merge as part of it. One CI wiring fix; the rest are comment/doc accuracy and test coverage. No behaviour changes.

The review found no correctness or soundness defect in #888. The verifier is untouched by that diff and every device-derived value is bound by a Merkle root the verifier re-hashes, so the worst outcome anywhere in it is a rejected or dead prove, never an accepted bad one.

### The one that matters

**`Makefile` — the new `gpu_force_downgrade` recipe line was missing `$(GPU_TEST_TIMEOUT)`.** The line above it has the wrapper, and the variable's own comment explains why: a panic on a device-only cliff assert leaves the prover hung rather than aborting, holding the rented merge-queue box until the workflow timeout. This target is the one that deliberately drives every device-only table through the decline path, so it is the most exposed in the suite. Without the wrapper a hang burns the full 240-minute workflow timeout instead of failing at 45 minutes with parseable output.

### Comments corrected

**`DEFAULT_DEVICE_ONLY_MIN_LDE`** promised that mid tables "keep a host copy so a dispatch decline degrades to CPU instead of aborting". True for every site that reads the LDE — they all gate on `host_trace_empty()` and take their host arm. Not true for the R4 Merkle-proof gather: `try_expand_leaf_and_tree_row_major_keep` makes the host tree root-only for every GPU-committed table, independent of `retain_host_lde`, so a declined `gather_proofs_dev` has nothing to fall back to and aborts regardless of the host LDE. Since tree residency is gated on `gpu_lde_threshold()`, the 2^19 → 2^14 move widens that one abort site by 32× even though it leaves the device-only envelope alone. Availability only, and a proof gather is a ~70 KB allocation versus multi-GB for an LDE, so the marginal probability is low — but the comment as written would mislead whoever picks up #927.

**The new `is_root_only` assert's rationale** said the host walk "would emit an empty path for position 0 instead of failing". `get_proof_by_pos` returns `None` on a root-only tree, so the fall-through panics at `.expect("FRI query index in bounds")`. The assert is worth keeping — it names the real cause instead of misdirecting at query indexing — but for that reason, not for preventing a bad proof. (The wording was inherited from an equally stale comment on `main`.)

**`gather_proofs_dev`'s doc** said callers fall back to the host tree on `None`. All three call sites `.expect()` and abort. This one is pre-existing, but it is exactly what made a "silent unverifiable proof" reading of this code look plausible to two independent reviewers, so it seemed worth closing while nearby.

**`DEFAULT_GPU_LDE_THRESHOLD`** now records that it gates the whole dispatch layer — R2 decompose, the R3 contexts, R4 DEEP, the FRI fold — not just the commit, so moving it moves 17 floors together. The sweep measured the aggregate, so the value is fine; the description was narrower than the constant.

Plus two small ones: `PreUploadedMainTrace`'s doc claimed its equality matched `ResidentMainTrace`, which compares row counts; and the split-tree test's "(2^19 LDE)" parenthetical read as if it were quoting the threshold.

### Docs and tests

`scripts/profiling/README.md` is the toolkit's reference and was missing all four new env vars and `h2d_histo.py`. Added, including a note that `LAMBDA_VM_GPU_DEVICE_ONLY_THRESHOLD` is the finer instrument for shedding device-only tables — better than reaching for `LAMBDA_VM_DISABLE_DEVICE_ONLY=1`, which is what the #927 workaround currently uses.

`bary_num_chunks` gets unit tests pinning which of its three terms binds per regime, plus degenerate inputs. This matters because every existing parity case is rows-bound at 1–2 chunks, including the one annotated as exercising the occupancy branch: at 100 columns and n=2^14 the rows term gives 2, well under occupancy's 20. Also added one parity case per kernel at the 64-chunk cap — the most chunks any shape can request — so the kernels are checked at both ends of the chunk range rather than only the bottom. The added cases cost about 67 MB and 50 MB of device memory. Also dropped an unused parameter in `h2d_histo.py`.

`make lint` passes all four clippy passes including the cuda one, and the new unit test runs without a GPU.

### For you to apply, since I can't edit #888's description

The body attributes the 187 GB → 70 GB PCIe reduction partly to the R1 trace pre-upload, but that bullet ships disabled (`LAMBDA_VM_TRACE_PREUPLOAD_MB` defaults to 0), and the code comment records that at 2^22 epochs the riding-ahead buffers pushed the prove past the card's headroom. One sentence saying it ships off would stop a reader attributing that figure to the default configuration.

### Deliberately not done

`BARY_BLOCK_DIM` (CUDA) and `BLOCK_DIM` (Rust) are still coupled by hand, and #888 adds two more kernels that depend on them matching. The `BARY_MAX_K` single-sourcing this PR introduced is exactly the right pattern for it, but it is pre-existing, and I have no local CUDA to compile a build-script change against — worth doing as its own PR.

Also not attempted: recovery for a declined R4 proof gather. Rebuilding or downloading the tree at that point is real work, not a review fix. If the abort rate under pressure turns out to matter, that is the fix, and it would make the `DEFAULT_DEVICE_ONLY_MIN_LDE` comment true as originally written.

### Notes from the review, no action needed here

Codex's posted "mixed host/device state" finding was real when posted and you fixed it 30 minutes later in `f42659dc`; that guard is now on both this branch and `main`.

Preprocessed tables genuinely do enter the device-only envelope now — BITWISE is 2^20 rows, so its 2^21 LDE clears the unchanged 2^19 floor, and it passes every `device_only_for` precondition. That is the feature, and it adds one or two large tables per epoch to the population with no host fallback at R3/R4 while #927 is open. Worth a release note so operators know the new threshold knob exists.

The ABBA benchmark was taken 11 days and 6 commits ago against a pre-#914 `main`. The intervening commits touch only recovery paths, an env read and a test, so the −15.5% still looks representative, but it is not a measurement of the current head.

At default thresholds no CI job exercises the preprocessed device-only *happy path* — the new forced-downgrade test covers the complement, and `gpu-tests` is merge-queue only. That configuration first runs on real bench or production proves.
