### PR TITLE
ci: run the kernel host-KAT gates on every PR (lane K, F8)

### DIFF
--- a/.github/workflows/pr_main.yaml
+++ b/.github/workflows/pr_main.yaml
@@ -191,10 +191,41 @@ jobs:
 
   # "Test" is a required check — keep this name to avoid branch protection changes.
   # This gate job passes only when CLI, executor, disk-spill, and prover tests succeed.
+  host-kat:
+    # The device kernels' known-answer gates. `make test-*-host-kat` compiles the
+    # REAL `.cu` sources as host C++ through
+    # `crypto/math-cuda/tests/host_kat/cuda_host_shim.h` and runs them against
+    # external vectors (the official BLAKE3 vectors, miden-crypto's RPO vectors)
+    # and the committed oracle tables — g++ only, no CUDA, no cargo, seconds. It
+    # is the only per-PR check on the kernel arithmetic: the GPU parity suites
+    # (gpu-tests.yml) run on merge_group alone, and until this job existed the
+    # host-KAT targets lived in no workflow at all. Arithmetic only — nvcc
+    # acceptance and everything about execution stay with the GPU tests.
+    name: Host KAT (kernel pins)
+    runs-on: ubuntu-latest
+    if: github.event_name != 'push' || github.actor != 'github-merge-queue[bot]'
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: BLAKE3 host-KAT (7-round and 6-round arms)
+        run: make test-blake3-host-kat
+
+      - name: RPX host-KAT (permutation, leaf sponge, parent, leaf and tree kernels)
+        run: make test-rpx-host-kat
+
+      # Second source for the TABLES the BLAKE3 host-KAT trusts: upstream
+      # BLAKE3's portable C with its round loop parameterised, against the
+      # committed 6-round vectors and the Python oracle. A ~1 s C compile plus a
+      # few seconds of Python (cc + python3, both on the runner); it too had no
+      # workflow before this job.
+      - name: BLAKE3 second-source check of the 6-round tables
+        run: make test-blake3-second-source
+
   test:
     name: Test
     if: always()
-    needs: [test-executor, test-cli, test-prover, test-disk-spill, test-stark-cuda-lib]
+    needs: [test-executor, test-cli, test-prover, test-disk-spill, test-stark-cuda-lib, host-kat]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
@@ -204,12 +235,14 @@ jobs:
           prover="${{ needs.test-prover.result }}"
           disk_spill="${{ needs.test-disk-spill.result }}"
           stark_cuda_lib="${{ needs.test-stark-cuda-lib.result }}"
+          host_kat="${{ needs.host-kat.result }}"
 
           echo "test-executor: $executor"
           echo "test-cli: $cli"
           echo "test-prover: $prover"
           echo "test-disk-spill: $disk_spill"
           echo "test-stark-cuda-lib: $stark_cuda_lib"
+          echo "host-kat: $host_kat"
 
           # Allow "success" or "skipped" (skipped on merge queue pushes)
           if [[ "$executor" != "success" && "$executor" != "skipped" ]]; then
@@ -225,6 +258,9 @@ jobs:
             exit 1
           fi
           if [[ "$stark_cuda_lib" != "success" && "$stark_cuda_lib" != "skipped" ]]; then
+            exit 1
+          fi
+          if [[ "$host_kat" != "success" && "$host_kat" != "skipped" ]]; then
             exit 1
           fi
 


### PR DESCRIPTION
Lane K follow-up F8: the kernel host-KAT gates run on every PR.

## Why

`make test-blake3-host-kat` and `make test-rpx-host-kat` compile the real `.cu` sources as host C++ through `crypto/math-cuda/tests/host_kat/cuda_host_shim.h` and run them against external vectors (official BLAKE3, miden-crypto RPO) and the committed oracle tables — g++ only, no CUDA, no cargo, seconds. They were in **no workflow**: `gpu-tests.yml` runs on `merge_group` only, so an edit to `blake3.cu` or `rpx.cu` that broke a hash reached the merge queue before anything noticed.

## What changes

One file, `.github/workflows/pr_main.yaml`:

- New job `host-kat` (`Host KAT (kernel pins)`, `ubuntu-latest`, same `if:` as the other jobs, `actions/checkout@v4` only — no Rust setup, no caches), three steps:
  1. `make test-blake3-host-kat` (7-round and 6-round arms);
  2. `make test-rpx-host-kat` (permutation, leaf sponge, parent, the seven leaf kernels and both Merkle compressors replayed through the shim);
  3. `make test-blake3-second-source` — the check on the TABLES the BLAKE3 host-KAT trusts (upstream BLAKE3's portable C with a parameterised round loop vs the committed 6-round vectors and the Python oracle). Included because it is the same class of gate, it also lived in no workflow, and every input it needs is tracked (`thoughts/blake3/reference-impl/{driver.c,upstream/*}`, `thoughts/blake3/blake3-oracle/*`, `crypto/crypto/src/hash/blake3/vectors.rs`); `cc` and `python3` are on the runner. Drop the step if the scope should stay at the two host-KATs.
- The `Test` gate: `host-kat` added to `needs`, its result echoed and checked like the others, so the pins gate merges rather than merely run.

No Makefile change: all three targets exist at the tip (`test-rpx-host-kat` since #952's merge).

## Evidence

Local, from a cold `target/host_kat`, laptop (clang, M-series):

```
make test-blake3-host-kat      2.47 s wall   ALL HOST KAT CHECKS PASS   (both arms)
make test-rpx-host-kat         1.31 s wall   ALL HOST KAT CHECKS PASS
make test-blake3-second-source 3.08 s wall   RESULT: ALL GREEN -- two independent sources agree on the ten 6-round vectors, and the 7-round anchor is external.
```

`git status` clean afterwards (the reference binaries are gitignored). YAML parsed with Ruby's `YAML.load_file`: jobs `lint, test-executor, test-cli, host-kat, test, test-disk-spill, test-stark-cuda-lib, build-prover-tests, test-prover, test-prover-comprehensive, seed-elf-cache`; `test.needs` = `test-executor, test-cli, test-prover, test-disk-spill, test-stark-cuda-lib, host-kat`.

## Prediction

Job wall time **30–60 s**: about 7 s of work locally, 1.5–3× that under g++ on the runner (≤ 20 s for the three steps), plus checkout and runner start-up. It should be the shortest job in the workflow by an order of magnitude; the gate's critical path is unchanged.

## Not covered

Arithmetic only. nvcc acceptance, register pressure and execution stay with `gpu-tests.yml` on `merge_group`.
