### PR TITLE
ci: bump the AI review workflows to actions v1.0.3

### DIFF
--- a/.github/workflows/pr_ai_review.yaml
+++ b/.github/workflows/pr_ai_review.yaml
@@ -513,7 +513,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-    uses: yetanotherco/actions/.github/workflows/pr_review_codex.yml@v1.0.0
+    uses: yetanotherco/actions/.github/workflows/pr_review_codex.yml@v1.0.3
     with:
       custom_prompt: ${{ needs.prepare.outputs.custom_prompt }}
     secrets:
@@ -527,7 +527,7 @@ jobs:
       pull-requests: write
       issues: read
       id-token: write
-    uses: yetanotherco/actions/.github/workflows/pr_review_claude.yml@v1.0.0
+    uses: yetanotherco/actions/.github/workflows/pr_review_claude.yml@v1.0.3
     with:
       model: opus
       max_turns: 50


### PR DESCRIPTION
Bumps both AI review jobs in `pr_ai_review.yaml` from `yetanotherco/actions` v1.0.0 to v1.0.3.

## Why

The Claude review has been broken since 2026-09-08. v1.0.0 tracked `anthropics/claude-code-action@v1`, which moved to a build whose installer exits 0 while leaving no launcher at `~/.local/bin/claude`, so every run failed before Claude started:

```
SDK execution error: ReferenceError: Claude Code native binary not found at
/home/runner/.local/bin/claude.
```

Upstream: https://github.com/anthropics/claude-code-action/issues/1817 (open, no fix).

## What each job gets

**`claude-review`** — three tags of changes:

- **v1.0.1**: fork-PR guard on the `issue_comment` path.
- **v1.0.2**: `claude-code-action` pinned to v1.0.217, past the broken build.
- **v1.0.3**: review-context fix. On `issue_comment` the reusable workflow checked out the *default branch* rather than the PR, while telling the model the PR was checked out — so reviews spent their turns trying to fetch the code under review via `git fetch origin pull/N/head` and `gh api …/contents/…`, both denied by the allowlist, and hit the turn cap with nothing posted. It now checks out `refs/pull/<n>/head` with full history, allowlists read-only `git diff`/`git log`/`git show`, and states the sandbox rules in the prompt.

**`codex-review`** — the only delta across these tags is the v1.0.1 fork-PR guard. No behavioral change to the review itself.

## Compatibility

Checked against this workflow specifically:

- v1.0.3's checkout derives the PR from `github.event.pull_request.number || github.event.issue.number`. This workflow triggers on `issue_comment` and `pull_request: labeled`, both of which populate one of those, so the ref resolves.
- The `model: opus` and `max_turns: 50` inputs are unchanged across all four tags.
- Note the reusable Claude workflow now checks out `refs/pull/<n>/head`, whereas this repo's own jobs use `refs/pull/<n>/merge`. That only affects the tree the Claude job sees, and head is what `gh pr diff` reports.

## Validation

The Claude review cannot self-test on this PR: the action skips when the workflow file differs from the copy on the default branch, and the step still exits 0, so a green check here proves nothing about the fix. After merge, `/ai-review` on any open PR exercises it.


