### PR TITLE
Let the guest's memcpy use unaligned word loads

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,13 @@
+# Guest-only build flags. The key is scoped to the guest target, so host builds
+# (the prover, the CLI, the tooling) read this file and take nothing from it.
+[target.riscv64im-lambda-vm-elf]
+# `compiler_builtins` turns its `mem-unaligned` feature on for x86, aarch64 and
+# bpf only, so on RISC-V every misaligned word inside `memcpy`/`memmove` is
+# reassembled with a load, two shifts, an or and a store. This VM does unaligned
+# scalar accesses natively (#864 already builds guests with
+# `unaligned-scalar-mem`), so that detour buys nothing: the rest of the guest was
+# already emitting unaligned loads and only these two functions avoided them.
+#
+# Cargo joins `rustflags` arrays across ancestor config files, so each guest
+# crate's own `.cargo/config.toml` keeps its flags and gains this one.
+rustflags = ["--cfg", "feature=\"mem-unaligned\""]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,13 +1,12 @@
-# Guest-only build flags. The key is scoped to the guest target, so host builds
-# (the prover, the CLI, the tooling) read this file and take nothing from it.
+# Guest-only build flags: the key is scoped to the guest target, so host builds
+# read this file and take nothing from it. Cargo joins `rustflags` across
+# ancestor configs, so each guest crate keeps its own flags and gains this one.
 [target.riscv64im-lambda-vm-elf]
-# `compiler_builtins` turns its `mem-unaligned` feature on for x86, aarch64 and
-# bpf only, so on RISC-V every misaligned word inside `memcpy`/`memmove` is
-# reassembled with a load, two shifts, an or and a store. This VM does unaligned
-# scalar accesses natively (#864 already builds guests with
-# `unaligned-scalar-mem`), so that detour buys nothing: the rest of the guest was
-# already emitting unaligned loads and only these two functions avoided them.
-#
-# Cargo joins `rustflags` arrays across ancestor config files, so each guest
-# crate's own `.cargo/config.toml` keeps its flags and gains this one.
+# `compiler_builtins` turns `mem-unaligned` on for x86, aarch64 and bpf only, so
+# on RISC-V `memcpy`/`memmove` reassemble every misaligned word by hand; this VM
+# does unaligned scalar accesses natively (#864). The cfg reaches every crate in
+# the guest graph, but only `compiler-builtins` reads that name, and it declares
+# the value in its own check-cfg. It lives in that crate's `build.rs` with no
+# stability guarantee: bumping the `nightly-2026-02-01` pin in the Makefile can
+# turn this into a silent no-op.
 rustflags = ["--cfg", "feature=\"mem-unaligned\""]

--- a/.github/workflows/hyperfine.yaml
+++ b/.github/workflows/hyperfine.yaml
@@ -40,7 +40,7 @@ jobs:
         id: cache
         with:
           path: ${{ matrix.branch }}_programs/*.elf
-          key: benchmarks-${{ matrix.branch }}-${{ hashFiles( 'executor/programs/bench/**', 'syscalls/**' ) }}
+          key: benchmarks-${{ matrix.branch }}-${{ hashFiles( 'executor/programs/bench/**', 'syscalls/**', '.cargo/config.toml' ) }}
           restore-keys: benchmarks-${{ matrix.branch }}-
 
       - name: Setup Rust Environment
@@ -56,7 +56,7 @@ jobs:
 
       - name: Export benchmark hashes
         id: export-hashes
-        run: echo "benchmark-hashes-${{ matrix.branch }}=${{ hashFiles( 'executor/programs/bench/**', 'syscalls/**' ) }}" >> "$GITHUB_OUTPUT"
+        run: echo "benchmark-hashes-${{ matrix.branch }}=${{ hashFiles( 'executor/programs/bench/**', 'syscalls/**', '.cargo/config.toml' ) }}" >> "$GITHUB_OUTPUT"
 
   build-binaries:
     strategy:

--- a/.github/workflows/pr_main.yaml
+++ b/.github/workflows/pr_main.yaml
@@ -103,7 +103,7 @@ jobs:
           path: |
             executor/program_artifacts/rust
             executor/shared_target
-          key: rust-elf-artifacts-${{ hashFiles('executor/programs/rust/**', 'executor/programs/riscv64im-lambda-vm-elf.json', 'syscalls/**', 'Makefile') }}
+          key: rust-elf-artifacts-${{ hashFiles('executor/programs/rust/**', 'executor/programs/riscv64im-lambda-vm-elf.json', 'syscalls/**', 'Makefile', '.cargo/config.toml') }}
           restore-keys: |
             rust-elf-artifacts-
 
@@ -275,7 +275,7 @@ jobs:
           path: |
             executor/program_artifacts/rust
             executor/shared_target
-          key: rust-elf-artifacts-${{ hashFiles('executor/programs/rust/**', 'executor/programs/riscv64im-lambda-vm-elf.json', 'syscalls/**', 'Makefile') }}
+          key: rust-elf-artifacts-${{ hashFiles('executor/programs/rust/**', 'executor/programs/riscv64im-lambda-vm-elf.json', 'syscalls/**', 'Makefile', '.cargo/config.toml') }}
           restore-keys: |
             rust-elf-artifacts-
 
@@ -391,7 +391,7 @@ jobs:
           path: |
             executor/program_artifacts/rust
             executor/shared_target
-          key: rust-elf-artifacts-${{ hashFiles('executor/programs/rust/**', 'executor/programs/riscv64im-lambda-vm-elf.json', 'syscalls/**', 'Makefile') }}
+          key: rust-elf-artifacts-${{ hashFiles('executor/programs/rust/**', 'executor/programs/riscv64im-lambda-vm-elf.json', 'syscalls/**', 'Makefile', '.cargo/config.toml') }}
           restore-keys: |
             rust-elf-artifacts-
 
@@ -409,7 +409,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: executor/program_artifacts/recursion
-          key: recursion-elf-artifacts-${{ hashFiles('bench_vs/lambda/**', 'prover/src/**', 'prover/Cargo.toml', 'crypto/**/src/**', 'crypto/**/Cargo.toml', 'executor/src/**', 'executor/Cargo.toml', 'syscalls/**', 'executor/programs/riscv64im-lambda-vm-elf.json', 'Makefile') }}
+          key: recursion-elf-artifacts-${{ hashFiles('bench_vs/lambda/**', 'prover/src/**', 'prover/Cargo.toml', 'crypto/**/src/**', 'crypto/**/Cargo.toml', 'executor/src/**', 'executor/Cargo.toml', 'syscalls/**', 'executor/programs/riscv64im-lambda-vm-elf.json', 'Makefile', '.cargo/config.toml') }}
           restore-keys: |
             recursion-elf-artifacts-
 
@@ -480,7 +480,7 @@ jobs:
           path: |
             executor/program_artifacts/rust
             executor/shared_target
-          key: rust-elf-artifacts-${{ hashFiles('executor/programs/rust/**', 'executor/programs/riscv64im-lambda-vm-elf.json', 'syscalls/**', 'Makefile') }}
+          key: rust-elf-artifacts-${{ hashFiles('executor/programs/rust/**', 'executor/programs/riscv64im-lambda-vm-elf.json', 'syscalls/**', 'Makefile', '.cargo/config.toml') }}
           restore-keys: |
             rust-elf-artifacts-
 
@@ -508,7 +508,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: executor/program_artifacts/recursion
-          key: recursion-elf-artifacts-${{ hashFiles('bench_vs/lambda/**', 'prover/src/**', 'prover/Cargo.toml', 'crypto/**/src/**', 'crypto/**/Cargo.toml', 'executor/src/**', 'executor/Cargo.toml', 'syscalls/**', 'executor/programs/riscv64im-lambda-vm-elf.json', 'Makefile') }}
+          key: recursion-elf-artifacts-${{ hashFiles('bench_vs/lambda/**', 'prover/src/**', 'prover/Cargo.toml', 'crypto/**/src/**', 'crypto/**/Cargo.toml', 'executor/src/**', 'executor/Cargo.toml', 'syscalls/**', 'executor/programs/riscv64im-lambda-vm-elf.json', 'Makefile', '.cargo/config.toml') }}
           restore-keys: |
             recursion-elf-artifacts-
 
@@ -564,7 +564,7 @@ jobs:
           path: |
             executor/program_artifacts/rust
             executor/shared_target
-          key: rust-elf-artifacts-${{ hashFiles('executor/programs/rust/**', 'executor/programs/riscv64im-lambda-vm-elf.json', 'syscalls/**', 'Makefile') }}
+          key: rust-elf-artifacts-${{ hashFiles('executor/programs/rust/**', 'executor/programs/riscv64im-lambda-vm-elf.json', 'syscalls/**', 'Makefile', '.cargo/config.toml') }}
           restore-keys: |
             rust-elf-artifacts-
 
@@ -581,7 +581,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: executor/program_artifacts/recursion
-          key: recursion-elf-artifacts-${{ hashFiles('bench_vs/lambda/**', 'prover/src/**', 'prover/Cargo.toml', 'crypto/**/src/**', 'crypto/**/Cargo.toml', 'executor/src/**', 'executor/Cargo.toml', 'syscalls/**', 'executor/programs/riscv64im-lambda-vm-elf.json', 'Makefile') }}
+          key: recursion-elf-artifacts-${{ hashFiles('bench_vs/lambda/**', 'prover/src/**', 'prover/Cargo.toml', 'crypto/**/src/**', 'crypto/**/Cargo.toml', 'executor/src/**', 'executor/Cargo.toml', 'syscalls/**', 'executor/programs/riscv64im-lambda-vm-elf.json', 'Makefile', '.cargo/config.toml') }}
           restore-keys: |
             recursion-elf-artifacts-
 


### PR DESCRIPTION
`compiler_builtins` enables its `mem-unaligned` feature for x86, aarch64 and bpf only, so on RISC-V
`memcpy`/`memmove` reassemble every misaligned word with a load, two shifts, an or and a store. This
VM doesn't need that: #864 already builds guests with `+unaligned-scalar-mem`, since the executor
byte-assembles an unaligned doubleword host-side at the same one-instruction cost as an aligned one.
The rest of the guest has been emitting unaligned loads since July — these two functions were the
last holdouts. `memcpy` is the largest leaf in an ethrex block at 25% of guest cycles.

The feature isn't reachable through `-Z build-std-features` (that chain only forwards
`compiler-builtins-mem`), hence the `--cfg`. The key is scoped to the guest target, so host builds
take nothing from it.

Real mainnet block 25368371, continuations at 2^22 (what `benchmark-pr.yml` uses), EPYC 9454P
48c/96t, this branch against its base:

| | base | this PR | Δ |
|---|---|---|---|
| guest cycles | 30,498,818 | 27,959,787 | **−8.32%** |
| epochs | 8 | 7 | −1 |
| proving time (median of 3) | 109.854 s | 101.623 s | **−7.49%** |
| proof size | 729,298,288 B | 665,350,256 B | −8.77% |
| verify | 10.894 s | 9.837 s | −9.70% |
| base-field-equivalent cells | 6,244,114,362 | 5,943,369,658 | −4.82% |

Ranges don't overlap (base 109.854/109.262/110.288, patched 101.623/101.425/102.249). Unaligned
accesses land on the pricier `MEMW` table rather than `MEMW_A`, so prover area was measured rather
than assumed — it still drops.

Correctness: `ethrex-tests` 6/6 including the two `--ignored`; all 262 guest ELFs build; local prover
suite 827/827; `verify` OK at two epoch sizes (2^22 and 2^21) — deliberate, since a known latent
issue can break the L2G table when a guest build moves the static layout. Measured on a second box
with a different clang: identical absolute saving of 2,539,031 cycles. All 29 Rust guests and the
four ethrex fixtures were measured both ways; nothing regresses.

The GPU job was not run locally — no GPU on the benchmark boxes.
