### PR TITLE
fix(math-cuda): the launch-size bound was 256x too strict, so the LogUp aux build never ran on the device

### DIFF
--- a/crypto/math-cuda/src/inverse.rs
+++ b/crypto/math-cuda/src/inverse.rs
@@ -148,6 +148,56 @@ fn launch_invert_total(
     Ok(())
 }
 
+/// Whether a one-dimensional launch over `total` elements is expressible.
+///
+/// The launches in this crate build their grid as `(total as u32).div_ceil(
+/// BLOCK_SIZE)` blocks of `BLOCK_SIZE` threads, and every kernel behind them
+/// (`logup.cu`, `inverse.cu`) computes its element index as the 64-bit
+/// `blockIdx.x * (uint64_t)blockDim.x + threadIdx.x`. The only thing that
+/// silently breaks is therefore the cast: past `u32::MAX` elements `total as
+/// u32` wraps, too few blocks launch, and a tail of the output is never
+/// written. Up to `u32::MAX` the grid is at most 16,777,216 blocks, far inside
+/// `gridDim.x`'s 2^31 − 1, and the index arithmetic is exact.
+///
+/// Until 2026-09 this bound was `u32::MAX / BLOCK_SIZE` — 256× too strict, as
+/// if the cast applied to the block count rather than the element count. Every
+/// LogUp aux build with more than 16,777,215 interaction·rows (at 2^22 rows,
+/// any table with five or more interactions) and every R3/R4 batch inverse
+/// past that size was refused before any launch and fell to the host, and the
+/// refusal wore a `CUDA_ERROR_INVALID_VALUE` that looked like the driver's.
+pub(crate) const fn launch_total_fits(total: usize) -> bool {
+    total <= u32::MAX as usize
+}
+
+#[cfg(test)]
+mod launch_bound_tests {
+    use super::*;
+
+    /// LOCAL_TO_GLOBAL at 2^22 rows with 6 interactions — the first shape the
+    /// loud aux-build admission surfaced — is expressible; so is the CPU table
+    /// at 2^22 with its full 24, and LFM_BLAKE3 at 2^21 with its 1,261.
+    #[test]
+    fn the_shapes_that_were_refused_fit() {
+        assert!(launch_total_fits(6 << 22));
+        assert!(launch_total_fits(24 << 22));
+        assert!(launch_total_fits(1261 << 21));
+        assert!(launch_total_fits(u32::MAX as usize));
+    }
+
+    /// The truncation hazard is real one past `u32::MAX`, and the old bound
+    /// sat 256× below it.
+    #[test]
+    fn the_bound_is_the_cast_not_the_block_count() {
+        assert!(!launch_total_fits(u32::MAX as usize + 1));
+        assert!(launch_total_fits(
+            u32::MAX as usize / BLOCK_SIZE as usize + 1
+        ));
+        let blocks = (u32::MAX).div_ceil(BLOCK_SIZE);
+        assert_eq!(blocks, 1 << 24);
+        assert!((blocks as u64) < (1u64 << 31));
+    }
+}
+
 /// Device-input batch inverse. Allocates and returns a fresh `CudaSlice<u64>`
 /// of length `3 * n` holding the inverses. Requires `n >= 1`.
 ///
@@ -160,12 +210,11 @@ pub fn batch_inverse_ext3_dev(
     stream: &Arc<CudaStream>,
 ) -> Result<CudaSlice<u64>> {
     assert!(n >= 1, "batch_inverse_ext3_dev requires n >= 1");
-    // Runtime guard (not debug_assert): a u32 grid_dim is truncated past
-    // u32::MAX / BLOCK_SIZE, which would silently launch too few blocks
-    // and leave a tail uninverted. Reachable on LDE size 2^23+ × multi-
-    // eval-point R4. Returning Err lets the dispatcher's Err(_) => None
-    // route the caller to the CPU `inplace_batch_inverse` fallback.
-    if n > u32::MAX as usize / BLOCK_SIZE as usize {
+    // Runtime guard (not debug_assert), see [`launch_total_fits`]: past the
+    // bound the u32 element count the launch is built from would truncate
+    // and leave a tail uninverted. Returning Err lets the dispatcher route
+    // the caller to the CPU `inplace_batch_inverse` fallback, or abort.
+    if !launch_total_fits(n) {
         return Err(cudarc::driver::DriverError(
             cudarc::driver::sys::CUresult::CUDA_ERROR_INVALID_VALUE,
         ));
@@ -259,10 +308,9 @@ pub fn compute_and_invert_denoms_ext3_dev(
     let total = k_scalars
         .checked_mul(n)
         .expect("compute_and_invert_denoms_ext3_dev: k_scalars * n overflow");
-    // See `batch_inverse_ext3_dev` for the rationale: runtime Err, not
-    // debug_assert, so release builds also route past the silent-truncation
-    // hazard via the caller's CPU fallback.
-    if total > u32::MAX as usize / BLOCK_SIZE as usize {
+    // See [`launch_total_fits`]: runtime Err, not debug_assert, so release
+    // builds also route past the truncation hazard.
+    if !launch_total_fits(total) {
         return Err(cudarc::driver::DriverError(
             cudarc::driver::sys::CUresult::CUDA_ERROR_INVALID_VALUE,
         ));

--- a/crypto/math-cuda/src/logup.rs
+++ b/crypto/math-cuda/src/logup.rs
@@ -44,12 +44,11 @@ pub struct LogupDescriptor<'a> {
 }
 
 fn cfg(total: usize) -> Result<LaunchConfig> {
-    // See `batch_inverse_ext3_dev` for the rationale: a u32 grid_dim is
-    // truncated past u32::MAX / BLOCK_SIZE, which would silently launch too
-    // few blocks and leave a tail of the (uninitialized) output unwritten.
-    // Runtime Err, not debug_assert, so release builds also route to the
-    // caller's CPU fallback.
-    if total > u32::MAX as usize / BLOCK_SIZE as usize {
+    // See `inverse::launch_total_fits` for the bound and its reasoning: past
+    // it the u32 element count would truncate and leave a tail of the
+    // (uninitialized) output unwritten. Runtime Err, not debug_assert, so
+    // release builds also route to the caller's fallback or abort.
+    if !crate::inverse::launch_total_fits(total) {
         return Err(cudarc::driver::DriverError(
             cudarc::driver::sys::CUresult::CUDA_ERROR_INVALID_VALUE,
         ));
@@ -482,4 +481,27 @@ pub fn logup_aux_resident(
         num_rows,
         table_contribution: [l_host[0], l_host[1], l_host[2]],
     })
+}
+
+#[cfg(test)]
+mod launch_cfg_tests {
+    use super::*;
+
+    /// 6 interactions × 2^22 rows (LOCAL_TO_GLOBAL in a 2^22 epoch) launches
+    /// 98,304 blocks; it used to be refused as if it were 256× larger.
+    #[test]
+    fn the_first_refused_aux_build_shape_launches() {
+        let c = cfg(6 << 22).expect("expressible");
+        assert_eq!(c.grid_dim, (98_304, 1, 1));
+        assert_eq!(c.block_dim, (BLOCK_SIZE, 1, 1));
+    }
+
+    /// The largest expressible launch is exactly u32::MAX elements; one more
+    /// is refused with the same error the driver would have used.
+    #[test]
+    fn the_bound_is_u32_max_elements() {
+        let c = cfg(u32::MAX as usize).expect("expressible");
+        assert_eq!(c.grid_dim.0, 1 << 24);
+        assert!(cfg(u32::MAX as usize + 1).is_err());
+    }
 }


### PR DESCRIPTION
## Correctness gate

Base layer, 10 × 2^22 epochs of block 25368371 through the CLI on a 5090: the proof host-verifies to a **byte-identical public output** against the pre-campaign record — both print `Output: 5d442ba039edfbb5edfb01fe024ebd6a4ca3c93b16f5448b483267dcb7d2906a8c852cfec692ac16db0935c14b963f7e3492813b4d61b62b0db1066954da0988588a` and `Verification succeeded!`. Since the aux columns are committed, a device build that diverged from the CPU one would move the roots; they did not move.

⚠ Proof BYTE COUNT is deliberately not the gate here and differs (record 907,507,216, this run 909,077,592). Two reasons: proof bytes are non-reproducible run to run in this project by construction, because the grinding nonce is drawn non-deterministically while roots are deterministic; and the record is at `8064a8ef` on `origin/main`, so everything the campaign has merged sits between it and this branch. Output equality is the claim; byte equality would not have been evidence either way. The LogUp aux columns are committed, so if the device build had diverged from the CPU build the Merkle roots would have moved and the bytes could not match; that is a sharper argument than any parity test, and the parity tests (`logup_gpu` Host vs Dev vs CPU reference) pass as well.

## The finding

**The GPU-resident LogUp aux build has never run for any table above 16,777,215 interaction·rows.** At 2^22 rows that is any table with five or more bus interactions — CPU, MEMW, LOCAL_TO_GLOBAL among them — and the wrap's LFM_BLAKE3 at 1,261 × 2^19 = 661M is the 13 s CPU LogUp stretch visible in the q=41 host-memory curve. The same bound sent every R3/R4 batch inverse above 16.7M elements (a 2^23 LDE at three evaluation points) to the host.

Two layers of `.ok()?` hid it: `try_build_aux_resident_gpu` fell to `try_build_term_columns_gpu`, which tripped the same bound and fell to the CPU build, with no message. The bound itself, `total > u32::MAX / BLOCK_SIZE`, is 256× stricter than the truncation it guards: the launch builds its grid as `(total as u32).div_ceil(256)`, so the cast wraps only past `u32::MAX` elements; the grid at `u32::MAX` is 16,777,216 blocks against gridDim.x's 2^31 − 1; and every kernel behind the three sites (`logup.cu`, `inverse.cu`) indexes with the 64-bit `blockIdx.x * (uint64_t)blockDim.x + threadIdx.x`. The refusal wore a synthesised `CUDA_ERROR_INVALID_VALUE`, so when the aux build's admission stopped swallowing the result (`pt/device-fit`) it surfaced as a device error on LOCAL_TO_GLOBAL at 2^22 rows with 6 interactions, 6 × 2^22 = 25,165,824.

## The fix

One bound, `launch_total_fits(total) = total <= u32::MAX`, with the reasoning in its doc, at the three sites (`logup::cfg`, `batch_inverse_ext3_dev`, the inverse-denominator launch). Beyond `u32::MAX` the refusal stands and is now loud at the admitted sites.

Pure tests: 6 × 2^22, 24 × 2^22 and 1,261 × 2^21 expressible; `u32::MAX` yields a 2^24-block grid; `u32::MAX + 1` refused.

## Measured (box A, RTX 5090, one run per cell)

The base layer is proved through the CLI, which has always installed jemalloc, so nothing in this measurement changes because of #966 (which gave the `cargo test --lib` harness the same allocator); the record row and this row are measured under one allocator and are directly comparable.

| | record (tip) | this branch |
|---|---|---|
| wall | 82.4 s | **64.7 s (−21%)** |
| host max RSS | 33.3 GiB | 33.4 GiB |
| VRAM peak (10 Hz) | 28,086 MiB | **31,896 MiB** |
| proof bytes | 907,507,216 | 909,077,592 — differs, and is not the gate (see above) |
| verified output | `5d442ba0…988588a` | **identical** |
| host verify | — | succeeded, 13.4 s |
| `[gpu] ABORT` / synthesised `CUDA_ERROR_INVALID_VALUE` | — | 0 / 0 |

math-cuda's own suites green. Pre-registered before the run: completes, host-verifies, wall 70–82 s (held: **64.66 s**, under the optimistic end), host flat (held: 33.3 → 33.4 GiB); VRAM up into the 30,000–32,000 MiB band because the aux-build transient (4× the fingerprint buffer, ~8 GiB for CPU at 2^22) was not in the fused-phase admission estimates and several builds can overlap (held: 31,896); host down 0–3 GiB (did not hold: flat at +0.1); wall not slower, 70–82 s (held, and beyond the optimistic end: 64.7 s). Moving the aux builds onto the card, which they had never used, makes the base layer a fifth faster with the proof verifying. One run per cell.

## The overlap, and where it is fixed

The VRAM peak sat at the card's ceiling: with the builds on the card, several overlapped under a gate whose estimates did not include them. At this branch alone an overlap that exceeds the card still falls back to the CPU build silently through the remaining `.ok()?`, so this run cannot say whether one did. The fix is not here: `pt/device-fit`'s second commit sizes the fused task on the larger of its two phases so builds that will not fit together serialise, and that branch's admission turns any remaining overflow into a loud abort. Merge order: this branch, then `pt/panic-shutdown` (so an abort fails the prove instead of hanging it), then `pt/device-fit`.
