### PR TITLE
test(gpu): assert the parts-download counter is zero on the happy path

### DIFF
--- a/prover/tests/cuda_path_integration.rs
+++ b/prover/tests/cuda_path_integration.rs
@@ -181,15 +181,16 @@ fn gpu_opening_gather_fires_and_verifies() {
 
 /// The full-residency Stage-3 device-only path fires: at least one table keeps
 /// its round-1 LDE device-resident (the host D2H is skipped), and the proof
-/// still verifies. This exercises every `host_trace_empty` hard-abort guard on
-/// the happy path (none may fire) plus the GPU-only R2/R3/R4 paths reading the
-/// device LDE with no host trace behind them. A regression that silently
-/// reverts to the host D2H drops the counter to 0 (while the proof would still
-/// verify). A mis-gate that forces a host fallback shows up one of two ways:
-/// at R3/R4 it panics one of the guards, while at R2 and the R1 resident-aux
-/// commit it recovers silently and is caught by the downgrade-counter
-/// assertions below — one per site, since the R1 counter also covers tables the
-/// device-only gate never cleared.
+/// still verifies. This exercises the GPU-only R2/R3/R4 paths reading the
+/// device LDE with no host trace behind them, plus the `host_trace_empty`
+/// hard-abort guards that remain on the R4 opening path (none may fire). A
+/// regression that silently reverts to the host D2H drops the counter to 0
+/// (while the proof would still verify). A mis-gate that forces a host
+/// fallback does not panic at the R2 commit, R3 or the R4 DEEP loop: those
+/// sites download the resident data and continue host-backed, so the counter
+/// assertions below are the only thing that surfaces one — one per site, since
+/// the R1 counter also covers tables the device-only gate never cleared, and
+/// the parts counter covers the H part evaluations rather than the trace.
 #[test]
 #[ignore = "requires GPU; run with --ignored --nocapture"]
 fn gpu_device_only_residency_fires_and_verifies() {
@@ -206,6 +207,15 @@ fn gpu_device_only_residency_fires_and_verifies() {
         "a device-only table was downgraded back to a host trace on the happy \
          path (its R2 dispatch declined at runtime: the gate should mirror the \
           missing condition)"
+    );
+    assert_eq!(
+        stark::gpu_lde::gpu_composition_parts_downloads(),
+        0,
+        "a device-only table's composition-poly parts were downloaded back to \
+         the host on the happy path (the R2 commit, the R3 parts OOD or the R4 \
+         DEEP H terms fell back to the host part evals: either the gate should \
+         mirror a missing dispatch condition, or the dispatch declined \
+         transiently under VRAM pressure)"
     );
     assert_eq!(
         stark::gpu_lde::gpu_resident_aux_downgrades(),


### PR DESCRIPTION
Small follow-up to #935, targeted at its branch so it can go in with the PR.

#935 replaces the device-only hard aborts with a silent download-and-continue. That is the right call, but the abort was also the detector for the LOCKSTEP rule in `device_only_gate`'s doc — add a decline condition to a dispatch without mirroring it into the gate, and the crash made it impossible to miss. With the recovery in place, the counters are the only thing left that surfaces it.

`GPU_DEVICE_ONLY_DOWNGRADES` (trace side) already has its `== 0` guard in `gpu_device_only_residency_fires_and_verifies`. Its parts-side counterpart, `GPU_COMPOSITION_PARTS_DOWNLOADS`, does not — its only readers are the `> 0` assertions in `cuda_fallback_tests`, which run with a fault deliberately armed. So on a healthy prove nothing reads it.

Concretely, what slips through today: a decline in `try_build_comp_poly_tree_gpu_from_dev` for device-only tables. `materialize_composition_parts_host` repopulates the evals, bumps only the parts counter, the proof verifies, the test passes green — while every device-only table pays a full parts D2H plus a CPU `commit_bit_reversed`, and `gpu_composition_tree` goes `None` so the R4 composition openings revert to the host tree too. A silent reversion of the win residency exists to deliver.

Scope: this closes the R2 commit site and the R3 parts-OOD site. The R4 DEEP site (`prover.rs:2392`) is already covered transitively — reaching it requires the trace to be device-only as well, and the only `host_trace_empty` true→false transition in the tree is `set_host_data`, one line above the `GPU_DEVICE_ONLY_DOWNGRADES` bump.

Zero is the right expectation: `materialize_composition_parts_host` early-returns without bumping when the part evals are already populated, so the counter never moves for a non-device-only table, even if both comp-tree arms decline.

The message names both causes instead of blaming the gate, matching the counter-family doc #935 rewrote, which now admits a transient VRAM decline as well as a gate miss. Worth considering the same wording for the two existing messages beside it — they still say "the gate should mirror the missing condition", which would misdiagnose a transient decline on a busy box.

Also refreshes the test's doc comment, which still said "at R3/R4 it panics one of the guards". After #935 that is only true on the R4 opening path.

Not verified on hardware — I have no CUDA device. `cargo fmt --check` and `cargo clippy -p lambda-vm-prover --all-targets --features cuda -- -D warnings` are clean; the assertion itself only runs under `make test-cuda-integration` on the GPU box.