### PR TITLE
docs(prover): state the allocator's memory saving, not a time cost we have not established

### DIFF
--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -920,14 +920,24 @@ fn name_panic_payload(
 /// was ever working set. (At q=41 the orders are indistinguishable, 98.5
 /// against 98.6 GiB.)
 ///
-/// ⇒ **The durable fix is the allocator, not this weight.** Setting
-/// `MALLOC_MMAP_THRESHOLD_` for the harness removes the effect outright and
-/// takes 1.2 GiB off the good arm too. It is not free: leaving the retentive
-/// state costs ~2.5% prove time (136.4 → 140.2 s here, while a build already
-/// out of it goes 140.3 → 140.1 s), so the time follows the retention state
-/// rather than the order. Until that lands, this order is kept because it is
-/// the one the prover had before #964 — not because reordering is a lever, as
-/// nothing in this file controls the layout that decides the number.
+/// ⇒ **The durable fix is the allocator, not this weight.** Lane S is landing
+/// it as jemalloc in the test harness; until then the effect is reproducible
+/// with `MALLOC_MMAP_THRESHOLD_=1048576`, which removes it outright and takes
+/// 1.2 GiB off the good arm as well. The MEMORY saving is large and comes with
+/// a control: ≈6 GiB at q=20 and ≈13 GiB at q=41 from a high-retention start,
+/// ≈1.2 GiB from a low-retention one.
+///
+/// The TIME effect is a different matter and is NOT established. In the paired
+/// q=20 comparison above the low-retention arm is ~2.5% slower (135.8/136.2 s
+/// against 139.1/140.3 s, two runs each, consistent sign) — but that does not
+/// carry to the allocator flag, whose four measured cells read −1.6%, +1.4%,
+/// −0.1% and +2.8%, one run each and no consistent sign, three of them inside
+/// what a single run resolves. Quote the memory saving; do not quote a time
+/// cost without paired repeats per shape.
+///
+/// Until the allocator fix lands, this order is kept because it is the one the
+/// prover had before #964 — not because reordering is a lever, since nothing in
+/// this file controls the layout that decides the number.
 ///
 /// Its arithmetic is inherited verbatim from the VRAM estimate the prover
 /// sorted by before the device-set model, and it is deliberately NOT re-read as


### PR DESCRIPTION
## The allocator's saving is memory; the time cost is not established

Doc-only follow-up to #964, which merged at `f1aff94f` a few minutes before this
correction was ready. One paragraph in `table_walk_weight`. No code changes —
`git diff -U0` against `per-table-gpu` yields zero non-`///` lines.

### Why

#964's doc landed saying the low-retention state "costs ~2.5% prove time", framed as
a property of the allocator flag. The four cells we actually measured do not support
that, and treating it as settled would have put an unearned number where the next
person will read it as one:

| shape | build | prove, flag off → on | max RSS, flag off → on |
|-------|-------|----------------------|------------------------|
| q=41 | tip `7c311c28` | 279.6 → 275.2 s (−1.6%) | 98.6 → 85.5 GiB |
| q=41 | `b92d8358` (#956's parent) | 274.6 → 278.4 s (+1.4%) | 86.7 → 85.5 GiB |
| q=20 | tip `7c311c28` | 140.3 → 140.1 s (−0.1%) | 45.1 → 43.9 GiB |
| q=20 | `a6359906` | 136.4 → 140.2 s (+2.8%) | 51.0 → 43.9 GiB |

One run per cell, no consistent sign, and three of the four sit inside what a single
run resolves. Only the last exceeds the noise floor, and one point is not a trade.

### What the paragraph says now

- **Quote the memory saving.** It is large and it has a control: ≈6 GiB at q=20 and
  ≈13 GiB at q=41 from a high-retention start, ≈1.2 GiB from a low-retention one.
- **Do not quote a time cost** for the flag without paired repeats per shape.
- The paired q=20 ORDER comparison is kept and still stated as supported, because it
  is a different measurement: two runs per arm, consistent sign, ~2.5%
  (135.8/136.2 s against 139.1/140.3 s). The doc now says explicitly that it does
  not carry to the flag — the q=41 tip moved into the low-retention state and got
  *faster*, which is exactly the generalisation that fails.
- Names where the durable fix is going, jemalloc in the test harness (lane S), rather
  than leaving a reader to infer it. Phrased as in flight: ✓ VERIFIED it is not in the
  tree yet, and `origin/pt/device-fit` carries no allocator change, so this does not
  point at something that does not exist.

Everything else from #964 is untouched: the table, the correlate-not-cause reading,
and the "any change needs a wrap measurement, not an argument about bytes" instruction.

### Gates

`make lint` exit 0 across all three feature sets, `make fmt` clean, `cargo test -p stark
--lib -- walk_tests:: device_set::` 13 passed. Signed.
