### PR TITLE
docs(tables): correct the stale per-table census and name its derivation

### DIFF
--- a/prover/src/tables/mod.rs
+++ b/prover/src/tables/mod.rs
@@ -63,40 +63,57 @@ pub const STATIC_BLOWUP_FACTORS: &[u8] = &[2, 4, 8];
 
 /// Per-table maximum rows, sized so each chunk uses roughly the same memory.
 ///
-/// Effective width = main_cols + 3 × bus_interactions (extension field = 3× cost).
-/// MEMW (effective width 127) at 2^19 is the baseline; other tables are scaled
-/// proportionally: max_rows = (127 × 2^19) / effective_width, rounded to 2^N.
-/// (* MEMW_A formula gives 2^20, but set to 2^19 to match MEMW chunk geometry;
-///    benchmarks show better parallel throughput with smaller chunks.)
+/// ★ **How to re-derive this table** (it is documentation — nothing reads it, so
+/// it rots silently): `Main` is that table's `cols::NUM_COLUMNS`; `Bus` is
+/// `bus_interactions().len()`; `Aux` is `⌈Bus/2⌉`, the committed extension
+/// columns LogUp actually allocates — `num_term_columns + 1` per
+/// `stark::lookup`'s `AirBuilder`, which `split_interactions` makes equal to
+/// `⌈Bus/2⌉` for every `Bus ≥ 1`, and which `auto_storage::aux_cols` spells as
+/// that closed form (that module is behind the `disk-spill` feature, so
+/// `stark::lookup` is the always-compiled source of truth). An extension
+/// element is three base felts, so
+/// `Eff.width = Main + 3 × Aux`. ⚠ Do NOT use `Main + 3 × Bus`: that was the
+/// previous formula here and it double-counts the bus term.
 ///
-/// | Table   | Main | Bus | Eff.width | Max rows |
-/// |---------|------|-----|-----------|----------|
-/// | MEMW    |  49  |  26 |    127    |  2^19    |
-/// | MEMW_A  |  29  |  20 |     89    |  2^19 *  |
-/// | CPU     |  74  |  40 |    194    |  2^19    |
-/// | DVRM    |  34  |  34 |    136    |  2^19    |
-/// | MUL     |  26  |  16 |     74    |  2^20    |
-/// | LT      |  15  |   9 |     42    |  2^20    |
-/// | SHIFT   |  27  |  15 |     72    |  2^20    |
-/// | LOAD    |  18  |   5 |     33    |  2^20    |
-/// | BRANCH  |  14  |   6 |     32    |  2^20    |
-/// | MEMW_R  |  10  |   7 |     31    |  2^20    |
+/// MEMW (Eff.width 88) at 2^19 is the baseline; the rest scale as
+/// `max_rows = nearest 2^N of (88 × 2^19) / Eff.width`, **capped at 2^20**.
+/// The cap is what holds LOAD, BRANCH, MEMW_R, EQ and STORE at 2^20 where the
+/// ratio alone would put them at 2^21.
+/// (* MEMW_A's ratio gives 2^20, but it is set to 2^19 to match MEMW chunk
+///    geometry; benchmarks show better parallel throughput with smaller chunks.)
+///
+/// | Table    | Main | Bus | Aux | Eff.width | Max rows |
+/// |----------|------|-----|-----|-----------|----------|
+/// | MEMW     |  49  |  26 |  13 |     88    |  2^19    |
+/// | MEMW_A   |  29  |  20 |  10 |     59    |  2^19 *  |
+/// | CPU      |  38  |  20 |  10 |     68    |  2^19    |
+/// | CPU32    |  38  |  23 |  12 |     74    |  2^19    |
+/// | DVRM     |  34  |  34 |  17 |     85    |  2^19    |
+/// | MUL      |  26  |  24 |  12 |     62    |  2^20    |
+/// | SHIFT    |  29  |  18 |   9 |     56    |  2^20    |
+/// | BYTEWISE |  26  |   9 |   5 |     41    |  2^20    |
+/// | LT       |  17  |   9 |   5 |     32    |  2^20    |
+/// | STORE    |  16  |  10 |   5 |     31    |  2^20    |
+/// | LOAD     |  18  |   5 |   3 |     27    |  2^20    |
+/// | BRANCH   |  14  |   6 |   3 |     23    |  2^20    |
+/// | MEMW_R   |  10  |   7 |   4 |     22    |  2^20    |
+/// | EQ       |  12  |   6 |   3 |     21    |  2^20    |
 pub mod max_rows {
-    pub const CPU: usize = 1 << 19; // 524,288   — eff. width 194
-    pub const MEMW: usize = 1 << 19; // 524,288  — eff. width 127 (baseline)
-    pub const MEMW_A: usize = 1 << 19; // 524,288 — eff. width 89
-    pub const DVRM: usize = 1 << 19; // 524,288  — eff. width 136
-    pub const MUL: usize = 1 << 20; // 1,048,576 — eff. width 74
-    pub const LT: usize = 1 << 20; // 1,048,576  — eff. width 42
-    pub const SHIFT: usize = 1 << 20; // 1,048,576 — eff. width 72
-    pub const LOAD: usize = 1 << 20; // 1,048,576 — eff. width 33
-    pub const BRANCH: usize = 1 << 20; // 1,048,576 — eff. width 32
-    pub const MEMW_R: usize = 1 << 20; // 1,048,576 — eff. width 31
+    pub const CPU: usize = 1 << 19; // 524,288   — eff. width 68
+    pub const MEMW: usize = 1 << 19; // 524,288  — eff. width 88 (baseline)
+    pub const MEMW_A: usize = 1 << 19; // 524,288 — eff. width 59
+    pub const DVRM: usize = 1 << 19; // 524,288  — eff. width 85
+    pub const MUL: usize = 1 << 20; // 1,048,576 — eff. width 62
+    pub const LT: usize = 1 << 20; // 1,048,576  — eff. width 32
+    pub const SHIFT: usize = 1 << 20; // 1,048,576 — eff. width 56
+    pub const LOAD: usize = 1 << 20; // 1,048,576 — eff. width 27 (capped)
+    pub const BRANCH: usize = 1 << 20; // 1,048,576 — eff. width 23 (capped)
+    pub const MEMW_R: usize = 1 << 20; // 1,048,576 — eff. width 22 (capped)
     // Auxiliary ALU / memory / CPU32 dispatch chips
-    pub const EQ: usize = 1 << 20;
-    pub const BYTEWISE: usize = 1 << 20;
-    pub const STORE: usize = 1 << 20;
-    pub const CPU32: usize = 1 << 19;
+    pub const EQ: usize = 1 << 20; // 1,048,576 — eff. width 21 (capped)
+    pub const BYTEWISE: usize = 1 << 20; // 1,048,576 — eff. width 41
+    pub const STORE: usize = 1 << 20; // 1,048,576 — eff. width 31 (capped)
+    pub const CPU32: usize = 1 << 19; // 524,288  — eff. width 74
 }
 
 /// Per-table maximum row limits, configurable for different environments.


### PR DESCRIPTION
The per-table census above `max_rows` in `prover/src/tables/mod.rs` was stale in
three rows and wrong in its formula. It has misled width and VRAM arithmetic more
than once, each time caught only because someone re-derived the numbers from
source instead of trusting the table. This corrects it and writes down how to
re-derive it, so the next drift is visible rather than silent.

Documentation only: the fourteen `max_rows` constants are byte-for-byte unchanged.

⚠ **The diff does touch those fourteen lines, and it should not be read as a value change.** Each
carries a trailing `// … eff. width N` comment, and it is the comment that moves — the widths there
were the inflated ones. Every `1 << N` is identical before and after; the constants were extracted
and compared programmatically rather than eyeballed. Nothing in this change alters chunk geometry.

## What was wrong, and by how much

| Table | was | is |
|---|---|---|
| CPU | 74 main, 40 bus | **38 main, 20 bus** |
| MUL | 16 bus | **24 bus** |
| SHIFT | 27 main, 15 bus | **29 main, 18 bus** |
| LT | 15 main | **17 main** |

CPU was the worst of these: nearly double its real main width and double its real
bus count, which compounds into a ~2.9× overstatement of its effective width.

Every row in the new table was **executed, not read**. `auto_storage` already
imports each table's `bus_interactions` and `cols::NUM_COLUMNS`, so a throwaway
in-crate test can call all fourteen and print the counts; that probe produced the
numbers below and was then reverted, leaving only the doc change. Counting
`.push()` calls by brace-matching is what produced the stale table in the first
place — several of these bodies build their vectors through loops over column
arrays, where a static count is exactly the thing that goes wrong.

## The formula itself double-counted the bus term

The header read `Effective width = main_cols + 3 × bus_interactions`. That is
wrong, and it is the more consequential defect, because it is the part that
survives any refresh of the numbers.

LogUp does not commit one extension column per bus interaction. It commits
`⌈Bus/2⌉` of them: `crypto/stark/src/lookup.rs:939-944` sets
`num_aux_columns = num_term_columns + 1` for a non-empty interaction set, and
`num_term_columns` is `split_interactions`' committed-pair count — `0` for
`N ≤ 2`, `(N−1)/2` for odd `N`, `(N−2)/2` for even `N`. All four branches work
out to exactly `⌈N/2⌉` for every `N ≥ 1`. So the effective width is

```
Eff.width = Main + 3 × ⌈Bus/2⌉
```

`auto_storage::aux_cols` states that same closed form directly as
`bus_count.div_ceil(2)`, which is a useful corroboration — but that module sits
behind `#[cfg(feature = "disk-spill")]`, so `stark::lookup` is the
always-compiled source of truth and the doc now points there.

## Why this correction is right rather than merely different

The header also states the sizing rule: scale each table against MEMW's chunk
geometry. That rule is now checkable, and it comes out cleanly at the corrected
widths and badly at the old ones.

At the corrected widths, `nearest 2^N of (88 × 2^19) / Eff.width` reproduces
**eight tables exactly** — MEMW, CPU, CPU32, DVRM, MUL, SHIFT, BYTEWISE, LT.
Five more (LOAD, BRANCH, MEMW_R, EQ, STORE) land above 2^20 and ship at 2^20,
which is the ceiling every table in the module respects. MEMW_A keeps its
existing footnote: the ratio gives 2^20 and it is deliberately set to 2^19 to
match MEMW chunk geometry. That accounts for all fourteen.

Under the **old** widths the same rule put CPU at 2^18 against a shipped 2^19,
and no cap explains a table sized *below* the baseline. The old table was not
merely out of date — it was internally inconsistent with the rule printed
directly above it.

## Scope

Pure documentation, stated as a verified negative rather than left implicit:
`effective_width` and `Eff.width` occur in exactly two places in the workspace,
both inside this doc comment. Nothing computes or consumes the Main / Bus /
Eff.width columns, so there is no behaviour to test and no constant to re-pin.

The table also gains the four auxiliary chips that were already in `max_rows` but
missing from it — CPU32, BYTEWISE, STORE, EQ — so its rows now match the module's
constants one-to-one.

## Deliberately not in this change

The shipped `max_rows` values were scaled through the inflated bus term, which
penalises tables with a high bus-to-main ratio roughly twice as hard as it should
— DVRM, at 34 bus interactions against 34 main columns, is the extreme case.
At the corrected widths those tables land in a defensible place (DVRM 85 and CPU
68 against MEMW's 88), but the ratios that justified the constants were not the
ratios the code actually has.

Re-tuning the constants changes chunk geometry and therefore prover parallelism
and peak memory. That is a measured change, not a documentation one, and it is
left for a pass that can run the benchmark. This PR changes no constant.

## Corroboration

Three independent routes produced this census and agree on every cell: executing
`bus_interactions()` directly, reading and brace-matching the function bodies,
and inverting the prover's run-time walk weights to recover CPU's main and aux
widths. A table three methods agree on is a different object from one person's
re-read, which is what the previous table was.
